### PR TITLE
Ensured the dev tools are not included in the build

### DIFF
--- a/frontend/node_modules/.vite/deps/_metadata.json
+++ b/frontend/node_modules/.vite/deps/_metadata.json
@@ -1,19 +1,19 @@
 {
-  "hash": "e5010ef7",
-  "configHash": "e87064f2",
-  "lockfileHash": "b8357f7c",
-  "browserHash": "48b4295d",
+  "hash": "cc8b133c",
+  "configHash": "10dc73b6",
+  "lockfileHash": "ac0242e5",
+  "browserHash": "41d94b43",
   "optimized": {
     "vue": {
       "src": "../../vue/dist/vue.runtime.esm-bundler.js",
       "file": "vue.js",
-      "fileHash": "cdc5c0e0",
+      "fileHash": "d3c44e8b",
       "needsInterop": false
     },
     "vue-router": {
       "src": "../../vue-router/dist/vue-router.mjs",
       "file": "vue-router.js",
-      "fileHash": "3428ebe9",
+      "fileHash": "e8b98e7c",
       "needsInterop": false
     }
   },

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,11 +5,11 @@ import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({mode}) => ({
   plugins: [
     vue(),
-    vueDevTools(),
-  ],
+    mode === 'development' && vueDevTools()
+  ].filter(Boolean),
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
@@ -34,4 +34,4 @@ export default defineConfig({
       }
     }
   }
-})
+}))


### PR DESCRIPTION
This pull request updates the Vite configuration to ensure that the `vite-plugin-vue-devtools` plugin is only enabled during development mode. This change helps prevent the inclusion of development-only tools in production builds.

Plugin configuration improvements:

* Modified the `plugins` array in `vite.config.js` so that `vueDevTools()` is only included when `mode` is `'development'`, using a conditional and `.filter(Boolean)` to clean up the array.
* Updated the `defineConfig` export to accept a function with `{mode}` and return the config object, enabling mode-based configuration.

closing #63 if approved