### PR TITLE
Phase 2

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -64,6 +64,22 @@ class Settings:
     ZAI_LLM_URL: str = os.getenv("ZAI_LLM_URL", "https://api.z.ai/api/paas/v4/chat/completions")
     ZAI_LLM_MODEL: str = os.getenv("ZAI_LLM_MODEL", "GLM-4.7-Flash")
 
+    # Local Ollama pipeline (replaces ZAI when USE_LOCAL_PIPELINE=true)
+    USE_LOCAL_PIPELINE: bool = _env_bool("USE_LOCAL_PIPELINE", "false")
+    LOCAL_OCR_URL: str = os.getenv("LOCAL_OCR_URL", "http://10.8.0.8:11434")
+    LOCAL_OCR_MODEL: str = os.getenv("LOCAL_OCR_MODEL", "glm-ocr-hires")
+    LOCAL_LLM_URL: str = os.getenv("LOCAL_LLM_URL", "http://10.8.0.8:11434")
+    LOCAL_LLM_MODEL: str = os.getenv("LOCAL_LLM_MODEL", "qwen2.5:7b")
+    LOCAL_OCR_TIMEOUT: float = float(os.getenv("LOCAL_OCR_TIMEOUT", "120"))
+    LOCAL_LLM_TIMEOUT: float = float(os.getenv("LOCAL_LLM_TIMEOUT", "120"))
+    LOCAL_OCR_DPI: int = int(os.getenv("LOCAL_OCR_DPI", "120"))
+
+    # Redis parse queue
+    REDIS_URL: str = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    REDIS_ENABLED: bool = _env_bool("REDIS_ENABLED", "false")
+    PARSE_QUEUE_NAME: str = os.getenv("PARSE_QUEUE_NAME", "uah:parse_jobs")
+    PARSE_QUEUE_MAX_RETRIES: int = int(os.getenv("PARSE_QUEUE_MAX_RETRIES", "3"))
+
     # Muse jobs API guardrails
     MUSE_PAGE_CHASE_ENABLED: bool = _env_bool("MUSE_PAGE_CHASE_ENABLED", "true")
     MUSE_PAGE_CHASE_MAX_PAGES: int = int(os.getenv("MUSE_PAGE_CHASE_MAX_PAGES", "3"))

--- a/docs/LOCAL_OLLAMA_REDIS_MIGRATION_PLAN.md
+++ b/docs/LOCAL_OLLAMA_REDIS_MIGRATION_PLAN.md
@@ -14,14 +14,14 @@ Migrate resume OCR and parsing from ZAI cloud APIs to a feature-flagged local Ol
 - [x] Add Redis dependency to backend/requirements.txt
 - [x] Install poppler-utils in backend/Dockerfile for pdftoppm
 - [x] Add Local Ollama + Redis queue env block to root .env
-- [x] Add Local Ollama + Redis queue env block to env-examples/beta/.env.example
+- [x] Add Local Ollama + Redis queue env block to docs/beta-prep/.env.beta.example
 - [x] Add backend environment passthrough defaults for new vars in docker-compose.yml
 - [x] Validate Phase 1 file changes
 
 ### Phase 2 - Configuration Surface
-- [ ] Add local pipeline settings to backend/app/core/config.py
-- [ ] Add Redis queue settings to backend/app/core/config.py
-- [ ] Keep ZAI settings unchanged and default feature flags off
+- [x] Add local pipeline settings to backend/app/core/config.py
+- [x] Add Redis queue settings to backend/app/core/config.py
+- [x] Keep ZAI settings unchanged and default feature flags off
 
 ### Phase 3 - Resume Parser Local Adapters
 - [ ] Add ocr_pdf_local(pdf_bytes) to backend/app/services/resume_parser.py
@@ -65,5 +65,6 @@ Migrate resume OCR and parsing from ZAI cloud APIs to a feature-flagged local Ol
 - 2026-04-08: Added poppler-utils install layer to backend/Dockerfile.
 - 2026-04-08: Added Local Ollama and Redis queue environment passthrough defaults to backend service in docker-compose.yml.
 - 2026-04-08: Added Local Ollama and Redis queue feature-flag blocks to root .env.
-- 2026-04-08: Added Local Ollama and Redis queue feature-flag blocks to env-examples/beta/.env.example.
+- 2026-04-08: Added Local Ollama and Redis queue feature-flag blocks to docs/beta-prep/.env.beta.example.
 - 2026-04-08: Validated Phase 1 file set (compose config rendered successfully; file-level diagnostics clean).
+- 2026-04-08: Completed Phase 2 configuration settings in backend/app/core/config.py (local pipeline + Redis queue flags/settings; ZAI defaults unchanged).


### PR DESCRIPTION
This pull request introduces new configuration options to support a feature-flagged local Ollama pipeline and Redis-backed queue for resume OCR and parsing, while keeping the existing ZAI cloud API settings unchanged. These changes are part of a migration plan and update both the backend configuration and the related documentation to reflect the new environment variables and settings.

Configuration updates for local pipeline and Redis queue:

* Added new environment variable settings in `backend/app/core/config.py` to enable a local Ollama pipeline (via `USE_LOCAL_PIPELINE`) and configure local OCR/LLM endpoints, models, timeouts, and DPI, as well as Redis queue connection details and retry limits.

Documentation updates for migration plan:

* Updated the migration checklist in `docs/LOCAL_OLLAMA_REDIS_MIGRATION_PLAN.md` to mark the addition of local pipeline and Redis queue settings to `backend/app/core/config.py` as complete, and clarified the correct example `.env` file for beta environments.
* Updated the migration log in `docs/LOCAL_OLLAMA_REDIS_MIGRATION_PLAN.md` to document the completion of Phase 2 configuration settings and corrected the path for the beta example environment file.