### PR TITLE
Make email the primary user identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ NETWORK_FINDINGS_2026-04-08.md
 endpoint_inventory_backend.tsv
 endpoint_inventory_frontend_calls.tsv
 endpoint_utilization_matrix_2026-04-11.tsv
+/docs/backend/*.tsv

--- a/backend/app/api/account.py
+++ b/backend/app/api/account.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from app.db.session import get_db
 from app.models.user import User
@@ -14,6 +15,7 @@ from app.core.security import (
     create_verification_token, decode_verification_token,
 )
 from app.core.config import settings
+from app.core.validation import require_valid_email
 from app.services.email import send_email, EmailNotConfiguredError
 
 router = APIRouter(prefix="/api/account", tags=["account"])
@@ -32,7 +34,8 @@ def forgot_password(payload: ForgotPasswordRequest, db: Session = Depends(get_db
     - 200: Reset flow accepted (message always returned).
     - 500: Email infrastructure not configured or send failure.
     """
-    user = db.query(User).filter(User.email == payload.email).first()
+    normalized_email = require_valid_email(payload.email)
+    user = db.query(User).filter(func.lower(User.email) == normalized_email).first()
 
     if not user:
         return MessageResponse(message="If that email exists, a reset link has been sent")
@@ -135,8 +138,9 @@ def change_email(
     - 200: Email updated and verification required.
     - 400: Email already belongs to another account.
     """
-    existing = db.query(User).filter(User.email == payload.new_email).first()
-    if existing:
+    normalized_new_email = require_valid_email(payload.new_email, field_name="new_email")
+    existing = db.query(User).filter(func.lower(User.email) == normalized_new_email).first()
+    if existing and existing.id != current_user.id:
         raise HTTPException(status_code=400, detail="Email already in use")
 
     old_email = current_user.email
@@ -164,7 +168,8 @@ def change_email(
             detail="Your current email must be verified before changing it. A verification email has been sent."
         )
 
-    current_user.email = payload.new_email
+    current_user.email = normalized_new_email
+    current_user.username = normalized_new_email
     current_user.email_verified = False
     db.commit()
 
@@ -174,7 +179,7 @@ def change_email(
                 to=old_email,
                 subject="UAH account email changed",
                 text=(
-                    f"The email on your UAH account was just changed to {payload.new_email}.\n\n"
+                    f"The email on your UAH account was just changed to {normalized_new_email}.\n\n"
                     "If you did not make this change, please contact support immediately.\n"
                 ),
             )
@@ -191,23 +196,15 @@ def change_username(
     current_user: User = Depends(get_current_user),
 ):
     """
-    Update username for the current user.
-
-    Ensures the new username is unique before persisting and returning the
-    updated user profile.
+    Deprecated endpoint retained temporarily for compatibility.
 
     Response codes:
-    - 200: Username changed successfully.
-    - 400: Username already taken by another account.
+    - 410: Username updates are no longer supported.
     """
-    existing = db.query(User).filter(User.username == payload.new_username).first()
-    if existing and existing.id != current_user.id:
-        raise HTTPException(status_code=400, detail="Username already taken")
-
-    current_user.username = payload.new_username
-    db.commit()
-    db.refresh(current_user)
-    return current_user
+    raise HTTPException(
+        status_code=status.HTTP_410_GONE,
+        detail="Username updates are deprecated. Email is now the sign-in identifier.",
+    )
 
 
 @router.put("/change-name", response_model=UserResponse)

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,11 +1,13 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 import os
 from app.db.session import get_db
 from app.models.user import User
 from app.schemas.user import UserRegister, UserLogin, UserResponse, TokenResponse
 from app.core.security import hash_password, verify_password, create_access_token, decode_access_token
+from app.core.validation import normalize_email, require_valid_email
 from app.api.deps import oauth2_scheme
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
@@ -15,7 +17,6 @@ ADMIN_EMAIL = "admincontact@uahapp.com"
 
 
 def _ensure_admin_user(db: Session) -> User:
-    admin_username = os.getenv("ADMIN_BOOTSTRAP_USERNAME")
     admin_password = os.getenv("ADMIN_BOOTSTRAP_PASSWORD")
     admin_first_name = os.getenv("ADMIN_BOOTSTRAP_FIRST_NAME")
     admin_last_name = os.getenv("ADMIN_BOOTSTRAP_LAST_NAME")
@@ -23,7 +24,6 @@ def _ensure_admin_user(db: Session) -> User:
     missing = [
         name
         for name, value in {
-            "ADMIN_BOOTSTRAP_USERNAME": admin_username,
             "ADMIN_BOOTSTRAP_PASSWORD": admin_password,
             "ADMIN_BOOTSTRAP_FIRST_NAME": admin_first_name,
             "ADMIN_BOOTSTRAP_LAST_NAME": admin_last_name,
@@ -36,18 +36,23 @@ def _ensure_admin_user(db: Session) -> User:
             detail=f"Admin bootstrap env vars missing: {', '.join(missing)}",
         )
 
-    user = db.query(User).filter(User.email == ADMIN_EMAIL).first()
+    normalized_admin_email = normalize_email(ADMIN_EMAIL)
+    user = db.query(User).filter(func.lower(User.email) == normalized_admin_email).first()
     if user:
         if not user.hashed_password:
             user.hashed_password = hash_password(admin_password)
-            db.add(user)
-            db.commit()
-            db.refresh(user)
+        if user.username != normalized_admin_email:
+            user.username = normalized_admin_email
+        if user.email != normalized_admin_email:
+            user.email = normalized_admin_email
+        db.add(user)
+        db.commit()
+        db.refresh(user)
         return user
 
     user = User(
-        email=ADMIN_EMAIL,
-        username=admin_username,
+        email=normalized_admin_email,
+        username=normalized_admin_email,
         hashed_password=hash_password(admin_password),
         first_name=admin_first_name,
         last_name=admin_last_name,
@@ -66,31 +71,26 @@ def register(payload: UserRegister, db: Session = Depends(get_db)):
     Register a new user account and return an access token.
 
     Creates a local credential-based account after validating that the submitted
-    email and username are not already in use. On success, this endpoint returns
+    email is not already in use. On success, this endpoint returns
     a bearer token and the normalized user profile so the frontend can treat
     registration as an authenticated session.
 
     Response codes:
     - 201: Account created successfully and token issued.
-    - 400: Email already registered or username already taken.
+    - 400: Email already registered.
     - 422: Request validation failed (for example, missing fields).
     - 500: Server/database error while creating the account.
     """
-    if db.query(User).filter(User.email == payload.email).first():
+    normalized_email = require_valid_email(payload.email)
+    if db.query(User).filter(func.lower(User.email) == normalized_email).first():
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Email already registered",
         )
 
-    if db.query(User).filter(User.username == payload.username).first():
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Username already taken",
-        )
-
     user = User(
-        email=payload.email,
-        username=payload.username,
+        email=normalized_email,
+        username=normalized_email,
         hashed_password=hash_password(payload.password),
         first_name=payload.first_name,
         last_name=payload.last_name,
@@ -112,7 +112,7 @@ def login(
     db: Session = Depends(get_db),
 ):
     """
-    Authenticate with username and password.
+    Authenticate with email and password.
 
     Validates submitted credentials against a local account, verifies the account
     is active, and returns a signed bearer token plus profile data. This endpoint
@@ -120,16 +120,17 @@ def login(
 
     Response codes:
     - 200: Authentication succeeded and token issued.
-    - 401: Invalid username/password combination.
+    - 401: Invalid email/password combination.
     - 403: Account exists but is deactivated.
     - 422: Request validation failed.
     """
-    user = db.query(User).filter(User.username == payload.username).first()
+    identifier = require_valid_email(payload.email)
+    user = db.query(User).filter(func.lower(User.email) == identifier).first()
 
     if not user or not user.hashed_password or not verify_password(payload.password, user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid username or password",
+            detail="Invalid email or password",
         )
 
     if not user.is_active:
@@ -159,16 +160,20 @@ def token_login(
 
     Response codes:
     - 200: Token generated successfully.
-    - 401: Invalid username/password.
+    - 401: Invalid email/password.
     - 403: Account is deactivated.
     - 422: Invalid form payload.
     """
-    user = db.query(User).filter(User.username == form_data.username).first()
+    try:
+        identifier = require_valid_email(form_data.username, field_name="username")
+    except ValueError:
+        identifier = ""
+    user = db.query(User).filter(func.lower(User.email) == identifier).first()
 
     if not user or not user.hashed_password or not verify_password(form_data.password, user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid username or password",
+            detail="Invalid email or password",
         )
 
     if not user.is_active:

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -53,6 +53,7 @@ import time
 from urllib.parse import urlencode
 from fastapi import APIRouter, HTTPException, Request, Query, Depends
 from fastapi.responses import RedirectResponse
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from app.api.deps import get_current_user, require_admin_user
 from app.models.user import User, SavedJob
@@ -2388,12 +2389,13 @@ async def google_oauth_callback(
             _clear_google_oauth_session(request)
             return _oauth_settings_redirect("error", "google_already_linked")
 
-        email_owner = db.query(User).filter(User.email == email).first()
+        email_owner = db.query(User).filter(func.lower(User.email) == email).first()
         if email_owner and email_owner.id != user.id:
             _clear_google_oauth_session(request)
             return _oauth_settings_redirect("error", "email_conflict")
 
         user.google_id = google_id
+        user.username = (user.email or "").strip().lower()
         if picture:
             user.picture_url = picture
         if name and not user.full_name:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -218,8 +218,11 @@ class Settings:
         raise RuntimeError("DEV_AUTH_TEST_ACCOUNT_ENABLED is only allowed in development/local environments.")
 
       if self.DEV_AUTH_TEST_ACCOUNT_ENABLED:
-        if not self.DEV_AUTH_TEST_USERNAME.strip():
-          raise RuntimeError("DEV_AUTH_TEST_USERNAME is required when DEV_AUTH_TEST_ACCOUNT_ENABLED=true.")
+        if not self.DEV_AUTH_TEST_EMAIL.strip() and not self.DEV_AUTH_TEST_USERNAME.strip():
+          raise RuntimeError(
+            "DEV_AUTH_TEST_EMAIL is required when DEV_AUTH_TEST_ACCOUNT_ENABLED=true "
+            "(legacy fallback: DEV_AUTH_TEST_USERNAME)."
+          )
         if not self.DEV_AUTH_TEST_PASSWORD.strip():
           raise RuntimeError("DEV_AUTH_TEST_PASSWORD is required when DEV_AUTH_TEST_ACCOUNT_ENABLED=true.")
 

--- a/backend/app/core/validation.py
+++ b/backend/app/core/validation.py
@@ -1,0 +1,45 @@
+import re
+
+
+EMAIL_PATTERN = re.compile(r"^[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,63}$", re.IGNORECASE)
+PHONE_ALLOWED_PATTERN = re.compile(r"^[0-9+\-().\s]+$")
+
+
+def normalize_email(value: str | None) -> str:
+    return (value or "").strip().lower()
+
+
+def require_valid_email(value: str | None, field_name: str = "email") -> str:
+    normalized = normalize_email(value)
+    if not normalized:
+        raise ValueError(f"{field_name} is required")
+    if not EMAIL_PATTERN.match(normalized):
+        raise ValueError("Please enter a valid email address")
+    return normalized
+
+
+def normalize_phone(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    raw = str(value).strip()
+    if not raw:
+        return None
+
+    if not PHONE_ALLOWED_PATTERN.match(raw):
+        raise ValueError("Please enter a valid phone number")
+
+    has_plus = raw.lstrip().startswith("+")
+    digits = re.sub(r"\D", "", raw)
+    if len(digits) < 7 or len(digits) > 15:
+        raise ValueError("Please enter a valid phone number")
+
+    if not has_plus:
+        if len(digits) == 10:
+            return f"({digits[:3]}) {digits[3:6]}-{digits[6:]}"
+        if len(digits) == 11 and digits.startswith("1"):
+            return f"({digits[1:4]}) {digits[4:7]}-{digits[7:]}"
+
+    if has_plus:
+        return f"+{digits}"
+    return digits

--- a/backend/app/google/service.py
+++ b/backend/app/google/service.py
@@ -1,21 +1,10 @@
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from app.models.user import User
+from app.core.validation import normalize_email
 
 
 class GoogleAuthService:
-    @staticmethod
-    def _unique_username(db: Session, preferred: str) -> str:
-        base = (preferred or "user").strip().lower()
-        if not base:
-            base = "user"
-
-        candidate = base
-        suffix = 1
-        while db.query(User).filter(User.username == candidate).first():
-            suffix += 1
-            candidate = f"{base}{suffix}"
-        return candidate
-
     @classmethod
     def get_or_create_user(
         cls,
@@ -26,14 +15,20 @@ class GoogleAuthService:
         picture_url: str | None,
         email_verified: bool = False,
     ) -> User:
+        normalized_email = normalize_email(email)
+        if not normalized_email:
+            raise ValueError("Google profile email is missing")
+
         # Prefer existing account already linked by Google subject id.
         user = db.query(User).filter(User.google_id == google_id).first()
 
         # Fall back to matching by email so existing local accounts can link.
         if not user:
-            user = db.query(User).filter(User.email == email).first()
+            user = db.query(User).filter(func.lower(User.email) == normalized_email).first()
 
         if user:
+            user.email = normalized_email
+            user.username = normalized_email
             if not user.google_id:
                 user.google_id = google_id
             if picture_url:
@@ -43,12 +38,10 @@ class GoogleAuthService:
             if email_verified:
                 user.email_verified = True
         else:
-            local_part = (email.split("@")[0] if "@" in email else "user").strip().lower()
-            username = cls._unique_username(db, local_part)
             user = User(
                 google_id=google_id,
-                email=email,
-                username=username,
+                email=normalized_email,
+                username=normalized_email,
                 full_name=full_name,
                 picture_url=picture_url,
                 email_verified=bool(email_verified),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,7 @@ from app.api.applicant_profile import router as profile_router
 from app.api.apply_session import router as apply_session_router
 from app.api.gmail import router as gmail_router
 from app.core.config import settings
+from app.core.validation import normalize_email, require_valid_email
 from app.db.base import Base
 from app.db.session import get_engine, init_engine
 from app.services.geolocation import ensure_city_dataset
@@ -148,6 +149,68 @@ def _bootstrap_admin_user_if_enabled() -> None:
         db.close()
 
 
+def _enforce_email_first_identity_mirror() -> None:
+    """Normalize stored emails and mirror username=email for all users.
+
+    This runs at startup as an idempotent guard while username sunset is in
+    progress. It fails fast on case-insensitive duplicate emails so we never
+    violate uniqueness assumptions when normalizing.
+    """
+
+    try:
+        from sqlalchemy import func
+        from app.db.session import SessionLocal
+        from app.models.user import User
+    except Exception as exc:
+        logger.exception("Email-first identity bootstrap import failed: %s", exc)
+        raise
+
+    db = SessionLocal()
+    try:
+        duplicate_rows = (
+            db.query(
+                func.lower(User.email).label("normalized_email"),
+                func.count(User.id).label("row_count"),
+            )
+            .group_by(func.lower(User.email))
+            .having(func.count(User.id) > 1)
+            .all()
+        )
+
+        if duplicate_rows:
+            sample = ", ".join(
+                [f"{row.normalized_email} ({row.row_count})" for row in duplicate_rows[:5]]
+            )
+            raise RuntimeError(
+                "Case-insensitive duplicate emails detected; cannot enforce email-first identity mirror. "
+                f"Examples: {sample}"
+            )
+
+        users = db.query(User).all()
+        updated_count = 0
+        for user in users:
+            normalized = normalize_email(user.email)
+            if not normalized:
+                raise RuntimeError(f"User id={user.id} has an empty email; cannot enforce email-first identity.")
+            if user.email != normalized or user.username != normalized:
+                user.email = normalized
+                user.username = normalized
+                updated_count += 1
+
+        if updated_count:
+            db.commit()
+            logger.warning("Email-first identity mirror enforced for %s user(s).", updated_count)
+        else:
+            db.rollback()
+            logger.info("Email-first identity mirror already in sync.")
+    except Exception:
+        db.rollback()
+        logger.exception("Email-first identity mirror bootstrap failed.")
+        raise
+    finally:
+        db.close()
+
+
 def _ensure_dev_test_user_if_enabled() -> None:
     if not settings.DEV_AUTH_TEST_ACCOUNT_ENABLED:
         return
@@ -160,12 +223,17 @@ def _ensure_dev_test_user_if_enabled() -> None:
         )
         return
 
-    username = settings.DEV_AUTH_TEST_USERNAME.strip()
+    legacy_username = settings.DEV_AUTH_TEST_USERNAME.strip()
     password = settings.DEV_AUTH_TEST_PASSWORD.strip()
-    email = (settings.DEV_AUTH_TEST_EMAIL or f"{username}@uah.local").strip().lower()
+    identifier = settings.DEV_AUTH_TEST_EMAIL.strip() or legacy_username
+    if not identifier or not password:
+        logger.error("[DEV-AUTH] DEV_AUTH_TEST_ACCOUNT_ENABLED=true but email/password are missing")
+        return
 
-    if not username or not password:
-        logger.error("[DEV-AUTH] DEV_AUTH_TEST_ACCOUNT_ENABLED=true but username/password are missing")
+    try:
+        email = require_valid_email(identifier, field_name="DEV_AUTH_TEST_EMAIL")
+    except ValueError as exc:
+        logger.error("[DEV-AUTH] Invalid dev test email identifier: %s", exc)
         return
 
     try:
@@ -178,12 +246,14 @@ def _ensure_dev_test_user_if_enabled() -> None:
 
     db = SessionLocal()
     try:
-        user = db.query(User).filter(User.username == username).first()
+        from sqlalchemy import func
+
+        user = db.query(User).filter(func.lower(User.email) == email).first()
         if not user:
-            user = db.query(User).filter(User.email == email).first()
+            user = db.query(User).filter(User.username == email).first()
 
         if user:
-            user.username = username
+            user.username = email
             user.email = email
             user.first_name = settings.DEV_AUTH_TEST_FIRST_NAME or "Dev"
             user.last_name = settings.DEV_AUTH_TEST_LAST_NAME or "Tester"
@@ -196,12 +266,12 @@ def _ensure_dev_test_user_if_enabled() -> None:
             db.add(user)
             db.commit()
             db.refresh(user)
-            logger.warning("[DEV-AUTH] Ensured dev test user '%s'", username)
+            logger.warning("[DEV-AUTH] Ensured dev test user '%s'", email)
             return
 
         user = User(
             email=email,
-            username=username,
+            username=email,
             hashed_password=hash_password(password),
             first_name=settings.DEV_AUTH_TEST_FIRST_NAME or "Dev",
             last_name=settings.DEV_AUTH_TEST_LAST_NAME or "Tester",
@@ -211,7 +281,7 @@ def _ensure_dev_test_user_if_enabled() -> None:
         db.add(user)
         db.commit()
         db.refresh(user)
-        logger.warning("[DEV-AUTH] Created dev test user '%s'", username)
+        logger.warning("[DEV-AUTH] Created dev test user '%s'", email)
     except Exception as exc:
         logger.exception("[DEV-AUTH] Failed to ensure dev test user: %s", exc)
     finally:
@@ -227,8 +297,10 @@ async def lifespan(app: FastAPI):
     Base.metadata.create_all(bind=engine)
     _ensure_users_table_columns(engine)
     _ensure_resumes_table_columns(engine)
+    _enforce_email_first_identity_mirror()
     _bootstrap_admin_user_if_enabled()
     _ensure_dev_test_user_if_enabled()
+    _enforce_email_first_identity_mirror()
 
     geo_dataset_status = ensure_city_dataset()
     status = geo_dataset_status.get("status")

--- a/backend/app/schemas/applicant_profile.py
+++ b/backend/app/schemas/applicant_profile.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from datetime import datetime
+from app.core.validation import normalize_phone, require_valid_email
 
 
 class ProfileBase(BaseModel):
@@ -39,6 +40,18 @@ class ProfileBase(BaseModel):
     veteran_status: str | None = Field(default=None, max_length=120, description="Optional veteran status answer used in compliance forms.", examples=["Not a protected veteran"])
     disability_status: str | None = Field(default=None, max_length=160, description="Optional disability self-identification response.", examples=["I do not wish to answer"])
     california_resident: str | None = Field(default=None, max_length=60, description="Optional California residency declaration used by some employers.", examples=["No"])
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return require_valid_email(value)
+
+    @field_validator("phone")
+    @classmethod
+    def validate_phone(cls, value: str | None) -> str | None:
+        return normalize_phone(value)
 
 
 class ProfileCreate(ProfileBase):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel, Field, AliasChoices
+from pydantic import BaseModel, Field, AliasChoices, field_validator
+from app.core.validation import require_valid_email
 
 
 class UserRegister(BaseModel):
@@ -8,13 +9,6 @@ class UserRegister(BaseModel):
         max_length=255,
         description="Unique login email used for authentication, password recovery, and account notifications.",
         examples=["jane.doe@example.com"],
-    )
-    username: str = Field(
-        ...,
-        min_length=3,
-        max_length=64,
-        description="Unique public username displayed in the UI and used for credential-based login.",
-        examples=["jane_doe"],
     )
     password: str = Field(
         ...,
@@ -36,21 +30,32 @@ class UserRegister(BaseModel):
         examples=["Doe"],
     )
 
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, value: str) -> str:
+        return require_valid_email(value)
+
 class UserLogin(BaseModel):
-    username: str = Field(
+    email: str = Field(
         ...,
-        min_length=3,
-        max_length=64,
-        description="Existing username for credential-based login.",
-        examples=["jane_doe"],
+        min_length=5,
+        max_length=255,
+        validation_alias=AliasChoices("email", "username"),
+        description="Existing account email for credential-based login. Legacy `username` payload key is accepted temporarily for compatibility.",
+        examples=["jane.doe@example.com"],
     )
     password: str = Field(
         ...,
         min_length=8,
         max_length=128,
-        description="Account password for the specified username.",
+        description="Account password for the specified email account.",
         examples=["MySecurePass!123"],
     )
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, value: str) -> str:
+        return require_valid_email(value)
 
 class UserResponse(BaseModel):
     id: int = Field(
@@ -65,8 +70,8 @@ class UserResponse(BaseModel):
     )
     username: str | None = Field(
         default=None,
-        description="Public username chosen by the user.",
-        examples=["jane_doe"],
+        description="Compatibility field mirrored to the account email while username sunset is in progress.",
+        examples=["jane.doe@example.com"],
     )
     first_name: str | None = Field(
         default=None,
@@ -152,6 +157,11 @@ class ForgotPasswordRequest(BaseModel):
         examples=["jane.doe@example.com"],
     )
 
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, value: str) -> str:
+        return require_valid_email(value)
+
 class ChangeEmailRequest(BaseModel):
     new_email: str = Field(
         ...,
@@ -161,12 +171,17 @@ class ChangeEmailRequest(BaseModel):
         examples=["jane.new@example.com"],
     )
 
+    @field_validator("new_email")
+    @classmethod
+    def validate_new_email(cls, value: str) -> str:
+        return require_valid_email(value, field_name="new_email")
+
 class ChangeUsernameRequest(BaseModel):
     new_username: str = Field(
         ...,
         min_length=3,
         max_length=64,
-        description="New unique username for the authenticated account.",
+        description="Deprecated request shape retained for compatibility while username sunset is in progress.",
         examples=["jane_doe_2"],
     )
 

--- a/docs/SERVER_ENV_CHECKLIST.md
+++ b/docs/SERVER_ENV_CHECKLIST.md
@@ -20,9 +20,9 @@ This checklist captures environment variables that must exist on server-side `.e
 Document these keys in env templates even when disabled:
 
 - `DEV_AUTH_TEST_ACCOUNT_ENABLED`
-- `DEV_AUTH_TEST_USERNAME`
 - `DEV_AUTH_TEST_PASSWORD`
 - `DEV_AUTH_TEST_EMAIL`
+- `DEV_AUTH_TEST_USERNAME` (legacy fallback only)
 - `DEV_AUTH_TEST_FIRST_NAME`
 - `DEV_AUTH_TEST_LAST_NAME`
 - `DEV_AUTH_TEST_IS_ADMIN`
@@ -30,7 +30,8 @@ Document these keys in env templates even when disabled:
 
 Environment policy:
 
-- Dev/local: may enable test account; when enabled, username and password must be set.
+- Dev/local: may enable test account; when enabled, email and password must be set.
+- `DEV_AUTH_TEST_USERNAME` is legacy-only compatibility and should be an email value if used.
 - Beta/prod: must keep `DEV_AUTH_TEST_ACCOUNT_ENABLED=false`.
 
 ## Required For Gmail Integration

--- a/docs/backend/EMAIL_FIRST_IDENTITY_AUTOFILL_RESET_IMPLEMENTATION_2026-04-11.md
+++ b/docs/backend/EMAIL_FIRST_IDENTITY_AUTOFILL_RESET_IMPLEMENTATION_2026-04-11.md
@@ -1,0 +1,57 @@
+# Email-First Identity + Autofill Scope Reset (2026-04-11)
+
+## What Changed
+
+- Identity is now email-first across active auth/account flows.
+- Username is sunset in UI and treated as an internal compatibility mirror of email.
+- Non-auth autofill was rolled back on Settings profile/preferences and resume/applicant profile forms.
+- Autofill/password-manager metadata remains on auth and account-security forms only.
+- Shared validation/normalization was added for email and phone.
+
+## Backend
+
+- Added shared validators:
+  - `backend/app/core/validation.py`
+  - Email normalization/validation (`trim + lowercase + regex`)
+  - Phone normalization (`7-15 digits`, international-friendly, US-format on 10/11-digit US-like numbers)
+- Startup identity backfill and guardrails:
+  - `backend/app/main.py`
+  - Preflights for case-insensitive duplicate emails and fails fast if found
+  - Normalizes stored emails and enforces `username=email` for all users
+  - Idempotent and rerunnable at startup
+- Dev test bootstrap alignment:
+  - `DEV_AUTH_TEST_EMAIL` is the primary identifier when enabled.
+  - `DEV_AUTH_TEST_USERNAME` is retained as a legacy fallback only and should contain an email value.
+- Auth/account changes:
+  - `POST /api/auth/register` now email + password (+ names); persists `username=email`
+  - `POST /api/auth/login` uses email; still accepts legacy `username` payload key as alias
+  - `POST /api/auth/token` still receives OAuth2 `username` form field, treated as email
+  - `PUT /api/account/change-email` now updates both `email` and mirrored `username`
+  - `PUT /api/account/change-username` now returns `410 Gone` with deprecation message
+- Google OAuth account provisioning/linking now enforces email/username mirror:
+  - `backend/app/google/service.py`
+  - `backend/app/api/routes.py`
+
+## Frontend
+
+- Email-first auth UI:
+  - Login now uses email input/payload
+  - Register removes username/confirm-username fields
+  - Settings removes username-change UI
+  - Nav user summary falls back to full name, then email
+- Autofill policy:
+  - Kept on login/register/forgot/reset and Settings account-security (change email/password)
+  - Set to `autocomplete="off"` for non-auth profile/preferences/resume/applicant forms
+- Added shared frontend validation helper:
+  - `frontend/src/lib/validation.js`
+  - Used by login/register/forgot-password/settings-change-email and applicant save in resumes
+  - Includes phone normalization on blur/save in resume applicant form
+- Local mock API aligned with new contracts:
+  - Email-first login/register payload handling
+  - `username=email` mirror behavior
+  - `/api/account/change-username` returns `410`
+
+## Notes
+
+- `UserResponse.username` is intentionally retained for compatibility and mirrors email.
+- Column removal for `users.username` is deferred to a later migration window.

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -35,9 +35,9 @@ Recommended: load these from the repository root `.env` file instead of typing p
 The backend supports a dev/local-only seeded test account via env flags:
 
 - `DEV_AUTH_TEST_ACCOUNT_ENABLED`
-- `DEV_AUTH_TEST_USERNAME`
 - `DEV_AUTH_TEST_PASSWORD`
 - `DEV_AUTH_TEST_EMAIL`
+- `DEV_AUTH_TEST_USERNAME` (legacy fallback only)
 - `DEV_AUTH_TEST_FIRST_NAME`
 - `DEV_AUTH_TEST_LAST_NAME`
 - `DEV_AUTH_TEST_IS_ADMIN`
@@ -45,7 +45,8 @@ The backend supports a dev/local-only seeded test account via env flags:
 
 Behavior:
 
-- If `DEV_AUTH_TEST_ACCOUNT_ENABLED=true`, username and password must be set.
+- If `DEV_AUTH_TEST_ACCOUNT_ENABLED=true`, email and password must be set.
+- `DEV_AUTH_TEST_USERNAME` remains accepted as a temporary compatibility fallback identifier but should be treated as an email value.
 - This feature is blocked in beta/prod and should remain disabled there.
 
 You can generate secrets with:

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -71,16 +71,16 @@ npm run build
   - Location cap/truncation diagnostics
   - Search diagnostics fields used by Job Board transparency UI
 
-## Settings And Autofill Notes (April 11, 2026)
+## Identity And Autofill Notes (April 11, 2026)
 
-- Settings layout now keeps `Notifications & Preferences` inside the `Profile Settings` card for a single consolidated profile area.
-- `Connected Accounts` remains a dedicated card for long-term provider support (`Google` now, additional providers later).
-- Browser autofill compatibility pass applied to core forms:
-  - Auth (`Login`, `Register`, `Forgot-Password`, `Reset-Password`)
-  - Settings account/security inputs
-  - Resume applicant profile forms
-  - Applicant Information page
-- Standards used:
-  - Personal/contact fields use semantic `name` + `autocomplete` tokens (`given-name`, `family-name`, `email`, `tel`, `street-address`, `address-level2`, `address-level1`, `postal-code`).
-  - Password/token fields use `current-password`, `new-password`, `one-time-code`.
-  - Search/filter/custom query controls use `autocomplete="off"` plus neutral names to prevent account autofill bleed into non-account forms.
+- Identity is now email-first in UI flows.
+  - Login uses email as the sign-in identifier.
+  - Register no longer asks for username.
+  - Settings no longer shows username management.
+- Autofill policy is intentionally narrow:
+  - Keep browser/password-manager metadata only on auth + account-security forms:
+    - `Login`, `Register`, `Forgot-Password`, `Reset-Password`
+    - Settings `Change Email` + `Change Password`
+  - All profile/resume/settings-preference data-entry fields are `autocomplete="off"` to avoid noisy autofill interference.
+- Password manager compatibility is preserved for credential updates:
+  - Account-security forms provide username/email context and keep `current-password` / `new-password` semantics for password updates.

--- a/frontend/node_modules/.package-lock.json
+++ b/frontend/node_modules/.package-lock.json
@@ -35,7 +35,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1611,7 +1610,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2352,7 +2350,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2531,7 +2528,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.28.tgz",
       "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.28",
         "@vue/compiler-sfc": "3.5.28",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,7 +51,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1627,7 +1626,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2368,7 +2366,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2547,7 +2544,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.28.tgz",
       "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.28",
         "@vue/compiler-sfc": "3.5.28",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -42,6 +42,15 @@ body {
   line-height: 1.4;
 }
 
+button {
+  padding: 0 12px;
+  transition: background-color 0.2s;
+}
+
+button:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
 #uah-app {
   width: 100%;
   max-width: 100%;

--- a/frontend/src/components/Burger.vue
+++ b/frontend/src/components/Burger.vue
@@ -45,7 +45,7 @@
 
         <div class="burger-bottom">
             <div class="user-summary" v-if="currentUser">
-                <div class="user-name">{{ displayUsername }}</div>
+                <div class="user-name">{{ displayIdentity }}</div>
                 <div class="user-email" v-if="currentUser.email">{{ currentUser.email }}</div>
             </div>
 
@@ -103,8 +103,12 @@
             };
         },
         computed: {
-            displayUsername() {
-                return this.currentUser?.username || 'User'
+            displayIdentity() {
+                const first = this.currentUser?.first_name || this.currentUser?.firstName || ''
+                const last = this.currentUser?.last_name || this.currentUser?.lastName || ''
+                const fullName = `${first} ${last}`.trim()
+                if (fullName) return fullName
+                return this.currentUser?.email || 'User'
             }
         },
         mounted() {

--- a/frontend/src/lib/localMockApi.js
+++ b/frontend/src/lib/localMockApi.js
@@ -276,7 +276,7 @@ function makeMockToken(user) {
   const header = { alg: 'HS256', typ: 'JWT' }
   const payload = {
     sub: String(user.id),
-    username: user.username,
+    username: user.email || user.username,
     exp: Math.floor(Date.now() / 1000) + 12 * 60 * 60,
     iat: Math.floor(Date.now() / 1000),
   }
@@ -334,10 +334,11 @@ export function assertSafeLocalModeConfig() {
 }
 
 function createDefaultUser(overrides = {}) {
+  const defaultEmail = 'localdev@uah.local'
   return {
     id: 1,
-    username: 'localdev',
-    email: 'localdev@uah.local',
+    username: defaultEmail,
+    email: defaultEmail,
     email_verified: true,
     first_name: 'Local',
     last_name: 'Developer',
@@ -1138,11 +1139,12 @@ async function handleMockApiRequest(request, requestUrl, state) {
 
   if (pathname === '/api/auth/login' && method === 'POST') {
     const body = await parseJsonBody(request)
-    const username = normalizeText(body.username) || 'localdev'
+    const email = normalizeTextLower(body.email || body.username) || 'localdev@uah.local'
 
     state.user = {
       ...state.user,
-      username,
+      email,
+      username: email,
     }
     const token = makeMockToken(state.user)
     saveState(state)
@@ -1156,10 +1158,11 @@ async function handleMockApiRequest(request, requestUrl, state) {
 
   if (pathname === '/api/auth/register' && method === 'POST') {
     const body = await parseJsonBody(request)
+    const email = normalizeTextLower(body.email) || 'localdev@uah.local'
 
     state.user = createDefaultUser({
-      username: normalizeText(body.username) || 'localdev',
-      email: normalizeText(body.email) || 'localdev@uah.local',
+      username: email,
+      email,
       first_name: normalizeText(body.first_name) || 'Local',
       last_name: normalizeText(body.last_name) || 'Developer',
     })
@@ -1234,7 +1237,7 @@ async function handleMockApiRequest(request, requestUrl, state) {
 
   if (pathname === '/api/account/change-email' && method === 'PUT') {
     const body = await parseJsonBody(request)
-    const nextEmail = normalizeText(body.new_email)
+    const nextEmail = normalizeTextLower(body.new_email)
 
     if (!nextEmail) {
       return toJsonResponse({ detail: 'new_email is required' }, 400)
@@ -1243,6 +1246,7 @@ async function handleMockApiRequest(request, requestUrl, state) {
     state.user = {
       ...state.user,
       email: nextEmail,
+      username: nextEmail,
       email_verified: false,
     }
 
@@ -1256,20 +1260,10 @@ async function handleMockApiRequest(request, requestUrl, state) {
   }
 
   if (pathname === '/api/account/change-username' && method === 'PUT') {
-    const body = await parseJsonBody(request)
-    const nextUsername = normalizeText(body.new_username)
-
-    if (!nextUsername) {
-      return toJsonResponse({ detail: 'new_username is required' }, 400)
-    }
-
-    state.user = {
-      ...state.user,
-      username: nextUsername,
-    }
-    saveState(state)
-
-    return toJsonResponse(state.user)
+    return toJsonResponse(
+      { detail: 'Username updates are deprecated. Email is now the sign-in identifier.' },
+      410
+    )
   }
 
   if (pathname === '/api/account/send-verification' && method === 'POST') {

--- a/frontend/src/lib/validation.js
+++ b/frontend/src/lib/validation.js
@@ -1,0 +1,49 @@
+const EMAIL_PATTERN = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,63}$/i
+const PHONE_ALLOWED_PATTERN = /^[0-9+\-().\s]+$/
+
+export function normalizeEmail(value) {
+  return String(value || '').trim().toLowerCase()
+}
+
+export function isValidEmail(value) {
+  const normalized = normalizeEmail(value)
+  return EMAIL_PATTERN.test(normalized)
+}
+
+export function assertValidEmail(value, label = 'email') {
+  const normalized = normalizeEmail(value)
+  if (!normalized) {
+    throw new Error(`Please enter your ${label}`)
+  }
+  if (!isValidEmail(normalized)) {
+    throw new Error('Please enter a valid email address')
+  }
+  return normalized
+}
+
+export function normalizePhone(value) {
+  const raw = String(value || '').trim()
+  if (!raw) return ''
+
+  if (!PHONE_ALLOWED_PATTERN.test(raw)) {
+    throw new Error('Please enter a valid phone number')
+  }
+
+  const hasPlus = raw.startsWith('+')
+  const digits = raw.replace(/\D/g, '')
+  if (digits.length < 7 || digits.length > 15) {
+    throw new Error('Please enter a valid phone number')
+  }
+
+  if (!hasPlus) {
+    if (digits.length === 10) {
+      return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`
+    }
+    if (digits.length === 11 && digits.startsWith('1')) {
+      return `(${digits.slice(1, 4)}) ${digits.slice(4, 7)}-${digits.slice(7)}`
+    }
+  }
+
+  if (hasPlus) return `+${digits}`
+  return digits
+}

--- a/frontend/src/views/Applicant-Information.vue
+++ b/frontend/src/views/Applicant-Information.vue
@@ -11,17 +11,17 @@
                 </template>
                 <div class="appInfo-group">
                     <p>First Name</p>
-                    <input id="applicant-first-name" type="text" name="first_name" autocomplete="given-name" v-model="firstName">
+                    <input id="applicant-first-name" type="text" name="first_name" autocomplete="off" v-model="firstName">
                     <p>Last Name</p>
-                    <input id="applicant-last-name" type="text" name="last_name" autocomplete="family-name" v-model="lastName">
+                    <input id="applicant-last-name" type="text" name="last_name" autocomplete="off" v-model="lastName">
                     <p>Email</p>
-                    <input id="applicant-email" type="email" name="email" autocomplete="email" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="currentUser.email">
+                    <input id="applicant-email" type="email" name="email" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="currentUser.email">
                     <p>Phone</p>
-                    <input id="applicant-phone" type="tel" name="phone" autocomplete="tel" v-model="currentUser.phone">
+                    <input id="applicant-phone" type="tel" name="phone" autocomplete="off" v-model="currentUser.phone">
                     <p>LinkedIN URL</p>
-                    <input id="applicant-linkedin-url" type="url" name="linkedin_url" autocomplete="url" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="currentUser.linkedin">
+                    <input id="applicant-linkedin-url" type="url" name="linkedin_url" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="currentUser.linkedin">
                     <p>Portfolio/Website</p>
-                    <input id="applicant-portfolio-url" type="url" name="portfolio_url" autocomplete="url" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="currentUser.portfolio">
+                    <input id="applicant-portfolio-url" type="url" name="portfolio_url" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="currentUser.portfolio">
                 </div>
             </Card>
 
@@ -31,13 +31,13 @@
                 </template>
                 <div class="appInfo-group">
                     <p>Street Address</p>
-                    <input id="applicant-street-address" type="text" name="street_address" autocomplete="street-address" v-model="currentUser.streetAddress" placeholder="Street address">
+                    <input id="applicant-street-address" type="text" name="street_address" autocomplete="off" v-model="currentUser.streetAddress" placeholder="Street address">
                     <p>City</p>
-                    <input id="applicant-city" type="text" name="city" autocomplete="address-level2" v-model="currentUser.city" placeholder="City">
+                    <input id="applicant-city" type="text" name="city" autocomplete="off" v-model="currentUser.city" placeholder="City">
                     <p>State/Province</p>
-                    <input id="applicant-state" type="text" name="state" autocomplete="address-level1" v-model="currentUser.state" placeholder="State/Province">
+                    <input id="applicant-state" type="text" name="state" autocomplete="off" v-model="currentUser.state" placeholder="State/Province">
                     <p>ZIP/Postal Code</p>
-                    <input id="applicant-postal-code" type="text" name="postal_code" autocomplete="postal-code" inputmode="numeric" v-model="currentUser.zip" placeholder="ZIP/Postal Code">
+                    <input id="applicant-postal-code" type="text" name="postal_code" autocomplete="off" inputmode="numeric" v-model="currentUser.zip" placeholder="ZIP/Postal Code">
                 </div>
             </Card>
 
@@ -76,11 +76,11 @@
                 <div class="appInfo-group">
                 <h3>Education</h3>
                     <p>Degree</p>
-                    <input id="applicant-degree" type="text" name="degree" autocomplete="organization-title" v-model="currentUser.degree" placeholder="Degree">
+                    <input id="applicant-degree" type="text" name="degree" autocomplete="off" v-model="currentUser.degree" placeholder="Degree">
                     <p>Major/Field of Study</p>
                     <input id="applicant-major" type="text" name="major" autocomplete="off" v-model="currentUser.major" placeholder="Major/Field of Study">
                     <p>University</p>
-                    <input id="applicant-university" type="text" name="university" autocomplete="organization" v-model="currentUser.university" placeholder="University">
+                    <input id="applicant-university" type="text" name="university" autocomplete="off" v-model="currentUser.university" placeholder="University">
                     <p>Graduation Year</p>
                     <input id="applicant-graduation-year" type="text" name="graduation_year" inputmode="numeric" autocomplete="off" v-model="currentUser.gradYear" placeholder="Graduation Year">
                     <p>GPA (Optional)</p>
@@ -97,9 +97,9 @@
                 <p>Years of Experience</p>
                 <input id="applicant-years-experience" type="text" name="years_experience" inputmode="numeric" autocomplete="off" v-model="currentUser.yearsExperience" placeholder="Years of Experience">
                 <p>Current Job Title</p>
-                <input id="applicant-current-job-title" type="text" name="current_job_title" autocomplete="organization-title" v-model="currentUser.currentJobTitle" placeholder="Current Job Title">
+                <input id="applicant-current-job-title" type="text" name="current_job_title" autocomplete="off" v-model="currentUser.currentJobTitle" placeholder="Current Job Title">
                 <p>Current Company</p>
-                <input id="applicant-current-company" type="text" name="current_company" autocomplete="organization" v-model="currentUser.currentCompany" placeholder="Current Company">
+                <input id="applicant-current-company" type="text" name="current_company" autocomplete="off" v-model="currentUser.currentCompany" placeholder="Current Company">
             </Card>
 
             <Card>
@@ -137,7 +137,6 @@
 <script>
 import Card from "../components/Card.vue";
 import ConfirmModal from "../components/ConfirmModal.vue";
-import SecretInput from "../components/SecretInput.vue";
 import { authedFetch, clearAuth, getCurrentUser, setCurrentUser } from "../lib/auth.js";
 
 export default {
@@ -145,7 +144,6 @@ export default {
   components: {
         Card,
         ConfirmModal,
-        SecretInput,
     },
     data() {
         return {
@@ -156,7 +154,6 @@ export default {
             working: false,
             actionStatus: {
                 changeName: { state: 'idle', message: '' },
-                changeUsername: { state: 'idle', message: '' },
                 changeEmail: { state: 'idle', message: '' },
                 changePassword: { state: 'idle', message: '' },
                 sendVerification: { state: 'idle', message: '' },
@@ -164,9 +161,6 @@ export default {
                 deleteAccount: { state: 'idle', message: '' },
             },
             _actionTimers: {},
-
-            changeUsernameNew: '',
-            changeUsernameNewConfirm: '',
 
             changeEmailNew: '',
             changeEmailNewConfirm: '',
@@ -358,42 +352,6 @@ export default {
                 await this.loadUser()
             } catch (e) {
                 this.setActionStatus('changeEmail', 'error', this.formatFailure('Update email', e))
-            } finally {
-                this.working = false
-            }
-        },
-
-        async changeUsername() {
-            const newUsername = (this.changeUsernameNew || '').trim()
-            const newUsernameConfirm = (this.changeUsernameNewConfirm || '').trim()
-            if (!newUsername || !newUsernameConfirm) {
-                this.setActionStatus('changeUsername', 'error', 'Please enter and confirm your new username')
-                return
-            }
-            if (newUsername !== newUsernameConfirm) {
-                this.setActionStatus('changeUsername', 'error', 'Usernames do not match')
-                return
-            }
-            this.working = true
-            this.setActionStatus('changeUsername', 'working', 'Updating…')
-            try {
-                const res = await authedFetch('/api/account/change-username', {
-                    method: 'PUT',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        new_username: newUsername,
-                    }),
-                })
-                const data = await res.json().catch(() => null)
-                if (!res.ok) throw new Error(data?.detail || `HTTP ${res.status}`)
-
-                // Endpoint returns UserResponse
-                this.currentUser = data
-                setCurrentUser(data)
-                this.setActionStatus('changeUsername', 'success', 'Username updated')
-                this.changeUsernameNewConfirm = ''
-            } catch (e) {
-                this.setActionStatus('changeUsername', 'error', this.formatFailure('Update username', e))
             } finally {
                 this.working = false
             }

--- a/frontend/src/views/Forgot-Password.vue
+++ b/frontend/src/views/Forgot-Password.vue
@@ -39,6 +39,8 @@
 </template>
 
 <script>
+import { assertValidEmail } from '../lib/validation.js'
+
 export default {
   name: 'ForgotPassword',
   data() {
@@ -55,10 +57,11 @@ export default {
       this.error = null
       this.message = null
       try {
+        const email = assertValidEmail(this.email)
         const res = await fetch('/api/account/forgot-password', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email: this.email }),
+          body: JSON.stringify({ email }),
         })
 
         const data = await res.json().catch(() => null)

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -6,16 +6,16 @@
 
             <form @submit.prevent="login">
                 <input
-                    id="login-username"
-                    name="username"
+                    id="login-email"
+                    name="email"
                     class="email-input"
-                    type="text"
-                    v-model="username"
+                    type="email"
+                    v-model="email"
                     autocomplete="username"
                     autocapitalize="none"
                     autocorrect="off"
                     spellcheck="false"
-                    placeholder="Username"
+                    placeholder="Email"
                 />
                 <SecretInput
                     v-model="password"
@@ -67,6 +67,7 @@
 <script>
     import SecretInput from "../components/SecretInput.vue";
     import { setAuth } from "../lib/auth.js";
+    import { assertValidEmail } from "../lib/validation.js";
 
     export default{
         name: "Login",
@@ -75,7 +76,7 @@
         },
         data() {
             return {
-                username: "",
+                email: "",
                 password: "",
                 loading: false,
                 oauthRedirecting: false,
@@ -97,11 +98,12 @@
                 this.loading = true
                 this.error = null
                 try {
+                    const email = assertValidEmail(this.email)
                     const res = await fetch('/api/auth/login', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({
-                            username: this.username,
+                            email,
                             password: this.password,
                         }),
                     })

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -3,19 +3,17 @@
     <div class="auth-card">
       <h1>Create account</h1>
       <p class="subtitle">Create an account to access UAH</p>
-
-      <input id="register-email" name="email" class="email-input" type="email" v-model="email" autocomplete="email" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="Email" />
-      <input id="register-confirm-email" name="confirm_email" class="email-input" type="email" v-model="confirmEmail" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="Confirm email" />
-      <input id="register-username" name="account_username" class="email-input" type="text" v-model="username" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="Username" />
-      <input id="register-confirm-username" name="account_username_confirm" class="email-input" type="text" v-model="confirmUsername" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="Confirm username" />
-      <SecretInput v-model="password" id="register-password" name="new-password" inputClass="email-input" autocomplete="new-password" inputmode="text" autocapitalize="none" autocorrect="off" :spellcheck="false" placeholder="Password" :disabled="loading" />
-      <SecretInput v-model="confirmPassword" id="register-confirm-password" name="confirm_password" inputClass="email-input" autocomplete="new-password" inputmode="text" autocapitalize="none" autocorrect="off" :spellcheck="false" placeholder="Confirm password" :disabled="loading" />
-      <input id="register-first-name" name="first_name" class="email-input" type="text" v-model="first_name" autocomplete="given-name" placeholder="First name" />
-      <input id="register-last-name" name="last_name" class="email-input" type="text" v-model="last_name" autocomplete="family-name" placeholder="Last name" />
-
-      <button class="submit-btn" @click="register" :disabled="loading">
-        {{ loading ? 'Creating…' : 'Create account' }}
-      </button>
+      <form @submit.prevent="register">
+        <input id="register-email" name="email" class="email-input" type="email" v-model="email" autocomplete="email" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="Email" />
+        <input id="register-confirm-email" name="confirm_email" class="email-input" type="email" v-model="confirmEmail" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="Confirm email" />
+        <SecretInput v-model="password" id="register-password" name="new-password" inputClass="email-input" autocomplete="new-password" inputmode="text" autocapitalize="none" autocorrect="off" :spellcheck="false" placeholder="Password" :disabled="loading" />
+        <SecretInput v-model="confirmPassword" id="register-confirm-password" name="confirm_password" inputClass="email-input" autocomplete="new-password" inputmode="text" autocapitalize="none" autocorrect="off" :spellcheck="false" placeholder="Confirm password" :disabled="loading" />
+        <input id="register-first-name" name="first_name" class="email-input" type="text" v-model="first_name" autocomplete="given-name" placeholder="First name" />
+        <input id="register-last-name" name="last_name" class="email-input" type="text" v-model="last_name" autocomplete="family-name" placeholder="Last name" />
+        <button class="submit-btn" type="submit" :disabled="loading">
+          {{ loading ? 'Creating…' : 'Create account' }}
+        </button>
+      </form>
 
       <div class="oauth-divider" aria-hidden="true">
         <span>or</span>
@@ -43,6 +41,7 @@
 <script>
 import SecretInput from '../components/SecretInput.vue'
 import { setAuth } from '../lib/auth.js'
+import { assertValidEmail } from '../lib/validation.js'
 
 export default {
   name: 'Register',
@@ -53,8 +52,6 @@ export default {
     return {
       email: '',
       confirmEmail: '',
-      username: '',
-      confirmUsername: '',
       password: '',
       confirmPassword: '',
       first_name: '',
@@ -79,21 +76,10 @@ export default {
       this.loading = true
       this.error = null
       try {
-        const email = (this.email || '').trim()
-        const confirmEmail = (this.confirmEmail || '').trim()
-        const username = (this.username || '').trim()
-        const confirmUsername = (this.confirmUsername || '').trim()
-
-
-        const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i
-        if (!emailRegex.test(email)) {
-          throw new Error('Please enter a valid email address')
-        }
+        const email = assertValidEmail(this.email)
+        const confirmEmail = assertValidEmail(this.confirmEmail, 'confirm email')
         if (!email || !confirmEmail || email.toLowerCase() !== confirmEmail.toLowerCase()) {
           throw new Error('Emails do not match')
-        }
-        if (!username || !confirmUsername || username !== confirmUsername) {
-          throw new Error('Usernames do not match')
         }
         if (!this.password || !this.confirmPassword || this.password !== this.confirmPassword) {
           throw new Error('Passwords do not match')
@@ -104,7 +90,6 @@ export default {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             email,
-            username,
             password: this.password,
             first_name: this.first_name || null,
             last_name: this.last_name || null,

--- a/frontend/src/views/Resumes.vue
+++ b/frontend/src/views/Resumes.vue
@@ -349,27 +349,27 @@
                 <div class="appinfo-grid">
                     <div class="field-group">
                         <label>First Name</label>
-                        <input id="resume-first-name" type="text" name="first_name" autocomplete="given-name" v-model="firstName" placeholder="John">
+                        <input id="resume-first-name" type="text" name="first_name" autocomplete="off" v-model="firstName" placeholder="John">
                     </div>
                     <div class="field-group">
                         <label>Last Name</label>
-                        <input id="resume-last-name" type="text" name="last_name" autocomplete="family-name" v-model="lastName" placeholder="Doe">
+                        <input id="resume-last-name" type="text" name="last_name" autocomplete="off" v-model="lastName" placeholder="Doe">
                     </div>
                     <div class="field-group">
                         <label>Email</label>
-                        <input id="resume-email" type="email" name="email" autocomplete="email" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="appEmail" placeholder="john.doe@email.com">
+                        <input id="resume-email" type="email" name="email" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="appEmail" @blur="onApplicantEmailBlur" placeholder="john.doe@email.com">
                     </div>
                     <div class="field-group">
                         <label>Phone</label>
-                        <input id="resume-phone" type="tel" name="phone" autocomplete="tel" v-model="phone" placeholder="(555) 123-4567">
+                        <input id="resume-phone" type="tel" name="phone" autocomplete="off" v-model="phone" @blur="onApplicantPhoneBlur" placeholder="(555) 123-4567">
                     </div>
                     <div class="field-group">
                         <label>LinkedIn URL</label>
-                        <input id="resume-linkedin" type="url" name="linkedin_url" autocomplete="url" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="linkedin" placeholder="linkedin.com/in/johndoe">
+                        <input id="resume-linkedin" type="url" name="linkedin_url" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="linkedin" placeholder="linkedin.com/in/johndoe">
                     </div>
                     <div class="field-group">
                         <label>Portfolio/Website</label>
-                        <input id="resume-portfolio" type="url" name="portfolio_url" autocomplete="url" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="portfolio" placeholder="johndoe.com">
+                        <input id="resume-portfolio" type="url" name="portfolio_url" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="portfolio" placeholder="johndoe.com">
                     </div>
                 </div>
             </div>
@@ -379,20 +379,20 @@
                 <h3>Address</h3>
                 <div class="field-group field-group-spaced">
                     <label>Street Address</label>
-                    <input id="resume-street-address" type="text" name="street_address" autocomplete="street-address" v-model="streetAddress" placeholder="123 Main Street">
+                    <input id="resume-street-address" type="text" name="street_address" autocomplete="off" v-model="streetAddress" placeholder="123 Main Street">
                 </div>
                 <div class="appinfo-3col">
                     <div class="field-group">
                         <label>City</label>
-                        <input id="resume-city" type="text" name="city" autocomplete="address-level2" v-model="city" placeholder="San Francisco">
+                        <input id="resume-city" type="text" name="city" autocomplete="off" v-model="city" placeholder="San Francisco">
                     </div>
                     <div class="field-group">
                         <label>State</label>
-                        <input id="resume-state" type="text" name="state" autocomplete="address-level1" v-model="appState" placeholder="CA">
+                        <input id="resume-state" type="text" name="state" autocomplete="off" v-model="appState" placeholder="CA">
                     </div>
                     <div class="field-group">
                         <label>ZIP Code</label>
-                        <input id="resume-zip" type="text" name="postal_code" autocomplete="postal-code" inputmode="numeric" v-model="zip" placeholder="94105">
+                        <input id="resume-zip" type="text" name="postal_code" autocomplete="off" inputmode="numeric" v-model="zip" placeholder="94105">
                     </div>
                 </div>
             </div>
@@ -440,7 +440,7 @@
                 <div class="appinfo-grid">
                     <div class="field-group">
                         <label>Degree</label>
-                        <input id="resume-degree" type="text" name="degree" autocomplete="organization-title" v-model="degree" placeholder="Bachelor of Science">
+                        <input id="resume-degree" type="text" name="degree" autocomplete="off" v-model="degree" placeholder="Bachelor of Science">
                     </div>
                     <div class="field-group">
                         <label>Major / Field of Study</label>
@@ -448,7 +448,7 @@
                     </div>
                     <div class="field-group appinfo-full">
                         <label>University</label>
-                        <input id="resume-university" type="text" name="university" autocomplete="organization" v-model="university" placeholder="University of Alabama in Huntsville">
+                        <input id="resume-university" type="text" name="university" autocomplete="off" v-model="university" placeholder="University of Alabama in Huntsville">
                     </div>
                     <div class="field-group">
                         <label>Graduation Year</label>
@@ -471,7 +471,7 @@
                     </div>
                     <div class="field-group">
                         <label>Current / Most Recent Job Title</label>
-                        <input id="resume-job-title" type="text" name="job_title" autocomplete="organization-title" v-model="jobTitle" placeholder="Software Engineer Intern">
+                        <input id="resume-job-title" type="text" name="job_title" autocomplete="off" v-model="jobTitle" placeholder="Software Engineer Intern">
                     </div>
                 </div>
             </div>
@@ -871,6 +871,7 @@
 <script>
 import { authedFetch, getCurrentUser, setCurrentUser } from '../lib/auth.js'
 import { publishCurrentPageDiagnostics, clearCurrentPageDiagnostics } from '../lib/debugDiagnostics'
+import { assertValidEmail, normalizePhone } from '../lib/validation.js'
 import { showToast } from '../services/toastService.js'
 
 const APPINFO_KEY = 'uah_applicant_info'
@@ -1108,6 +1109,28 @@ export default {
     },
 
     methods: {
+        normalizeApplicantContactFields() {
+            if (this.appEmail) {
+                this.appEmail = assertValidEmail(this.appEmail)
+            }
+            this.phone = normalizePhone(this.phone)
+        },
+        onApplicantEmailBlur() {
+            if (!this.appEmail) return
+            try {
+                this.appEmail = assertValidEmail(this.appEmail)
+            } catch {
+                // Keep user's raw input in place until save validation.
+            }
+        },
+        onApplicantPhoneBlur() {
+            if (!this.phone) return
+            try {
+                this.phone = normalizePhone(this.phone)
+            } catch {
+                // Keep user's raw input in place until save validation.
+            }
+        },
         isPlaceholderValue(value) {
             if (value === null || value === undefined) return true
             if (typeof value !== 'string') return false
@@ -1830,6 +1853,7 @@ export default {
             this.saveStatus = { type: '', message: '' }
             if (this._saveTimer) clearTimeout(this._saveTimer)
             try {
+                this.normalizeApplicantContactFields()
                 const payload = this.buildProfilePayload()
                 delete payload.name  // don't overwrite profile name on save
 

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -10,8 +10,7 @@
                 </template>
                 <div class="settings-group">
                     <p v-if="currentUser" class="signed-in">
-                        Signed in as: <strong>{{ currentUser.username || 'User' }}</strong>
-                        <span v-if="currentUser.email">({{ currentUser.email }})</span>
+                        Signed in as: <strong>{{ currentUser.email || 'Not set' }}</strong>
                     </p>
                     <p v-if="currentUser && currentUser.email" class="email-status" :class="{ 'is-verified': !!currentUser.email_verified }">
                         Email status: <strong>{{ currentUser.email_verified ? 'Verified' : 'Not verified' }}</strong>
@@ -20,9 +19,9 @@
                         Current name: <strong>{{ (currentUser.first_name || currentUser.firstName || '') + (currentUser.last_name || currentUser.lastName ? ' ' + (currentUser.last_name || currentUser.lastName) : '') || 'Not set' }}</strong>
                     </p>
                     <p>First Name</p>
-                    <input id="settings-first-name" name="first_name" type="text" v-model="firstName" autocomplete="given-name">
+                    <input id="settings-first-name" name="first_name" type="text" v-model="firstName" autocomplete="off">
                     <p>Last Name</p>
-                    <input id="settings-last-name" name="last_name" type="text" v-model="lastName" autocomplete="family-name">
+                    <input id="settings-last-name" name="last_name" type="text" v-model="lastName" autocomplete="off">
                     <button @click="changeName" :disabled="working" :class="buttonStatusClass('changeName')">Update name</button>
                     <div v-if="actionStatus.changeName.message" :class="feedbackClass('changeName')">
                         {{ actionStatus.changeName.message }}
@@ -47,7 +46,7 @@
                         <option value="no">No</option>
                     </select>
                     <p>Language</p>
-                    <select v-model="language" name="language" id="settings-language" autocomplete="language">
+                    <select v-model="language" name="language" id="settings-language" autocomplete="off">
                         <option value="en">English</option>
                         <option value="es">Spanish</option>
                         <option value="fr">French</option>
@@ -66,22 +65,24 @@
                     <h3>Account & Security</h3>
                 </template>
                 <div class="settings-group">
-                    <h4>Change Username</h4>
-                    <p v-if="currentUser" class="current-value">Current: <strong>{{ currentUser.username || 'User' }}</strong></p>
-                    <input id="settings-new-username" name="new_username" type="text" v-model="changeUsernameNew" autocomplete="username" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="New username">
-                    <input id="settings-new-username-confirm" name="confirm_new_username" type="text" v-model="changeUsernameNewConfirm" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="Confirm new username">
-                    <button @click="changeUsername" :disabled="working" :class="buttonStatusClass('changeUsername')">Update username</button>
-                    <div v-if="actionStatus.changeUsername.message" :class="feedbackClass('changeUsername')">
-                        {{ actionStatus.changeUsername.message }}
-                    </div>
-                </div>
-
-                <div class="settings-group">
                     <h4>Change Email</h4>
                     <p v-if="currentUser" class="current-value">Current: <strong>{{ currentUser.email || 'Not set' }}</strong></p>
-                    <input id="settings-new-email" name="new_email" type="email" v-model="changeEmailNew" autocomplete="email" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="New email">
-                    <input id="settings-new-email-confirm" name="confirm_new_email" type="email" v-model="changeEmailNewConfirm" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="Confirm new email">
-                    <button @click="changeEmail" :disabled="working" :class="buttonStatusClass('changeEmail')">Update email</button>
+                    <form @submit.prevent="changeEmail" class="account-security-form">
+                        <input
+                            v-if="currentUser && currentUser.email"
+                            class="credential-context"
+                            type="email"
+                            :value="currentUser.email"
+                            autocomplete="username"
+                            name="username"
+                            readonly
+                            tabindex="-1"
+                            aria-hidden="true"
+                        >
+                        <input id="settings-new-email" name="username" type="email" v-model="changeEmailNew" autocomplete="username" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="New email">
+                        <input id="settings-new-email-confirm" name="confirm_new_email" type="email" v-model="changeEmailNewConfirm" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="Confirm new email">
+                        <button type="submit" :disabled="working" :class="buttonStatusClass('changeEmail')">Update email</button>
+                    </form>
                     <div v-if="actionStatus.changeEmail.message" :class="feedbackClass('changeEmail')">
                         {{ actionStatus.changeEmail.message }}
                     </div>
@@ -89,7 +90,18 @@
 
                 <div class="settings-group">
                     <h4>Change Password</h4>
-                    <form @submit.prevent="changePassword">
+                    <form @submit.prevent="changePassword" class="account-security-form">
+                        <input
+                            v-if="currentUser && currentUser.email"
+                            class="credential-context"
+                            type="email"
+                            :value="currentUser.email"
+                            autocomplete="username"
+                            name="username"
+                            readonly
+                            tabindex="-1"
+                            aria-hidden="true"
+                        >
                         <SecretInput id="settings-current-password" name="current_password" v-model="currentPassword" placeholder="Current password" autocomplete="current-password" inputmode="text" autocapitalize="none" autocorrect="off" :spellcheck="false" :disabled="working" />
                         <SecretInput id="settings-new-password" name="new_password" v-model="newPassword" placeholder="New password" autocomplete="new-password" inputmode="text" autocapitalize="none" autocorrect="off" :spellcheck="false" :disabled="working" />
                         <SecretInput id="settings-confirm-new-password" name="confirm_new_password" v-model="confirmNewPassword" placeholder="Confirm new password" autocomplete="new-password" inputmode="text" autocapitalize="none" autocorrect="off" :spellcheck="false" :disabled="working" />
@@ -102,11 +114,13 @@
 
                 <div class="settings-group">
                     <h4>Email Verification</h4>
-                    <button @click="sendVerification" :disabled="working" :class="buttonStatusClass('sendVerification')">Send verification token</button>
+                    <form @submit.prevent="sendVerification" class="account-security-form">
+                        <button type="submit" :disabled="working" :class="buttonStatusClass('sendVerification')">Send verification token</button>
+                    </form>
                     <div v-if="actionStatus.sendVerification.message" :class="feedbackClass('sendVerification')">
                         {{ actionStatus.sendVerification.message }}
                     </div>
-                    <form @submit.prevent="verifyEmail">
+                    <form @submit.prevent="verifyEmail" class="account-security-form">
                         <SecretInput id="settings-email-verification-token" name="email_verification_token" v-model="verifyToken" placeholder="Verification token" autocomplete="one-time-code" inputmode="text" autocapitalize="none" autocorrect="off" :spellcheck="false" :disabled="working" />
                         <button type="submit" :disabled="working" :class="buttonStatusClass('verifyEmail')">Verify email</button>
                     </form>
@@ -200,6 +214,7 @@ import Card from "../components/Card.vue";
 import ConfirmModal from "../components/ConfirmModal.vue";
 import SecretInput from "../components/SecretInput.vue";
 import { authedFetch, clearAuth, getCurrentUser, setCurrentUser } from "../lib/auth.js";
+import { assertValidEmail } from "../lib/validation.js";
 import { showToast } from '@/services/toastService.js';
 
 export default {
@@ -218,7 +233,6 @@ export default {
             working: false,
             actionStatus: {
                 changeName: { state: 'idle', message: '' },
-                changeUsername: { state: 'idle', message: '' },
                 changeEmail: { state: 'idle', message: '' },
                 changePassword: { state: 'idle', message: '' },
                 sendVerification: { state: 'idle', message: '' },
@@ -226,9 +240,6 @@ export default {
                 deleteAccount: { state: 'idle', message: '' },
             },
             _actionTimers: {},
-
-            changeUsernameNew: '',
-            changeUsernameNewConfirm: '',
 
             changeEmailNew: '',
             changeEmailNewConfirm: '',
@@ -482,8 +493,17 @@ export default {
         },
 
         async changeEmail() {
-            const newEmail = (this.changeEmailNew || '').trim()
-            const newEmailConfirm = (this.changeEmailNewConfirm || '').trim()
+            let newEmail = ''
+            let newEmailConfirm = ''
+            try {
+                newEmail = assertValidEmail(this.changeEmailNew, 'new email')
+                newEmailConfirm = assertValidEmail(this.changeEmailNewConfirm, 'confirm email')
+            } catch (e) {
+                const msg = e?.message ?? 'Please enter a valid email address'
+                this.setActionStatus('changeEmail', 'error', msg)
+                showToast(msg, 'error')
+                return
+            }
             if (!newEmail || !newEmailConfirm) {
                 const msg = 'Please enter and confirm your new email'
                 this.setActionStatus('changeEmail', 'error', msg)
@@ -492,13 +512,6 @@ export default {
             }
             if (newEmail.toLowerCase() !== newEmailConfirm.toLowerCase()) {
                 const msg = 'Emails do not match'
-                this.setActionStatus('changeEmail', 'error', msg)
-                showToast(msg, 'error')
-                return
-            }
-            const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i
-            if (!emailRegex.test(newEmail)) {
-                const msg = 'Please enter a valid email address'
                 this.setActionStatus('changeEmail', 'error', msg)
                 showToast(msg, 'error')
                 return
@@ -535,49 +548,6 @@ export default {
                 const msg = this.formatFailure('Update email', e)
                 this.setActionStatus('changeEmail', 'error', msg)
                 showToast(msg, 'error')
-            } finally {
-                this.working = false
-            }
-        },
-
-        async changeUsername() {
-            const newUsername = (this.changeUsernameNew || '').trim()
-            const newUsernameConfirm = (this.changeUsernameNewConfirm || '').trim()
-            if (!newUsername || !newUsernameConfirm) {
-                const msg = 'Please enter and confirm your new username'
-                this.setActionStatus('changeUsername', 'error', msg)
-                showToast(msg, 'error')
-                return
-            }
-            if (newUsername !== newUsernameConfirm) {
-                const msg = 'Usernames do not match'
-                this.setActionStatus('changeUsername', 'error', msg)
-                showToast(msg, 'error')
-                return
-            }
-            this.working = true
-            this.setActionStatus('changeUsername', 'working', 'Updating…')
-            try {
-                const res = await authedFetch('/api/account/change-username', {
-                    method: 'PUT',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        new_username: newUsername,
-                    }),
-                })
-                const data = await res.json().catch(() => null)
-                if (!res.ok) throw new Error(data?.detail || `HTTP ${res.status}`)
-
-                // Endpoint returns UserResponse
-                this.currentUser = data
-                setCurrentUser(data)
-                this.setActionStatus('changeUsername', 'success', 'Username updated')
-                showToast('Username updated successfully!', 'success')
-                this.changeUsernameNewConfirm = ''
-            } catch (e) {
-                const msg = this.formatFailure('Update username', e)
-                this.setActionStatus('changeUsername', 'error', msg)
-                showToast(msg, 'error') // ✅ add
             } finally {
                 this.working = false
             }

--- a/frontend/src/views/css/Login.css
+++ b/frontend/src/views/css/Login.css
@@ -27,6 +27,12 @@
   text-align: center;
 }
 
+.auth-card form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 .auth-card h1 {
   font-size: 1.65rem;
   font-weight: 700;

--- a/frontend/src/views/css/Resumes.css
+++ b/frontend/src/views/css/Resumes.css
@@ -220,14 +220,14 @@
 .resume-actions {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 12px;
   flex-shrink: 0;
 }
 
 .resume-badges {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
   margin-right: 8px;
 }
 
@@ -257,7 +257,7 @@
 }
 
 .resume-actions button {
-  width: 32px;
+  min-width: 32px;
   height: 32px;
   border: 1px solid rgba(0, 0, 0, 0.12);
   border-radius: 7px;
@@ -269,7 +269,7 @@
   color: var(--color-text-muted);
   font-size: 0.95rem;
   transition: background 0.1s, border-color 0.1s, color 0.1s;
-  padding: 0;
+  padding: 0 8px;
 }
 
 .resume-actions button:hover {

--- a/frontend/src/views/css/Settings.css
+++ b/frontend/src/views/css/Settings.css
@@ -66,11 +66,32 @@
   margin: 0;
 }
 
+
+
 .settings-group {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   align-items: flex-start;
+}
+
+.account-security-form {
+  width: min(420px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.credential-context {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
 }
 
 .settings-group input,
@@ -200,7 +221,7 @@
   width: min(620px, 100%);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
 }
 
 .connected-account-row {
@@ -208,7 +229,7 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 14px;
+  gap: 16px;
   border: 1px solid rgba(15, 23, 42, 0.14);
   border-radius: 10px;
   padding: 12px 14px;
@@ -275,7 +296,6 @@
 
 .connected-account-actions button {
   width: auto;
-  min-width: 108px;
 }
 
 @media (max-width: 700px) {

--- a/test.txt
+++ b/test.txt
@@ -1,7 +1,5 @@
 Trent notes
 
-add google oauth ui so real test can be done
-
 add default job board stuff and make searching less restrictive
 
 add filtering checks for job board api results which check to make sure jobs returned from api calls are filtered more at our level and jobs that resolve to
@@ -27,4 +25,10 @@ Move alerts/notifications page to below dash/home
 
 make sure all scripts are properly isolated and stuff to where they belong
 
-do a extensive sweep of site to apply proper form field attributes and fix any autofill problems.
+do a extensive sweep of site to apply proper form field attributes and fix any autofill problems.(done maybe, needs second pass)
+
+add nice regex for phone numbers and emails and stuff globally.
+
+add cool area code flag render for phone numbers idk
+
+add phone number linking ability


### PR DESCRIPTION
This pull request implements a comprehensive migration to an email-first identity model, deprecating usernames as primary identifiers throughout the backend. It standardizes email normalization and validation across all user flows, ensures case-insensitive uniqueness, and mirrors the `username` field to always match the normalized email. The changes also introduce a startup routine to enforce this invariant on all existing users, and deprecate the ability to change usernames. 

The most important changes are:

**Email-first identity enforcement and normalization:**

* Introduced a new module (`backend/app/core/validation.py`) with `normalize_email` and `require_valid_email` functions, enforcing consistent, lowercased, and validated emails throughout the codebase.
* Added a startup routine (`_enforce_email_first_identity_mirror` in `backend/app/main.py`) that normalizes all stored emails, mirrors `username = email`, and fails fast if case-insensitive duplicate emails exist. This ensures all users conform to the new invariant.
* All user creation, login, registration, and password reset flows now use case-insensitive, normalized emails for lookup and comparison, replacing previous username-based logic. [[1]](diffhunk://#diff-63ad54ca0eeed0b4dbb07208a92c36ac2509fc2a54610f305d2e24eb58d001e3L35-R38) [[2]](diffhunk://#diff-63ad54ca0eeed0b4dbb07208a92c36ac2509fc2a54610f305d2e24eb58d001e3L138-R143) [[3]](diffhunk://#diff-63ad54ca0eeed0b4dbb07208a92c36ac2509fc2a54610f305d2e24eb58d001e3L167-R172) [[4]](diffhunk://#diff-a9f728a58344f5bc544c6417c19674b3860818aead034c5f208bd8684bc58418L39-R55) [[5]](diffhunk://#diff-a9f728a58344f5bc544c6417c19674b3860818aead034c5f208bd8684bc58418L69-R93) [[6]](diffhunk://#diff-a9f728a58344f5bc544c6417c19674b3860818aead034c5f208bd8684bc58418L115-R133) [[7]](diffhunk://#diff-a9f728a58344f5bc544c6417c19674b3860818aead034c5f208bd8684bc58418L162-R176) [[8]](diffhunk://#diff-36d2ce3c0ef9249c043be6497c4ff1bf48e21597ba716d0d01452ba514ec1b89R18-R31) [[9]](diffhunk://#diff-36d2ce3c0ef9249c043be6497c4ff1bf48e21597ba716d0d01452ba514ec1b89L46-R44) [[10]](diffhunk://#diff-ae6170e4135656d8315f5682d50fdc16b1cc40efa1454c9a6bc2e305fa0199e5L2391-R2398)

**Username deprecation:**

* Deprecated the `change_username` endpoint, returning HTTP 410 Gone and clarifying that email is now the sole sign-in identifier. All new and existing users have `username` forcibly set to their normalized email. [[1]](diffhunk://#diff-63ad54ca0eeed0b4dbb07208a92c36ac2509fc2a54610f305d2e24eb58d001e3L194-R207) [[2]](diffhunk://#diff-a9f728a58344f5bc544c6417c19674b3860818aead034c5f208bd8684bc58418L39-R55) [[3]](diffhunk://#diff-a9f728a58344f5bc544c6417c19674b3860818aead034c5f208bd8684bc58418L69-R93) [[4]](diffhunk://#diff-36d2ce3c0ef9249c043be6497c4ff1bf48e21597ba716d0d01452ba514ec1b89R18-R31) [[5]](diffhunk://#diff-36d2ce3c0ef9249c043be6497c4ff1bf48e21597ba716d0d01452ba514ec1b89L46-R44) [[6]](diffhunk://#diff-ae6170e4135656d8315f5682d50fdc16b1cc40efa1454c9a6bc2e305fa0199e5L2391-R2398)

**Admin and test account bootstrap updates:**

* Updated admin and test account bootstrap logic to require and use email, removing any reliance on usernames. [[1]](diffhunk://#diff-a9f728a58344f5bc544c6417c19674b3860818aead034c5f208bd8684bc58418L18-L26) [[2]](diffhunk://#diff-a9f728a58344f5bc544c6417c19674b3860818aead034c5f208bd8684bc58418L39-R55) [[3]](diffhunk://#diff-c2a439a5efd7a63613ed8d0e1a3932a9d609406d28556c435b7190940282cedbL221-R225)

**Google OAuth and third-party identity:**

* Google login and account linking now use normalized, case-insensitive email matching, and always set `username = email` for linked accounts. Removed legacy username generation logic. [[1]](diffhunk://#diff-36d2ce3c0ef9249c043be6497c4ff1bf48e21597ba716d0d01452ba514ec1b89R1-L18) [[2]](diffhunk://#diff-36d2ce3c0ef9249c043be6497c4ff1bf48e21597ba716d0d01452ba514ec1b89R18-R31) [[3]](diffhunk://#diff-36d2ce3c0ef9249c043be6497c4ff1bf48e21597ba716d0d01452ba514ec1b89L46-R44) [[4]](diffhunk://#diff-ae6170e4135656d8315f5682d50fdc16b1cc40efa1454c9a6bc2e305fa0199e5L2391-R2398)

**Validation improvements:**

* Added robust email and phone number validation helpers, ensuring all user-provided emails and phone numbers are strictly validated and normalized at entry points.

These changes collectively ensure a consistent, robust, and future-proof email-first identity system across the backend.