### PR TITLE
Add pipeline availability checks and UI handling

### DIFF
--- a/backend/app/api/resume.py
+++ b/backend/app/api/resume.py
@@ -25,7 +25,11 @@ from app.services.parse_queue import (
     get_worker_status,
 )
 from app.services.resume_parser import (
-    ocr_pdf_dispatch, normalize_parse_method, parse_markdown_by_method, validate_and_fix, get_parse_input_text,
+    get_pipeline_availability,
+    normalize_parse_method,
+    parse_markdown_by_method,
+    validate_and_fix,
+    get_parse_input_text,
     check_portal_required,
 )
 
@@ -183,6 +187,7 @@ async def _build_queue_status_payload(
         }
 
     queue_depth_total = int(queue_depths.get("total", 0))
+    pipeline_availability = await get_pipeline_availability()
     payload = {
         "scope": effective_scope,
         "requested_scope": requested_scope,
@@ -238,6 +243,7 @@ async def _build_queue_status_payload(
             },
             "load_total": len(ordered_active_jobs) + queue_depth_total,
         },
+        "pipeline_availability": pipeline_availability,
         "local_queue_note": "Local queue load matters most when UAH parses with Local AI.",
         "global_queue": global_queue,
         "latest_active_job_redis_status": latest_active_job_redis_status,
@@ -252,17 +258,16 @@ async def upload_resume(
     current_user: User = Depends(get_current_user),
 ):
     """
-    Upload a resume PDF, run OCR extraction, and store parsed markdown.
+    Upload a resume PDF and store it for later parsing.
 
-    Accepts a PDF file, enforces upload limits/cooldowns, calls OCR, and stores
-    both binary PDF content and OCR markdown for later parsing.
+    Accepts a PDF file, enforces upload limits/cooldowns, and stores the
+    original PDF. OCR/text preparation happens during parse execution so the
+    selected parse method controls downstream dependencies.
 
     Response codes:
-    - 201: Resume uploaded and OCR text stored successfully.
+    - 201: Resume uploaded successfully.
     - 400: File type invalid or file exceeds max size.
-    - 422: OCR completed but returned no usable text.
     - 429: Upload rate or per-user resume limit exceeded.
-    - 502: Upstream OCR service failure.
     """
     if not file.filename.lower().endswith(".pdf"):
         raise HTTPException(status_code=400, detail="Only PDF files are supported")
@@ -286,45 +291,10 @@ async def upload_resume(
     if len(pdf_bytes) > MAX_FILE_SIZE:
         raise HTTPException(status_code=400, detail="File too large, max 5MB")
 
-    ocr_result = await ocr_pdf_dispatch(pdf_bytes)
-    if not ocr_result.get("ok"):
-        error_code = ocr_result.get("error_code") or "OCR_EXTRACTION_FAILED"
-        status_code = int(ocr_result.get("status_code") or 502)
-        public_message = "Could not extract text from the uploaded PDF."
-        if error_code == "OCR_NOT_CONFIGURED":
-            public_message = "Resume OCR service is not configured. Please contact support."
-        elif error_code == "OCR_TIMEOUT":
-            public_message = "Resume OCR request timed out. Please retry in a moment."
-
-        raise HTTPException(
-            status_code=status_code,
-            detail={
-                "code": "OCR_EXTRACTION_FAILED",
-                "message": public_message,
-                "debug": {
-                    "error_code": error_code,
-                    "status_code": status_code,
-                    "exception_type": ocr_result.get("exception_type"),
-                    "response_excerpt": ocr_result.get("response_excerpt"),
-                },
-            },
-        )
-
-    md_text = ocr_result.get("md_results", "")
-    if not md_text:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "code": "OCR_EMPTY_RESULTS",
-                "message": "OCR completed but no text was detected in this PDF.",
-            },
-        )
-
     resume = Resume(
         user_id=current_user.id,
         file_name=file.filename,
         pdf_data=pdf_bytes,
-        raw_markdown=md_text,
     )
     db.add(resume)
     db.commit()

--- a/backend/app/services/resume_parser.py
+++ b/backend/app/services/resume_parser.py
@@ -12,6 +12,8 @@ from app.core.config import settings
 logger = logging.getLogger(__name__)
 
 SUPPORTED_PARSE_METHODS = ("cloud", "local", "rules")
+LOCAL_PIPELINE_UNAVAILABLE_MESSAGE = "Local AI is unavailable right now."
+LOCAL_PIPELINE_PROBE_TIMEOUT_SECONDS = 1.5
 PLACEHOLDER_VALUES = {
     "null",
     "none",
@@ -497,6 +499,87 @@ async def categorize_with_local_llm(md_text: str) -> dict:
             "error_code": "LLM_INVALID_JSON",
             "message": "AI returned malformed data. Please try again.",
         }
+
+
+def _local_pipeline_probe_urls() -> list[str]:
+    urls: list[str] = []
+    seen: set[str] = set()
+
+    for base_url in (settings.LOCAL_OCR_URL, settings.LOCAL_LLM_URL):
+        cleaned = (base_url or "").strip().rstrip("/")
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        urls.append(f"{cleaned}/api/tags")
+
+    return urls
+
+
+async def _probe_local_pipeline_endpoint(url: str) -> bool:
+    try:
+        async with httpx.AsyncClient(
+            timeout=LOCAL_PIPELINE_PROBE_TIMEOUT_SECONDS,
+            follow_redirects=True,
+        ) as client:
+            response = await client.get(url)
+
+        if 200 <= response.status_code < 300:
+            return True
+
+        logger.warning(
+            "Local pipeline probe returned status %s for %s",
+            response.status_code,
+            url,
+        )
+    except httpx.TimeoutException as exc:
+        logger.info("Local pipeline probe timed out for %s: %s", url, exc)
+    except httpx.HTTPError as exc:
+        logger.info("Local pipeline probe failed for %s: %s", url, exc)
+    except Exception as exc:
+        logger.warning(
+            "Local pipeline probe errored for %s: %s: %s",
+            url,
+            type(exc).__name__,
+            exc,
+        )
+
+    return False
+
+
+async def get_pipeline_availability() -> dict:
+    probe_urls = _local_pipeline_probe_urls()
+
+    local_available = False
+    if probe_urls:
+        results = await asyncio.gather(
+            *[_probe_local_pipeline_endpoint(url) for url in probe_urls],
+            return_exceptions=True,
+        )
+        local_available = True
+        for url, result in zip(probe_urls, results):
+            if result is True:
+                continue
+            if isinstance(result, Exception):
+                logger.warning(
+                    "Local pipeline probe raised for %s: %s: %s",
+                    url,
+                    type(result).__name__,
+                    result,
+                )
+            local_available = False
+
+    return {
+        "local": {
+            "available": local_available,
+            "message": None if local_available else LOCAL_PIPELINE_UNAVAILABLE_MESSAGE,
+        },
+        "cloud": {
+            "available": True,
+        },
+        "rules": {
+            "available": True,
+        },
+    }
 
 
 async def ocr_pdf_dispatch(pdf_bytes: bytes) -> dict:

--- a/backend/tests/test_resume_pipeline_contract.py
+++ b/backend/tests/test_resume_pipeline_contract.py
@@ -1,0 +1,216 @@
+from io import BytesIO
+from types import SimpleNamespace
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+from fastapi import UploadFile
+
+from app.api import resume as resume_api
+from app.services import resume_parser
+
+
+class _FakeUploadQuery:
+    def __init__(self, db, call_index):
+        self._db = db
+        self._call_index = call_index
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def scalar(self):
+        if self._call_index != 1:
+            raise AssertionError("Unexpected scalar() call")
+        return self._db.resume_count
+
+    def first(self):
+        if self._call_index != 2:
+            raise AssertionError("Unexpected first() call")
+        return self._db.last_upload
+
+
+class _FakeUploadDb:
+    def __init__(self, resume_count=0, last_upload=None):
+        self.resume_count = resume_count
+        self.last_upload = last_upload
+        self.query_calls = 0
+        self.added = None
+        self.commits = 0
+
+    def query(self, *args, **kwargs):
+        self.query_calls += 1
+        return _FakeUploadQuery(self, self.query_calls)
+
+    def add(self, obj):
+        self.added = obj
+
+    def commit(self):
+        self.commits += 1
+
+    def refresh(self, obj):
+        if getattr(obj, "id", None) is None:
+            obj.id = 101
+
+
+class _FakeQueueQuery:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def limit(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeQueueDb:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def query(self, _model):
+        return _FakeQueueQuery(self._rows)
+
+
+class ResumePipelineContractTests(unittest.IsolatedAsyncioTestCase):
+    async def test_upload_stores_pdf_without_running_ocr(self):
+        fake_db = _FakeUploadDb()
+        current_user = SimpleNamespace(id=7)
+        upload = UploadFile(filename="resume.pdf", file=BytesIO(b"%PDF-1.4 mock"))
+
+        with patch.object(resume_api.settings, "USE_LOCAL_PIPELINE", True), \
+             patch.object(
+                 resume_parser,
+                 "ocr_pdf",
+                 AsyncMock(side_effect=AssertionError("Cloud OCR should not run during upload")),
+             ), \
+             patch.object(
+                 resume_parser,
+                 "ocr_pdf_local",
+                 AsyncMock(side_effect=AssertionError("Local OCR should not run during upload")),
+             ):
+            response = await resume_api.upload_resume(
+                file=upload,
+                db=fake_db,
+                current_user=current_user,
+            )
+
+        self.assertEqual(response.id, 101)
+        self.assertEqual(response.file_name, "resume.pdf")
+        self.assertEqual(response.status, "uploaded")
+        self.assertIsNotNone(fake_db.added)
+        self.assertEqual(fake_db.added.user_id, 7)
+        self.assertEqual(fake_db.added.file_name, "resume.pdf")
+        self.assertEqual(fake_db.added.pdf_data, b"%PDF-1.4 mock")
+        self.assertIsNone(fake_db.added.raw_markdown)
+        self.assertEqual(fake_db.commits, 1)
+
+    async def test_cloud_parse_input_uses_cloud_ocr_even_when_local_pipeline_flag_enabled(self):
+        cloud_ocr = AsyncMock(return_value={"ok": True, "md_results": "cloud text"})
+        local_ocr = AsyncMock(return_value={"ok": True, "md_results": "local text"})
+
+        with patch.object(resume_parser.settings, "USE_LOCAL_PIPELINE", True), \
+             patch.object(resume_parser, "ocr_pdf", cloud_ocr), \
+             patch.object(resume_parser, "ocr_pdf_local", local_ocr):
+            payload = await resume_parser.get_parse_input_text(b"pdf-bytes", "cloud")
+
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["text"], "cloud text")
+        self.assertEqual(payload["source"], "cloud_ocr")
+        cloud_ocr.assert_awaited_once_with(b"pdf-bytes")
+        local_ocr.assert_not_awaited()
+
+    async def test_rules_parse_input_uses_embedded_text_only(self):
+        extract_text = Mock(return_value={"ok": True, "text": "embedded text", "source": "rules_embedded_pdf_text"})
+        cloud_ocr = AsyncMock(return_value={"ok": True, "md_results": "cloud text"})
+        local_ocr = AsyncMock(return_value={"ok": True, "md_results": "local text"})
+
+        with patch.object(resume_parser.settings, "USE_LOCAL_PIPELINE", True), \
+             patch.object(resume_parser, "extract_embedded_pdf_text", extract_text), \
+             patch.object(resume_parser, "ocr_pdf", cloud_ocr), \
+             patch.object(resume_parser, "ocr_pdf_local", local_ocr):
+            payload = await resume_parser.get_parse_input_text(b"pdf-bytes", "rules")
+
+        self.assertEqual(payload["text"], "embedded text")
+        self.assertEqual(payload["source"], "rules_embedded_pdf_text")
+        extract_text.assert_called_once_with(b"pdf-bytes")
+        cloud_ocr.assert_not_awaited()
+        local_ocr.assert_not_awaited()
+
+    async def test_cloud_markdown_parse_uses_cloud_llm_even_when_local_pipeline_flag_enabled(self):
+        cloud_llm = AsyncMock(return_value={"parsed": "cloud"})
+        local_llm = AsyncMock(return_value={"parsed": "local"})
+
+        with patch.object(resume_parser.settings, "USE_LOCAL_PIPELINE", True), \
+             patch.object(resume_parser, "categorize_with_llm", cloud_llm), \
+             patch.object(resume_parser, "categorize_with_local_llm", local_llm):
+            structured = await resume_parser.parse_markdown_by_method("resume markdown", "cloud")
+
+        self.assertEqual(structured, {"parsed": "cloud"})
+        cloud_llm.assert_awaited_once_with("resume markdown")
+        local_llm.assert_not_awaited()
+
+    async def test_rules_markdown_parse_uses_rules_parser_only(self):
+        rules_parser = Mock(return_value={"parsed": "rules"})
+        cloud_llm = AsyncMock(return_value={"parsed": "cloud"})
+        local_llm = AsyncMock(return_value={"parsed": "local"})
+
+        with patch.object(resume_parser.settings, "USE_LOCAL_PIPELINE", True), \
+             patch.object(resume_parser, "parse_with_rules", rules_parser), \
+             patch.object(resume_parser, "categorize_with_llm", cloud_llm), \
+             patch.object(resume_parser, "categorize_with_local_llm", local_llm):
+            structured = await resume_parser.parse_markdown_by_method("resume markdown", "rules")
+
+        self.assertEqual(structured, {"parsed": "rules"})
+        rules_parser.assert_called_once_with("resume markdown")
+        cloud_llm.assert_not_awaited()
+        local_llm.assert_not_awaited()
+
+    async def test_queue_status_includes_local_pipeline_unavailable_payload(self):
+        fake_db = _FakeQueueDb(rows=[])
+        current_user = SimpleNamespace(id=3)
+        unavailable_payload = {
+            "local": {
+                "available": False,
+                "message": "Local AI is unavailable right now.",
+            },
+            "cloud": {
+                "available": True,
+            },
+            "rules": {
+                "available": True,
+            },
+        }
+
+        with patch.object(resume_api.settings, "REDIS_ENABLED", False), \
+             patch.object(
+                 resume_api,
+                 "get_pipeline_availability",
+                 AsyncMock(return_value=unavailable_payload),
+             ):
+            payload = await resume_api._build_queue_status_payload(
+                db=fake_db,
+                current_user=current_user,
+                scope="user",
+                focus_method="local",
+            )
+
+        self.assertIn("pipeline_availability", payload)
+        self.assertEqual(payload["pipeline_availability"]["local"]["available"], False)
+        self.assertEqual(
+            payload["pipeline_availability"]["local"]["message"],
+            "Local AI is unavailable right now.",
+        )
+        self.assertEqual(payload["pipeline_availability"]["cloud"]["available"], True)
+        self.assertEqual(payload["pipeline_availability"]["rules"]["available"], True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/lib/localMockApi.js
+++ b/frontend/src/lib/localMockApi.js
@@ -749,6 +749,7 @@ function buildQueueSnapshot(state, focusMethod = 'local', includeGlobalQueue = t
     queue_total: activeJobs.length,
     created_at: job.created_at,
   }))
+  const localAvailable = parseBoolean(import.meta.env.VITE_LOCAL_MOCK_LOCAL_AI_AVAILABLE, true)
 
   const snapshot = {
     can_view_global: true,
@@ -768,6 +769,18 @@ function buildQueueSnapshot(state, focusMethod = 'local', includeGlobalQueue = t
     },
     worker_status: {
       mode: 'mock',
+    },
+    pipeline_availability: {
+      local: {
+        available: localAvailable,
+        message: localAvailable ? null : 'Local AI is unavailable right now.',
+      },
+      cloud: {
+        available: true,
+      },
+      rules: {
+        available: true,
+      },
     },
     local_queue_note: 'Queue metrics are simulated in local mock mode.',
     cloud_behavior: {

--- a/frontend/src/views/Resumes.vue
+++ b/frontend/src/views/Resumes.vue
@@ -102,10 +102,11 @@
                             <button class="btn-secondary btn-compact parse-details-btn" type="button" @click="showPipelineDetails = true">View Details</button>
                         </div>
                         <div class="method-toggle method-toggle-3">
-                            <button :class="{ active: parseMethod === 'local' }" @click="parseMethod = 'local'">Local AI</button>
+                            <button :class="{ active: parseMethod === 'local' }" :disabled="!isLocalParseMethodAvailable" @click="parseMethod = 'local'">Local AI</button>
                             <button :class="{ active: parseMethod === 'cloud' }" @click="parseMethod = 'cloud'">Cloud AI (ZAI)</button>
                             <button :class="{ active: parseMethod === 'rules' }" @click="parseMethod = 'rules'">Rules-based</button>
                         </div>
+                        <p v-if="!isLocalParseMethodAvailable && localParseMethodUnavailableMessage" class="parse-method-note parse-method-note-unavailable">{{ localParseMethodUnavailableMessage }}</p>
                         <p class="parse-method-summary">{{ selectedParseMethodDescription }}</p>
                     </div>
 
@@ -1043,6 +1044,18 @@ export default {
             if (this.parseAttempt <= 0) return 'Attempt 1'
             return `Retry ${this.parseAttempt}`
         },
+        pipelineAvailability() {
+            return this.queueStatus?.pipeline_availability || null
+        },
+        isLocalParseMethodAvailable() {
+            return this.pipelineAvailability?.local?.available !== false
+        },
+        localParseMethodUnavailableMessage() {
+            if (this.isLocalParseMethodAvailable) return ''
+            const message = this.pipelineAvailability?.local?.message
+            if (typeof message === 'string' && message.trim()) return message.trim()
+            return 'Local AI is unavailable right now.'
+        },
         selectedParseMethodDescription() {
             const map = {
                 local: 'Local AI uses UAH local OCR + local parsing with isolated queue visibility.',
@@ -1194,6 +1207,18 @@ export default {
             tick()
         },
 
+        applyQueueStatus(status) {
+            this.queueStatus = status
+
+            if (!this.queueStatus?.can_view_global && this.queueScope === 'global') {
+                this.queueScope = 'user'
+            }
+
+            if (status?.pipeline_availability?.local?.available === false && this.parseMethod === 'local') {
+                this.parseMethod = 'cloud'
+            }
+        },
+
         async loadQueueStatus() {
             if (this.activeTab !== 'imported') return
 
@@ -1203,11 +1228,7 @@ export default {
                 const focusMethod = encodeURIComponent(this.parseJobMethod || this.parseMethod || 'local')
                 const res = await authedFetch(`/api/resume/queue/status?scope=${encodeURIComponent(this.queueScope)}&focus_method=${focusMethod}`)
                 if (!res.ok) throw new Error(`HTTP ${res.status}`)
-                this.queueStatus = await res.json()
-
-                if (!this.queueStatus?.can_view_global && this.queueScope === 'global') {
-                    this.queueScope = 'user'
-                }
+                this.applyQueueStatus(await res.json())
             } catch (e) {
                 if (e.message === 'Session expired' || e.message === 'Not authenticated') {
                     this.$router.push('/login')
@@ -1416,7 +1437,7 @@ export default {
         openUploadModal() {
             this.uploadStep = 'select'
             this.pendingFile = null
-            this.parseMethod = 'local'
+            this.parseMethod = this.isLocalParseMethodAvailable ? 'local' : 'cloud'
             this.uploadError = null
             this.isDragOver = false
             this.$nextTick(() => {
@@ -1475,6 +1496,12 @@ export default {
         },
         async doUpload() {
             if (!this.pendingFile || this.uploading) return
+            const selectedMethod = this.parseMethod === 'local' && !this.isLocalParseMethodAvailable
+                ? 'cloud'
+                : this.parseMethod
+            if (selectedMethod !== this.parseMethod) {
+                this.parseMethod = selectedMethod
+            }
             this.uploading = true
             this.uploadError = null
             try {
@@ -1495,7 +1522,7 @@ export default {
                 const parseRes = await authedFetch(`/api/resume/${resumeId}/parse-async`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ method: this.parseMethod }),
+                    body: JSON.stringify({ method: selectedMethod }),
                 })
                 const parseData = await parseRes.json().catch(() => null)
                 if (!parseRes.ok) {
@@ -1507,7 +1534,7 @@ export default {
                 this.parseStatus = 'queued'
                 this.parseStageLabel = 'Queued…'
                 this.parseError = null
-                this.parseJobMethod = this.parseMethod
+                this.parseJobMethod = selectedMethod
                 this.uploadStep = 'parsing'
                 this.uploading = false
                 this.publishDebugState('parse-started')
@@ -1529,7 +1556,7 @@ export default {
                 const job = await res.json()
 
                 if (job.queue_snapshot && this.queueScope !== 'global') {
-                    this.queueStatus = job.queue_snapshot
+                    this.applyQueueStatus(job.queue_snapshot)
                 }
 
                 this.parseStatus = job.status

--- a/frontend/src/views/css/Resumes.css
+++ b/frontend/src/views/css/Resumes.css
@@ -640,6 +640,19 @@
   color: var(--color-primary-700);
 }
 
+.method-toggle button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  border-color: rgba(148, 163, 184, 0.45);
+  color: #94a3b8;
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.method-toggle button:disabled:hover {
+  border-color: rgba(148, 163, 184, 0.45);
+  color: #94a3b8;
+}
+
 .method-toggle button:focus-visible {
   outline: 2px solid rgba(37, 99, 235, 0.45);
   outline-offset: 2px;
@@ -668,6 +681,16 @@
   margin: 8px 0 0 0;
   font-size: 0.8rem;
   color: #64748b;
+}
+
+.parse-method-note {
+  margin: 8px 0 0 0;
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.parse-method-note-unavailable {
+  color: #92400e;
 }
 
 .inline-actions {

--- a/scripts/beta/diagnostic/beta-debug.sh
+++ b/scripts/beta/diagnostic/beta-debug.sh
@@ -499,6 +499,7 @@ menu_users() {
     echo "    3) Show user by email"
     echo "    4) Activate/deactivate user"
     echo "    5) Toggle developer access"
+    echo "    6) Toggle admin access"
     echo ""
     echo "    0) ← Back"
     echo ""
@@ -581,6 +582,16 @@ PYEOF
         docker exec uah-beta-db psql -U uah -d uah_beta -c "
           UPDATE users SET is_developer=$developer WHERE lower(email)=lower('$user_email')
           RETURNING email, is_developer;
+        " | sed 's/^/  /'
+        press_enter ;;
+      6)
+        header
+        echo -e "${BOLD}  Toggle Admin Access${NC}\n"
+        read -rp "  Email: " user_email
+        read -rp "  Admin? (true/false): " admin
+        docker exec uah-beta-db psql -U uah -d uah_beta -c "
+          UPDATE users SET is_admin=$admin WHERE lower(email)=lower('$user_email')
+          RETURNING email, is_admin;
         " | sed 's/^/  /'
         press_enter ;;
       0) return ;;


### PR DESCRIPTION
Add runtime pipeline availability probing and surface it to the API and UI. Backend: introduce get_pipeline_availability() (probes local OCR/LLM endpoints), include pipeline_availability in queue status payload, and stop running OCR during resume upload (store PDF for later parsing). Add unit tests to enforce the resume upload / parse pipeline contract. Frontend: include pipeline_availability in local mock snapshot, disable the Local AI parse button when unavailable, show an explanatory message, auto-fallback selected method to Cloud when Local is unavailable, and centralize queue status handling via applyQueueStatus. Style: add CSS for disabled method buttons and parse method notes. Misc: add a beta diagnostic script menu entry to toggle admin access.