### PR TITLE
Add integrations API, service connections & UI

### DIFF
--- a/backend/app/api/gmail.py
+++ b/backend/app/api/gmail.py
@@ -6,6 +6,7 @@ from cryptography.fernet import Fernet
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
+from urllib.parse import urlencode
 from app.db.session import get_db
 from app.models.user import User
 from app.api.deps import get_current_user
@@ -41,15 +42,20 @@ def _decrypt_token(encrypted: str) -> str:
     return _get_fernet().decrypt(encrypted.encode()).decode()
 
 
-@router.get("/connect")
-async def gmail_connect(request: Request, current_user: User = Depends(get_current_user)):
-    if not settings.GMAIL_CLIENT_ID or not settings.GMAIL_REDIRECT_URI:
-        raise HTTPException(status_code=500, detail="Gmail integration not configured")
+def _clear_gmail_oauth_session(request: Request) -> None:
+    request.session.pop("gmail_oauth_state", None)
+    request.session.pop("gmail_oauth_user_id", None)
 
-    state = secrets.token_urlsafe(16)
-    request.session["gmail_oauth_state"] = state
-    request.session["gmail_oauth_user_id"] = current_user.id
 
+def _gmail_settings_redirect(service_state: str, reason: str | None = None) -> RedirectResponse:
+    public_url = (settings.PUBLIC_APP_URL or "").rstrip("/")
+    query = {"service": "gmail", "service_state": service_state}
+    if reason:
+        query["service_reason"] = reason
+    return RedirectResponse(f"{public_url}/settings?{urlencode(query)}")
+
+
+def _build_gmail_authorization_url(state: str) -> str:
     params = {
         "client_id": settings.GMAIL_CLIENT_ID,
         "redirect_uri": settings.GMAIL_REDIRECT_URI,
@@ -60,7 +66,33 @@ async def gmail_connect(request: Request, current_user: User = Depends(get_curre
         "state": state,
     }
     query = "&".join(f"{k}={v}" for k, v in params.items())
-    return RedirectResponse(f"{GOOGLE_AUTH_URL}?{query}")
+    return f"{GOOGLE_AUTH_URL}?{query}"
+
+
+def _start_gmail_connect(request: Request, current_user: User) -> str:
+    if not settings.GMAIL_CLIENT_ID or not settings.GMAIL_REDIRECT_URI:
+        raise RuntimeError("not_configured")
+
+    state = secrets.token_urlsafe(16)
+    request.session["gmail_oauth_state"] = state
+    request.session["gmail_oauth_user_id"] = current_user.id
+    return _build_gmail_authorization_url(state)
+
+
+@router.get("/connect")
+async def gmail_connect(request: Request, current_user: User = Depends(get_current_user)):
+    try:
+        return RedirectResponse(_start_gmail_connect(request, current_user))
+    except RuntimeError as exc:
+        return _gmail_settings_redirect("error", str(exc) or "not_configured")
+
+
+@router.post("/connect/start")
+async def gmail_connect_start(request: Request, current_user: User = Depends(get_current_user)):
+    try:
+        return {"authorization_url": _start_gmail_connect(request, current_user)}
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc) or "not_configured")
 
 
 @router.get("/callback")
@@ -74,41 +106,51 @@ async def gmail_callback(
     user_id = request.session.get("gmail_oauth_user_id")
 
     if not expected_state or state != expected_state or not user_id:
-        raise HTTPException(status_code=400, detail="Invalid or expired OAuth state")
+        _clear_gmail_oauth_session(request)
+        return _gmail_settings_redirect("error", "invalid_state")
 
-    async with httpx.AsyncClient() as client:
-        token_resp = await client.post(GOOGLE_TOKEN_URL, data={
-            "code": code,
-            "client_id": settings.GMAIL_CLIENT_ID,
-            "client_secret": settings.GMAIL_CLIENT_SECRET,
-            "redirect_uri": settings.GMAIL_REDIRECT_URI,
-            "grant_type": "authorization_code",
-        })
-        token_data = token_resp.json()
+    try:
+        async with httpx.AsyncClient() as client:
+            token_resp = await client.post(GOOGLE_TOKEN_URL, data={
+                "code": code,
+                "client_id": settings.GMAIL_CLIENT_ID,
+                "client_secret": settings.GMAIL_CLIENT_SECRET,
+                "redirect_uri": settings.GMAIL_REDIRECT_URI,
+                "grant_type": "authorization_code",
+            })
+            token_data = token_resp.json()
+    except Exception:
+        _clear_gmail_oauth_session(request)
+        return _gmail_settings_redirect("error", "token_exchange_failed")
 
     refresh_token = token_data.get("refresh_token")
     access_token = token_data.get("access_token")
 
     if not refresh_token or not access_token:
-        raise HTTPException(status_code=400, detail="Failed to get Gmail tokens")
+        _clear_gmail_oauth_session(request)
+        return _gmail_settings_redirect("error", "missing_tokens")
 
-    async with httpx.AsyncClient() as client:
-        profile = await client.get(
-            "https://www.googleapis.com/oauth2/v3/userinfo",
-            headers={"Authorization": f"Bearer {access_token}"},
-        )
-        gmail_email = profile.json().get("email", "")
+    try:
+        async with httpx.AsyncClient() as client:
+            profile = await client.get(
+                "https://www.googleapis.com/oauth2/v3/userinfo",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            gmail_email = profile.json().get("email", "")
+    except Exception:
+        _clear_gmail_oauth_session(request)
+        return _gmail_settings_redirect("error", "profile_fetch_failed")
 
     user = db.query(User).filter(User.id == user_id).first()
     if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+        _clear_gmail_oauth_session(request)
+        return _gmail_settings_redirect("error", "user_not_found")
 
     user.gmail_refresh_token = _encrypt_token(refresh_token)
     user.gmail_email = gmail_email
     db.commit()
-
-    public_url = (settings.PUBLIC_APP_URL or "").rstrip("/")
-    return RedirectResponse(f"{public_url}/settings?gmail=connected")
+    _clear_gmail_oauth_session(request)
+    return _gmail_settings_redirect("connected")
 
 
 @router.get("/status")

--- a/backend/app/api/integrations.py
+++ b/backend/app/api/integrations.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.api.deps import get_current_user
+from app.models.user import User
+from app.schemas.integration import ServiceDetail, ServiceSummary
+from app.services.service_connections import get_service_detail, list_service_summaries
+
+router = APIRouter(prefix="/api/integrations", tags=["integrations"])
+
+
+@router.get("/services", response_model=list[ServiceSummary])
+def list_services(
+    current_user: User = Depends(get_current_user),
+):
+    return list_service_summaries(current_user)
+
+
+@router.get("/services/{service_key}", response_model=ServiceDetail)
+def service_details(
+    service_key: str,
+    current_user: User = Depends(get_current_user),
+):
+    try:
+        return get_service_detail(current_user, service_key)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Service not found")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ from app.api.account import router as account_router
 from app.api.resume import router as resume_router
 from app.api.applicant_profile import router as profile_router
 from app.api.apply_session import router as apply_session_router
+from app.api.integrations import router as integrations_router
 from app.api.gmail import router as gmail_router
 from app.core.config import settings
 from app.core.validation import normalize_email, require_valid_email
@@ -400,6 +401,7 @@ app.include_router(account_router)
 app.include_router(resume_router)
 app.include_router(profile_router)
 app.include_router(apply_session_router)
+app.include_router(integrations_router)
 app.include_router(gmail_router)
 
 

--- a/backend/app/schemas/integration.py
+++ b/backend/app/schemas/integration.py
@@ -1,0 +1,44 @@
+from pydantic import BaseModel, Field
+
+
+class ServiceAction(BaseModel):
+    key: str = Field(..., examples=["connect"])
+    label: str = Field(..., examples=["Connect"])
+    enabled: bool = Field(default=True, examples=[True])
+    style: str = Field(default="primary", examples=["primary"])
+    method: str | None = Field(default=None, examples=["POST"])
+    href: str | None = Field(default=None, examples=["/api/integrations/gmail/connect/start"])
+
+
+class ServiceReadiness(BaseModel):
+    title: str = Field(..., examples=["Ready for mailbox-powered updates"])
+    description: str = Field(..., examples=["UAH can use this connection for future job-update signals."])
+    tone: str = Field(default="neutral", examples=["positive"])
+
+
+class ServiceSummary(BaseModel):
+    key: str = Field(..., examples=["gmail"])
+    label: str = Field(..., examples=["Gmail Updates"])
+    category: str = Field(..., examples=["communication"])
+    status: str = Field(..., examples=["connected"])
+    connected: bool = Field(..., examples=[True])
+    availability: str = Field(..., examples=["available"])
+    summary: str = Field(..., examples=["Mailbox ready for future job-update scanning and timeline enrichment."])
+    account_label: str | None = Field(default=None, examples=["jane.doe@example.com"])
+    primary_action: ServiceAction
+    can_view_details: bool = Field(default=True, examples=[True])
+
+
+class ServiceDetail(BaseModel):
+    key: str = Field(..., examples=["gmail"])
+    label: str = Field(..., examples=["Gmail Updates"])
+    status: str = Field(..., examples=["connected"])
+    connected: bool = Field(..., examples=[True])
+    account_label: str | None = Field(default=None, examples=["jane.doe@example.com"])
+    availability: str = Field(..., examples=["available"])
+    description: str = Field(..., examples=["Connect Gmail so UAH can prepare for inbox-driven job update workflows."])
+    capabilities: list[str] = Field(default_factory=list)
+    permissions: list[str] = Field(default_factory=list)
+    readiness: ServiceReadiness
+    planned_features: list[str] = Field(default_factory=list)
+    actions: list[ServiceAction] = Field(default_factory=list)

--- a/backend/app/services/service_connections.py
+++ b/backend/app/services/service_connections.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from app.core.config import settings
+from app.models.user import User
+from app.schemas.integration import ServiceAction, ServiceDetail, ServiceReadiness, ServiceSummary
+
+SERVICE_KEYS = ("gmail", "calendar_sync", "resume_imports")
+
+
+def _gmail_configured() -> bool:
+    return bool(
+        (settings.GMAIL_CLIENT_ID or "").strip()
+        and (settings.GMAIL_CLIENT_SECRET or "").strip()
+        and (settings.GMAIL_REDIRECT_URI or "").strip()
+    )
+
+
+def _coming_soon_action() -> ServiceAction:
+    return ServiceAction(
+        key="coming_soon",
+        label="Coming soon",
+        enabled=False,
+        style="muted",
+    )
+
+
+def _gmail_connect_action() -> ServiceAction:
+    return ServiceAction(
+        key="connect",
+        label="Connect",
+        enabled=True,
+        style="primary",
+        method="POST",
+        href="/api/integrations/gmail/connect/start",
+    )
+
+
+def _gmail_disconnect_action() -> ServiceAction:
+    return ServiceAction(
+        key="disconnect",
+        label="Disconnect",
+        enabled=True,
+        style="secondary",
+        method="DELETE",
+        href="/api/integrations/gmail/disconnect",
+    )
+
+
+def _gmail_unavailable_action() -> ServiceAction:
+    return ServiceAction(
+        key="unavailable",
+        label="Unavailable",
+        enabled=False,
+        style="muted",
+    )
+
+
+def _gmail_summary(user: User) -> ServiceSummary:
+    connected = bool(user.gmail_refresh_token)
+    configured = _gmail_configured()
+    account_label = (user.gmail_email or "").strip() or None
+
+    if connected:
+        return ServiceSummary(
+            key="gmail",
+            label="Gmail Updates",
+            category="communication",
+            status="connected",
+            connected=True,
+            availability="available",
+            summary="Mailbox ready for future job-update scanning and timeline enrichment.",
+            account_label=account_label or "Connected to Gmail",
+            primary_action=_gmail_disconnect_action(),
+            can_view_details=True,
+        )
+
+    if configured:
+        return ServiceSummary(
+            key="gmail",
+            label="Gmail Updates",
+            category="communication",
+            status="available",
+            connected=False,
+            availability="available",
+            summary="Opt in to read-only inbox access so UAH can prepare for job update workflows.",
+            account_label="No Gmail mailbox connected yet.",
+            primary_action=_gmail_connect_action(),
+            can_view_details=True,
+        )
+
+    return ServiceSummary(
+        key="gmail",
+        label="Gmail Updates",
+        category="communication",
+        status="needs_attention",
+        connected=False,
+        availability="available",
+        summary="Gmail support exists, but this environment still needs OAuth configuration before users can connect.",
+        account_label="Gmail OAuth is not configured for this environment.",
+        primary_action=_gmail_unavailable_action(),
+        can_view_details=True,
+    )
+
+
+def _gmail_detail(user: User) -> ServiceDetail:
+    summary = _gmail_summary(user)
+    connected = summary.connected
+    configured = _gmail_configured()
+
+    if connected:
+        readiness = ServiceReadiness(
+            title="Ready for mailbox-powered updates",
+            description="UAH can use this mailbox connection for future job-update scanning, status inference, and timeline enrichment without asking you to reconnect.",
+            tone="positive",
+        )
+    elif configured:
+        readiness = ServiceReadiness(
+            title="Available to connect",
+            description="Connect Gmail when you want UAH ready for inbox-based job update features. Nothing is scanned automatically in this phase.",
+            tone="neutral",
+        )
+    else:
+        readiness = ServiceReadiness(
+            title="Needs environment setup",
+            description="An administrator still needs to configure Gmail OAuth credentials for this environment before users can opt in.",
+            tone="warning",
+        )
+
+    actions = (
+        [_gmail_disconnect_action()]
+        if connected
+        else ([_gmail_connect_action()] if configured else [_gmail_unavailable_action()])
+    )
+
+    return ServiceDetail(
+        key="gmail",
+        label="Gmail Updates",
+        status=summary.status,
+        connected=summary.connected,
+        account_label=summary.account_label,
+        availability=summary.availability,
+        description="Connect Gmail so UAH can prepare for inbox-driven job update workflows and future email-based status intelligence.",
+        capabilities=[
+            "Recognize job-update emails like application receipts, interview invites, and decisions.",
+            "Enrich your future application timeline with inbox-derived signals.",
+            "Help surface job communication context without making Gmail your sign-in method.",
+        ],
+        permissions=[
+            "Read-only Gmail mailbox access via Google OAuth.",
+            "Google account email is used to label the mailbox connection in Settings.",
+            "Disconnecting removes the stored refresh token and stops future mailbox access.",
+        ],
+        readiness=readiness,
+        planned_features=[
+            "Inbox-powered application status detection",
+            "Timeline enrichment from recruiter communications",
+            "Optional service-level scan controls and summaries in a later phase",
+        ],
+        actions=actions,
+    )
+
+
+def _calendar_detail() -> ServiceDetail:
+    return ServiceDetail(
+        key="calendar_sync",
+        label="Calendar Sync",
+        status="coming_soon",
+        connected=False,
+        account_label="Planned for a future release.",
+        availability="coming_soon",
+        description="Calendar Sync will help UAH coordinate interview timing, reminders, and event context when the service launches.",
+        capabilities=[
+            "Match interview invites to tracked applications.",
+            "Highlight upcoming conversations and scheduling windows.",
+            "Reduce manual copy-and-paste between recruiting emails and your calendar.",
+        ],
+        permissions=[
+            "No calendar access is requested in this release.",
+            "Any future calendar permissions will be explained clearly before opt-in.",
+        ],
+        readiness=ServiceReadiness(
+            title="On the roadmap",
+            description="This service is being designed for a future release and is not yet connectable.",
+            tone="muted",
+        ),
+        planned_features=[
+            "Interview scheduling awareness",
+            "Reminder and event enrichment",
+            "Meeting context linked back to job applications",
+        ],
+        actions=[_coming_soon_action()],
+    )
+
+
+def _resume_imports_detail() -> ServiceDetail:
+    return ServiceDetail(
+        key="resume_imports",
+        label="Resume Imports",
+        status="coming_soon",
+        connected=False,
+        account_label="Planned for a future release.",
+        availability="coming_soon",
+        description="Resume Imports will make it easier to bring documents into UAH from external services without rebuilding your profile by hand.",
+        capabilities=[
+            "Import resumes and supporting documents from connected storage providers.",
+            "Keep document sources organized for future autofill workflows.",
+            "Reduce friction when refreshing resumes across multiple applications.",
+        ],
+        permissions=[
+            "No document-provider access is requested in this release.",
+            "Future providers will explain exactly which files or folders are shared.",
+        ],
+        readiness=ServiceReadiness(
+            title="Planned for later",
+            description="This service is intentionally listed early so Settings reads as a reusable integrations hub from day one.",
+            tone="muted",
+        ),
+        planned_features=[
+            "External resume import flows",
+            "Document source organization",
+            "Future profile/document sync helpers",
+        ],
+        actions=[_coming_soon_action()],
+    )
+
+
+def _coming_soon_summary(detail: ServiceDetail, category: str, summary: str) -> ServiceSummary:
+    return ServiceSummary(
+        key=detail.key,
+        label=detail.label,
+        category=category,
+        status=detail.status,
+        connected=False,
+        availability=detail.availability,
+        summary=summary,
+        account_label=detail.account_label,
+        primary_action=_coming_soon_action(),
+        can_view_details=True,
+    )
+
+
+def list_service_summaries(user: User) -> list[ServiceSummary]:
+    calendar_detail = _calendar_detail()
+    resume_imports_detail = _resume_imports_detail()
+    return [
+        _gmail_summary(user),
+        _coming_soon_summary(
+            calendar_detail,
+            category="productivity",
+            summary="Prepare for future interview scheduling and reminder enrichment.",
+        ),
+        _coming_soon_summary(
+            resume_imports_detail,
+            category="documents",
+            summary="Bring resumes and related documents into UAH from future connected sources.",
+        ),
+    ]
+
+
+def get_service_detail(user: User, service_key: str) -> ServiceDetail:
+    normalized_key = (service_key or "").strip().lower()
+    if normalized_key == "gmail":
+        return _gmail_detail(user)
+    if normalized_key == "calendar_sync":
+        return _calendar_detail()
+    if normalized_key == "resume_imports":
+        return _resume_imports_detail()
+    raise KeyError(normalized_key)

--- a/backend/tests/test_service_connections.py
+++ b/backend/tests/test_service_connections.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from app.models.user import User
+from app.services import service_connections
+
+
+class ServiceConnectionsTests(unittest.TestCase):
+    def _make_user(self, **overrides) -> User:
+        return User(
+            id=overrides.pop("id", 1),
+            email=overrides.pop("email", "service@example.com"),
+            username=overrides.pop("username", "service@example.com"),
+            hashed_password=overrides.pop("hashed_password", "mock-hash"),
+            gmail_refresh_token=overrides.pop("gmail_refresh_token", None),
+            gmail_email=overrides.pop("gmail_email", None),
+            **overrides,
+        )
+
+    def test_gmail_summary_is_available_when_configured_and_disconnected(self):
+        user = self._make_user()
+
+        with patch.object(service_connections.settings, "GMAIL_CLIENT_ID", "client-id"), \
+             patch.object(service_connections.settings, "GMAIL_CLIENT_SECRET", "client-secret"), \
+             patch.object(service_connections.settings, "GMAIL_REDIRECT_URI", "https://beta.uahapp.com/api/integrations/gmail/callback"):
+            summaries = service_connections.list_service_summaries(user)
+
+        gmail = next(item for item in summaries if item.key == "gmail")
+        self.assertEqual(gmail.status, "available")
+        self.assertFalse(gmail.connected)
+        self.assertEqual(gmail.primary_action.key, "connect")
+        self.assertEqual(gmail.primary_action.href, "/api/integrations/gmail/connect/start")
+
+    def test_gmail_summary_is_connected_when_mailbox_is_linked(self):
+        user = self._make_user(
+            gmail_refresh_token="encrypted-refresh-token",
+            gmail_email="mailbox@example.com",
+        )
+
+        with patch.object(service_connections.settings, "GMAIL_CLIENT_ID", "client-id"), \
+             patch.object(service_connections.settings, "GMAIL_CLIENT_SECRET", "client-secret"), \
+             patch.object(service_connections.settings, "GMAIL_REDIRECT_URI", "https://beta.uahapp.com/api/integrations/gmail/callback"):
+            detail = service_connections.get_service_detail(user, "gmail")
+
+        self.assertTrue(detail.connected)
+        self.assertEqual(detail.status, "connected")
+        self.assertEqual(detail.account_label, "mailbox@example.com")
+        self.assertEqual(detail.actions[0].key, "disconnect")
+
+    def test_gmail_summary_reports_needs_attention_when_config_is_missing(self):
+        user = self._make_user()
+
+        with patch.object(service_connections.settings, "GMAIL_CLIENT_ID", ""), \
+             patch.object(service_connections.settings, "GMAIL_CLIENT_SECRET", ""), \
+             patch.object(service_connections.settings, "GMAIL_REDIRECT_URI", ""):
+            summaries = service_connections.list_service_summaries(user)
+
+        gmail = next(item for item in summaries if item.key == "gmail")
+        self.assertEqual(gmail.status, "needs_attention")
+        self.assertFalse(gmail.primary_action.enabled)
+        self.assertEqual(gmail.primary_action.key, "unavailable")
+
+    def test_placeholder_services_are_returned_as_coming_soon(self):
+        user = self._make_user()
+
+        with patch.object(service_connections.settings, "GMAIL_CLIENT_ID", "client-id"), \
+             patch.object(service_connections.settings, "GMAIL_CLIENT_SECRET", "client-secret"), \
+             patch.object(service_connections.settings, "GMAIL_REDIRECT_URI", "https://beta.uahapp.com/api/integrations/gmail/callback"):
+            summaries = service_connections.list_service_summaries(user)
+
+        calendar = next(item for item in summaries if item.key == "calendar_sync")
+        resume_imports = next(item for item in summaries if item.key == "resume_imports")
+
+        self.assertEqual(calendar.status, "coming_soon")
+        self.assertEqual(calendar.availability, "coming_soon")
+        self.assertFalse(calendar.primary_action.enabled)
+
+        self.assertEqual(resume_imports.status, "coming_soon")
+        self.assertEqual(resume_imports.availability, "coming_soon")
+        self.assertEqual(resume_imports.primary_action.label, "Coming soon")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -33,11 +33,14 @@
   --shadow-soft: 0 2px 6px rgba(15, 23, 42, 0.08);
   --shadow-card: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
   --transition-fast: 0.15s ease;
+  --app-page-background:
+    radial-gradient(circle at top right, rgba(14, 165, 233, 0.08), transparent 28%),
+    linear-gradient(180deg, #f8fafc 0%, #eef4f8 100%);
 }
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  background: var(--color-surface);
+  background: var(--app-page-background);
   color: var(--color-text-primary);
   line-height: 1.4;
 }
@@ -69,8 +72,13 @@ button:hover {
 #current-page {
   flex: 1;
   min-width: 0;
+  background: var(--app-page-background);
   overflow: auto;
   overflow-x: clip;
+}
+
+.page {
+  background: var(--app-page-background);
 }
 
 header {

--- a/frontend/src/components/ServiceDetailsModal.vue
+++ b/frontend/src/components/ServiceDetailsModal.vue
@@ -1,0 +1,444 @@
+<template>
+  <div
+    class="service-details-overlay"
+    role="dialog"
+    aria-modal="true"
+    :aria-label="service?.label || 'Service details'"
+    @click="close"
+  >
+    <div class="service-details-dialog" v-draggable-modal="{ handle: '.service-details-header' }" @click.stop>
+      <div class="service-details-header drag-handle">
+        <div class="service-details-hero">
+          <div class="service-details-chip" :class="chipClass">
+            {{ monogram }}
+          </div>
+          <div class="service-details-heading">
+            <p class="service-details-eyebrow">Service connection</p>
+            <h2>{{ service?.label || 'Loading service' }}</h2>
+            <p class="service-details-subtitle">
+              {{ service?.description || 'Preparing connection details…' }}
+            </p>
+          </div>
+        </div>
+        <button type="button" class="service-details-close" @click="close">Close</button>
+      </div>
+
+      <div class="service-details-body">
+        <div class="service-details-status-row">
+          <span class="service-details-badge" :class="badgeClass">
+            {{ statusLabel }}
+          </span>
+          <span v-if="service?.account_label" class="service-details-account">
+            {{ service.account_label }}
+          </span>
+        </div>
+
+        <p v-if="error" class="service-details-error">{{ error }}</p>
+        <p v-if="loading" class="service-details-loading">Loading service details…</p>
+
+        <template v-else-if="service">
+          <section class="service-details-section">
+            <h3>Why connect this</h3>
+            <p>{{ service.description }}</p>
+          </section>
+
+          <section class="service-details-section">
+            <h3>What UAH can use it for</h3>
+            <ul>
+              <li v-for="capability in service.capabilities || []" :key="capability">{{ capability }}</li>
+            </ul>
+          </section>
+
+          <section class="service-details-section">
+            <h3>What access is requested</h3>
+            <ul>
+              <li v-for="permission in service.permissions || []" :key="permission">{{ permission }}</li>
+            </ul>
+          </section>
+
+          <section class="service-details-section">
+            <h3>Current status</h3>
+            <p class="service-details-readiness-title">{{ service.readiness?.title || 'Service status' }}</p>
+            <p>{{ service.readiness?.description || 'No readiness details available yet.' }}</p>
+          </section>
+
+          <section v-if="(service.planned_features || []).length" class="service-details-section">
+            <h3>Planned features</h3>
+            <ul>
+              <li v-for="feature in service.planned_features || []" :key="feature">{{ feature }}</li>
+            </ul>
+          </section>
+        </template>
+      </div>
+
+      <div class="service-details-actions">
+        <button
+          v-for="action in service?.actions || []"
+          :key="`${service?.key || 'service'}-${action.key}`"
+          type="button"
+          class="service-details-action"
+          :class="`is-${action.style || 'secondary'}`"
+          :disabled="loading || !action.enabled || busyActionKey === `${service?.key || ''}:${action.key}`"
+          @click="$emit('action', action)"
+        >
+          {{ actionLabel(action) }}
+        </button>
+        <button type="button" class="service-details-action is-ghost" @click="close">Close</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+const STATUS_LABELS = {
+  connected: 'Connected',
+  available: 'Available',
+  coming_soon: 'Coming soon',
+  needs_attention: 'Needs attention',
+}
+
+const MONOGRAMS = {
+  gmail: 'GM',
+  calendar_sync: 'CS',
+  resume_imports: 'RI',
+}
+
+export default {
+  name: 'ServiceDetailsModal',
+  props: {
+    service: {
+      type: Object,
+      default: null,
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    error: {
+      type: String,
+      default: '',
+    },
+    busyActionKey: {
+      type: String,
+      default: '',
+    },
+  },
+  emits: ['close', 'action'],
+  computed: {
+    statusLabel() {
+      const status = this.service?.status || 'available'
+      return STATUS_LABELS[status] || 'Available'
+    },
+    badgeClass() {
+      const status = this.service?.status || 'available'
+      return `is-${status.replaceAll('_', '-')}`
+    },
+    chipClass() {
+      const key = String(this.service?.key || 'service').replaceAll('_', '-')
+      return `is-${key}`
+    },
+    monogram() {
+      return MONOGRAMS[this.service?.key] || 'SV'
+    },
+  },
+  mounted() {
+    this._onKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        this.close()
+      }
+    }
+    window.addEventListener('keydown', this._onKeyDown)
+  },
+  beforeUnmount() {
+    if (this._onKeyDown) {
+      window.removeEventListener('keydown', this._onKeyDown)
+    }
+  },
+  methods: {
+    close() {
+      this.$emit('close')
+    },
+    actionLabel(action) {
+      const actionKey = `${this.service?.key || ''}:${action.key}`
+      if (this.busyActionKey !== actionKey) return action.label
+      if (action.key === 'connect') return 'Connecting…'
+      if (action.key === 'disconnect') return 'Disconnecting…'
+      return 'Working…'
+    },
+  },
+}
+</script>
+
+<style scoped>
+.service-details-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10020;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.service-details-dialog {
+  width: min(760px, 96vw);
+  max-height: 88vh;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 18px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+  box-shadow: 0 26px 60px rgba(15, 23, 42, 0.24);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.service-details-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 20px 22px 16px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  cursor: grab;
+}
+
+.service-details-hero {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  min-width: 0;
+}
+
+.service-details-chip {
+  width: 54px;
+  height: 54px;
+  border-radius: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #7f1d1d;
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.18), rgba(254, 226, 226, 0.92));
+  border: 1px solid rgba(239, 68, 68, 0.18);
+  flex-shrink: 0;
+}
+
+.service-details-chip.is-calendar-sync {
+  color: #1d4ed8;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.2), rgba(219, 234, 254, 0.95));
+  border-color: rgba(59, 130, 246, 0.22);
+}
+
+.service-details-chip.is-resume-imports {
+  color: #0f766e;
+  background: linear-gradient(135deg, rgba(45, 212, 191, 0.2), rgba(204, 251, 241, 0.96));
+  border-color: rgba(13, 148, 136, 0.24);
+}
+
+.service-details-heading {
+  min-width: 0;
+}
+
+.service-details-eyebrow {
+  margin: 0 0 4px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.service-details-heading h2 {
+  margin: 0;
+  font-size: 1.28rem;
+  color: #111827;
+}
+
+.service-details-subtitle {
+  margin: 8px 0 0;
+  color: #475569;
+  line-height: 1.55;
+}
+
+.service-details-close,
+.service-details-action {
+  border: 1px solid rgba(148, 163, 184, 0.42);
+  border-radius: 10px;
+  background: #ffffff;
+  color: #1f2937;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.service-details-close {
+  padding: 10px 14px;
+}
+
+.service-details-body {
+  padding: 18px 22px;
+  overflow: auto;
+  display: grid;
+  gap: 14px;
+}
+
+.service-details-status-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.service-details-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  border: 1px solid transparent;
+}
+
+.service-details-badge.is-connected {
+  color: #166534;
+  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(22, 101, 52, 0.28);
+}
+
+.service-details-badge.is-available {
+  color: #0f172a;
+  background: rgba(148, 163, 184, 0.16);
+  border-color: rgba(100, 116, 139, 0.26);
+}
+
+.service-details-badge.is-coming-soon {
+  color: #7c2d12;
+  background: rgba(251, 191, 36, 0.16);
+  border-color: rgba(180, 83, 9, 0.26);
+}
+
+.service-details-badge.is-needs-attention {
+  color: #9a3412;
+  background: rgba(251, 146, 60, 0.16);
+  border-color: rgba(194, 65, 12, 0.25);
+}
+
+.service-details-account {
+  color: #475569;
+  font-size: 0.9rem;
+  overflow-wrap: anywhere;
+}
+
+.service-details-error,
+.service-details-loading {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(248, 250, 252, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: #334155;
+}
+
+.service-details-error {
+  border-color: rgba(239, 68, 68, 0.22);
+  color: #991b1b;
+}
+
+.service-details-section {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 14px 16px;
+}
+
+.service-details-section h3 {
+  margin: 0 0 8px;
+  font-size: 0.98rem;
+  color: #111827;
+}
+
+.service-details-section p,
+.service-details-section li {
+  color: #475569;
+  line-height: 1.55;
+}
+
+.service-details-section p {
+  margin: 0;
+}
+
+.service-details-section ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.service-details-section li + li {
+  margin-top: 8px;
+}
+
+.service-details-readiness-title {
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 6px;
+}
+
+.service-details-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 16px 22px 20px;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(248, 250, 252, 0.92);
+}
+
+.service-details-action {
+  min-width: 120px;
+  padding: 10px 14px;
+}
+
+.service-details-action:disabled {
+  opacity: 0.65;
+  cursor: default;
+}
+
+.service-details-action.is-primary {
+  background: #111827;
+  color: #ffffff;
+  border-color: #111827;
+}
+
+.service-details-action.is-secondary {
+  background: rgba(226, 232, 240, 0.7);
+}
+
+.service-details-action.is-muted,
+.service-details-action.is-ghost {
+  background: #ffffff;
+}
+
+@media (max-width: 720px) {
+  .service-details-overlay {
+    padding: 12px;
+  }
+
+  .service-details-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .service-details-hero {
+    align-items: center;
+  }
+
+  .service-details-actions {
+    justify-content: stretch;
+  }
+
+  .service-details-action,
+  .service-details-close {
+    width: 100%;
+  }
+}
+</style>

--- a/frontend/src/lib/localMockApi.js
+++ b/frontend/src/lib/localMockApi.js
@@ -339,9 +339,13 @@ function createDefaultUser(overrides = {}) {
     id: 1,
     username: defaultEmail,
     email: defaultEmail,
+    hashed_password: 'mock-password-hash',
     email_verified: true,
     is_admin: true,
     is_developer: true,
+    google_id: null,
+    gmail_refresh_token: null,
+    gmail_email: null,
     first_name: 'Local',
     last_name: 'Developer',
     phone: '',
@@ -908,6 +912,221 @@ function makeDiagnosticsPayload() {
   }
 }
 
+function mockGmailConfigured() {
+  return true
+}
+
+function buildMockConnectedAccounts(state) {
+  const googleConnected = Boolean(state.user.google_id)
+  const hasPassword = Boolean(state.user.hashed_password)
+  return {
+    providers: [
+      {
+        provider: 'google',
+        label: 'Google',
+        connected: googleConnected,
+        account_email: googleConnected ? state.user.email : null,
+        can_connect: !googleConnected,
+        can_disconnect: googleConnected && hasPassword,
+        disconnect_disabled_reason: googleConnected && !hasPassword
+          ? 'Set a password before disconnecting your only sign-in method.'
+          : null,
+        coming_soon: false,
+      },
+      {
+        provider: 'linkedin',
+        label: 'LinkedIn',
+        connected: false,
+        account_email: null,
+        can_connect: false,
+        can_disconnect: false,
+        disconnect_disabled_reason: null,
+        coming_soon: true,
+      },
+    ],
+    has_password: hasPassword,
+  }
+}
+
+function buildMockServiceAction({ key, label, enabled = true, style = 'primary', method = null, href = null }) {
+  return { key, label, enabled, style, method, href }
+}
+
+function buildMockServiceDetail(state, serviceKey) {
+  const normalized = normalizeTextLower(serviceKey)
+  const gmailConnected = Boolean(state.user.gmail_refresh_token)
+  const gmailConfigured = mockGmailConfigured()
+
+  if (normalized === 'gmail') {
+    const connected = gmailConnected
+    const status = connected ? 'connected' : (gmailConfigured ? 'available' : 'needs_attention')
+    const accountLabel = connected
+      ? (state.user.gmail_email || state.user.email)
+      : (gmailConfigured ? 'No Gmail mailbox connected yet.' : 'Gmail OAuth is not configured for this environment.')
+    return {
+      key: 'gmail',
+      label: 'Gmail Updates',
+      status,
+      connected,
+      account_label: accountLabel,
+      availability: 'available',
+      description: 'Connect Gmail so UAH can prepare for inbox-driven job update workflows and future email-based status intelligence.',
+      capabilities: [
+        'Recognize job-update emails like application receipts, interview invites, and decisions.',
+        'Enrich your future application timeline with inbox-derived signals.',
+        'Help surface job communication context without making Gmail your sign-in method.',
+      ],
+      permissions: [
+        'Read-only Gmail mailbox access via Google OAuth.',
+        'Google account email is used to label the mailbox connection in Settings.',
+        'Disconnecting removes the stored refresh token and stops future mailbox access.',
+      ],
+      readiness: connected
+        ? {
+            title: 'Ready for mailbox-powered updates',
+            description: 'UAH can use this mailbox connection for future job-update scanning, status inference, and timeline enrichment without asking you to reconnect.',
+            tone: 'positive',
+          }
+        : (gmailConfigured
+            ? {
+                title: 'Available to connect',
+                description: 'Connect Gmail when you want UAH ready for inbox-based job update features. Nothing is scanned automatically in this phase.',
+                tone: 'neutral',
+              }
+            : {
+                title: 'Needs environment setup',
+                description: 'An administrator still needs to configure Gmail OAuth credentials for this environment before users can opt in.',
+                tone: 'warning',
+              }),
+      planned_features: [
+        'Inbox-powered application status detection',
+        'Timeline enrichment from recruiter communications',
+        'Optional service-level scan controls and summaries in a later phase',
+      ],
+      actions: connected
+        ? [buildMockServiceAction({ key: 'disconnect', label: 'Disconnect', style: 'secondary', method: 'DELETE', href: '/api/integrations/gmail/disconnect' })]
+        : [gmailConfigured
+            ? buildMockServiceAction({ key: 'connect', label: 'Connect', style: 'primary', method: 'POST', href: '/api/integrations/gmail/connect/start' })
+            : buildMockServiceAction({ key: 'unavailable', label: 'Unavailable', enabled: false, style: 'muted' })],
+    }
+  }
+
+  if (normalized === 'calendar_sync') {
+    return {
+      key: 'calendar_sync',
+      label: 'Calendar Sync',
+      status: 'coming_soon',
+      connected: false,
+      account_label: 'Planned for a future release.',
+      availability: 'coming_soon',
+      description: 'Calendar Sync will help UAH coordinate interview timing, reminders, and event context when the service launches.',
+      capabilities: [
+        'Match interview invites to tracked applications.',
+        'Highlight upcoming conversations and scheduling windows.',
+        'Reduce manual copy-and-paste between recruiting emails and your calendar.',
+      ],
+      permissions: [
+        'No calendar access is requested in this release.',
+        'Any future calendar permissions will be explained clearly before opt-in.',
+      ],
+      readiness: {
+        title: 'On the roadmap',
+        description: 'This service is being designed for a future release and is not yet connectable.',
+        tone: 'muted',
+      },
+      planned_features: [
+        'Interview scheduling awareness',
+        'Reminder and event enrichment',
+        'Meeting context linked back to job applications',
+      ],
+      actions: [buildMockServiceAction({ key: 'coming_soon', label: 'Coming soon', enabled: false, style: 'muted' })],
+    }
+  }
+
+  if (normalized === 'resume_imports') {
+    return {
+      key: 'resume_imports',
+      label: 'Resume Imports',
+      status: 'coming_soon',
+      connected: false,
+      account_label: 'Planned for a future release.',
+      availability: 'coming_soon',
+      description: 'Resume Imports will make it easier to bring documents into UAH from external services without rebuilding your profile by hand.',
+      capabilities: [
+        'Import resumes and supporting documents from connected storage providers.',
+        'Keep document sources organized for future autofill workflows.',
+        'Reduce friction when refreshing resumes across multiple applications.',
+      ],
+      permissions: [
+        'No document-provider access is requested in this release.',
+        'Future providers will explain exactly which files or folders are shared.',
+      ],
+      readiness: {
+        title: 'Planned for later',
+        description: 'This service is intentionally listed early so Settings reads as a reusable integrations hub from day one.',
+        tone: 'muted',
+      },
+      planned_features: [
+        'External resume import flows',
+        'Document source organization',
+        'Future profile/document sync helpers',
+      ],
+      actions: [buildMockServiceAction({ key: 'coming_soon', label: 'Coming soon', enabled: false, style: 'muted' })],
+    }
+  }
+
+  return null
+}
+
+function listMockServiceSummaries(state) {
+  const gmailDetail = buildMockServiceDetail(state, 'gmail')
+  const calendarDetail = buildMockServiceDetail(state, 'calendar_sync')
+  const resumeImportsDetail = buildMockServiceDetail(state, 'resume_imports')
+
+  return [
+    {
+      key: gmailDetail.key,
+      label: gmailDetail.label,
+      category: 'communication',
+      status: gmailDetail.status,
+      connected: gmailDetail.connected,
+      availability: gmailDetail.availability,
+      summary: gmailDetail.connected
+        ? 'Mailbox ready for future job-update scanning and timeline enrichment.'
+        : (mockGmailConfigured()
+            ? 'Opt in to read-only inbox access so UAH can prepare for job update workflows.'
+            : 'Gmail support exists, but this environment still needs OAuth configuration before users can connect.'),
+      account_label: gmailDetail.account_label,
+      primary_action: gmailDetail.actions[0],
+      can_view_details: true,
+    },
+    {
+      key: calendarDetail.key,
+      label: calendarDetail.label,
+      category: 'productivity',
+      status: calendarDetail.status,
+      connected: false,
+      availability: calendarDetail.availability,
+      summary: 'Prepare for future interview scheduling and reminder enrichment.',
+      account_label: calendarDetail.account_label,
+      primary_action: calendarDetail.actions[0],
+      can_view_details: true,
+    },
+    {
+      key: resumeImportsDetail.key,
+      label: resumeImportsDetail.label,
+      category: 'documents',
+      status: resumeImportsDetail.status,
+      connected: false,
+      availability: resumeImportsDetail.availability,
+      summary: 'Bring resumes and related documents into UAH from future connected sources.',
+      account_label: resumeImportsDetail.account_label,
+      primary_action: resumeImportsDetail.actions[0],
+      can_view_details: true,
+    },
+  ]
+}
+
 function queryValues(params, key) {
   return params.getAll(key).map((value) => normalizeText(value)).filter(Boolean)
 }
@@ -1251,6 +1470,87 @@ async function handleMockApiRequest(request, requestUrl, state) {
 
   if (pathname === '/api/auth/me' && method === 'GET') {
     return toJsonResponse(state.user)
+  }
+
+  if (pathname === '/api/auth/connected-accounts' && method === 'GET') {
+    return toJsonResponse(buildMockConnectedAccounts(state))
+  }
+
+  if (pathname === '/api/auth/google/connect/start' && method === 'POST') {
+    state.user = {
+      ...state.user,
+      google_id: state.user.google_id || 'mock-google-account',
+    }
+    saveState(state)
+    return toJsonResponse({
+      authorization_url: `${window.location.origin}/settings?accounts=connected&provider=google`,
+    })
+  }
+
+  if (pathname === '/api/auth/google/disconnect' && method === 'DELETE') {
+    if (!state.user.google_id) {
+      return toJsonResponse({ message: 'Google account already disconnected' })
+    }
+
+    if (!state.user.hashed_password) {
+      return toJsonResponse(
+        { detail: 'Cannot disconnect Google without another sign-in method. Set a password first.' },
+        400
+      )
+    }
+
+    state.user = {
+      ...state.user,
+      google_id: null,
+    }
+    saveState(state)
+    return toJsonResponse({ message: 'Google account disconnected' })
+  }
+
+  if (pathname === '/api/integrations/services' && method === 'GET') {
+    return toJsonResponse(listMockServiceSummaries(state))
+  }
+
+  const integrationServiceMatch = pathname.match(/^\/api\/integrations\/services\/([^/]+)$/)
+  if (integrationServiceMatch && method === 'GET') {
+    const detail = buildMockServiceDetail(state, integrationServiceMatch[1])
+    if (!detail) {
+      return toJsonResponse({ detail: 'Service not found' }, 404)
+    }
+    return toJsonResponse(detail)
+  }
+
+  if (pathname === '/api/integrations/gmail/status' && method === 'GET') {
+    return toJsonResponse({
+      connected: Boolean(state.user.gmail_refresh_token),
+      email: state.user.gmail_email,
+    })
+  }
+
+  if (pathname === '/api/integrations/gmail/connect/start' && method === 'POST') {
+    if (!mockGmailConfigured()) {
+      return toJsonResponse({ detail: 'not_configured' }, 400)
+    }
+
+    state.user = {
+      ...state.user,
+      gmail_refresh_token: 'mock-gmail-refresh-token',
+      gmail_email: state.user.email,
+    }
+    saveState(state)
+    return toJsonResponse({
+      authorization_url: `${window.location.origin}/settings?service=gmail&service_state=connected`,
+    })
+  }
+
+  if (pathname === '/api/integrations/gmail/disconnect' && method === 'DELETE') {
+    state.user = {
+      ...state.user,
+      gmail_refresh_token: null,
+      gmail_email: null,
+    }
+    saveState(state)
+    return toJsonResponse({ message: 'Gmail disconnected' })
   }
 
   if (pathname === '/api/account/change-name' && method === 'PUT') {

--- a/frontend/src/views/Resumes.vue
+++ b/frontend/src/views/Resumes.vue
@@ -171,6 +171,14 @@
                             <p class="panel-eyebrow">Library</p>
                             <h3>Imported Resumes</h3>
                         </div>
+                        <button
+                            v-if="libraryHasOverflow"
+                            class="btn-secondary btn-compact"
+                            type="button"
+                            @click="showLibraryModal = true"
+                        >
+                            View All
+                        </button>
                     </div>
                 </template>
 
@@ -181,7 +189,7 @@
                 <div v-else-if="resumesError" class="upload-error">{{ resumesError }}</div>
 
                 <div v-else-if="resumes.length" class="resume-list">
-                    <div v-for="r in resumes" :key="r.id" class="resume-list-item">
+                    <div v-for="r in libraryPreviewResumes" :key="r.id" class="resume-list-item">
                         <div class="pdf-icon">PDF</div>
                         <div class="resume-meta">
                             <p class="resume-name">{{ r.file_name }}</p>
@@ -203,6 +211,15 @@
                             </button>
                         </div>
                     </div>
+                </div>
+
+                <div v-if="libraryHasOverflow" class="library-preview-footer">
+                    <p class="library-preview-note">
+                        Showing {{ libraryPreviewResumes.length }} of {{ resumes.length }} resumes.
+                    </p>
+                    <button class="btn-secondary" type="button" @click="showLibraryModal = true">
+                        Expand Library
+                    </button>
                 </div>
 
                 <div v-else class="empty-state">
@@ -957,6 +974,53 @@
             @confirm="confirmJobInfoLeave"
         />
 
+        <div v-if="showLibraryModal" class="modal-overlay" @click.self="showLibraryModal = false">
+            <div class="modal-box library-modal-box" v-draggable-modal="{ handle: '.modal-drag-header' }">
+                <div class="modal-drag-header library-modal-header">
+                    <div>
+                        <h2>Imported Resume Library</h2>
+                        <p class="subtitle">Browse all imported resumes in one place without stretching the main page layout.</p>
+                    </div>
+                    <button class="btn-secondary btn-compact" @click="showLibraryModal = false">Close</button>
+                </div>
+
+                <div v-if="resumesLoading" class="loading-row">
+                    <div class="spinner"></div> Loading resumes…
+                </div>
+
+                <div v-else-if="resumesError" class="upload-error">{{ resumesError }}</div>
+
+                <div v-else-if="resumes.length" class="resume-list resume-list--modal">
+                    <div v-for="r in resumes" :key="`modal-${r.id}`" class="resume-list-item">
+                        <div class="pdf-icon">PDF</div>
+                        <div class="resume-meta">
+                            <p class="resume-name">{{ r.file_name }}</p>
+                            <p class="resume-date">Uploaded {{ formatDate(r.created_at) }}</p>
+                        </div>
+                        <div class="resume-badges">
+                            <span :class="['badge', badgeClass(r)]">{{ badgeText(r) }}</span>
+                            <span v-if="r.parse_method" :class="['badge', 'parse-method-badge', parseMethodToneClass(r.parse_method)]">{{ parseMethodTagLabel(r.parse_method) }}</span>
+                        </div>
+                        <div class="resume-actions">
+                            <button title="View parsed data" @click="viewResume(r.id)">View</button>
+                            <button
+                                title="Delete resume"
+                                class="delete-btn"
+                                :class="{ 'confirm-delete': deletingId === r.id }"
+                                @click="handleDelete(r.id)"
+                            >
+                                {{ deletingId === r.id ? 'Confirm Delete' : 'Delete' }}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <div v-else class="empty-state">
+                    <p>No resumes yet. Import a PDF to get started.</p>
+                </div>
+            </div>
+        </div>
+
     </div><!-- /.page -->
 </template>
 
@@ -987,6 +1051,7 @@ export default {
             resumesLoading: false,
             resumesError: null,
             deletingId: null,
+            showLibraryModal: false,
 
             // Inline upload
             uploadStep: 'select',   // 'select' | 'confirm'
@@ -1126,6 +1191,12 @@ export default {
         },
         portalReadyCount() {
             return this.resumes.filter(r => r.portal_ready).length
+        },
+        libraryPreviewResumes() {
+            return this.resumes.slice(0, 3)
+        },
+        libraryHasOverflow() {
+            return this.resumes.length > 3
         },
         latestUploadDate() {
             if (!this.resumes.length) return '—'
@@ -1620,6 +1691,7 @@ export default {
 
         // ── View modal ──────────────────────────────────────
         async viewResume(id) {
+            this.showLibraryModal = false
             this._viewResumeId = id
             this.showViewModal = true
             this.viewLoading = true
@@ -1695,6 +1767,7 @@ export default {
 
         // ── Inline upload ───────────────────────────────────
         openUploadModal() {
+            this.showLibraryModal = false
             this.uploadStep = 'select'
             this.pendingFile = null
             this.parseMethod = this.isLocalParseMethodAvailable ? 'local' : 'cloud'

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -139,11 +139,11 @@
             </Card>
             <Card class="settings-card settings-card--integrations">
                 <template #header>
-                    <h3>Connected Accounts</h3>
+                    <h3>Sign-in Methods</h3>
                 </template>
                 <div class="settings-group connected-accounts-group">
                     <p class="connected-accounts-intro">
-                        Manage linked sign-in providers. This section is built to support additional providers over time.
+                        Manage linked sign-in providers separately from optional platform services like Gmail updates.
                     </p>
                     <p v-if="connectedAccountsError" class="account-error">{{ connectedAccountsError }}</p>
                     <div class="connected-accounts-list">
@@ -189,7 +189,7 @@
                         </div>
                     </div>
                     <button type="button" @click="loadConnectedAccounts" :disabled="connectedAccountsLoading || !!connectedAccountsBusyProvider">
-                        {{ connectedAccountsLoading ? 'Refreshing…' : 'Refresh connected accounts' }}
+                        {{ connectedAccountsLoading ? 'Refreshing…' : 'Refresh sign-in methods' }}
                     </button>
                 </div>
                 <div v-if="canAccessDebugTools" class="settings-group developer-tools-group">
@@ -211,6 +211,67 @@
                     <p class="connected-account-detail">This toggle is local to this browser and can be turned off later without changing your account role.</p>
                 </div>
             </Card>
+
+            <Card class="settings-card settings-card--services">
+                <template #header>
+                    <h3>Service Connections</h3>
+                </template>
+                <div class="settings-group service-connections-group">
+                    <p class="service-connections-intro">
+                        Opt in to services that help UAH organize updates, reminders, and documents.
+                    </p>
+                    <p v-if="serviceConnectionsError" class="account-error">{{ serviceConnectionsError }}</p>
+                    <div class="service-connections-list">
+                        <div
+                            v-for="service in serviceConnections"
+                            :key="service.key"
+                            class="service-connection-row"
+                            :class="[
+                                `is-${serviceClassKey(service.key)}`,
+                                { 'is-highlighted': highlightedServiceKey === service.key },
+                            ]"
+                        >
+                            <div class="service-connection-leading">
+                                <div class="service-connection-chip" :class="`is-${serviceClassKey(service.key)}`">
+                                    {{ serviceMonogram(service.key) }}
+                                </div>
+                                <div class="service-connection-meta">
+                                    <p class="service-connection-title">
+                                        {{ service.label }}
+                                        <span class="connected-account-badge service-connection-badge" :class="serviceBadgeClass(service.status)">
+                                            {{ serviceStatusLabel(service.status) }}
+                                        </span>
+                                    </p>
+                                    <p class="service-connection-summary">{{ service.summary }}</p>
+                                    <p v-if="service.account_label" class="service-connection-detail">{{ service.account_label }}</p>
+                                </div>
+                            </div>
+                            <div class="service-connection-actions">
+                                <button
+                                    type="button"
+                                    class="service-action-button"
+                                    :class="`is-${service.primary_action?.style || 'secondary'}`"
+                                    :disabled="serviceActionBusyKey === serviceBusyKey(service.key, service.primary_action?.key) || !service.primary_action?.enabled"
+                                    @click="runServiceAction(service.primary_action, service.key)"
+                                >
+                                    {{ serviceActionLabel(service.primary_action, service.key) }}
+                                </button>
+                                <button
+                                    type="button"
+                                    class="service-action-button is-ghost"
+                                    :disabled="serviceDetailsLoading && activeServiceDetails?.key === service.key"
+                                    @click="openServiceDetails(service)"
+                                >
+                                    View Details
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <button type="button" @click="loadServiceConnections" :disabled="serviceConnectionsLoading || !!serviceActionBusyKey">
+                        {{ serviceConnectionsLoading ? 'Refreshing…' : 'Refresh services' }}
+                    </button>
+                </div>
+            </Card>
         </div>
 
         <ConfirmModal
@@ -223,6 +284,16 @@
             @cancel="confirmDeleteOpen = false"
             @confirm="confirmDeleteAccount"
         />
+
+        <ServiceDetailsModal
+            v-if="serviceDetailsOpen"
+            :service="activeServiceDetails"
+            :loading="serviceDetailsLoading"
+            :error="serviceDetailsError"
+            :busyActionKey="serviceActionBusyKey"
+            @close="closeServiceDetails"
+            @action="runServiceAction($event, activeServiceDetails?.key)"
+        />
     </div>
 
 </template>
@@ -231,10 +302,24 @@
 import Card from "../components/Card.vue";
 import ConfirmModal from "../components/ConfirmModal.vue";
 import SecretInput from "../components/SecretInput.vue";
+import ServiceDetailsModal from "../components/ServiceDetailsModal.vue";
 import { authedFetch, clearAuth, getCurrentUser, setCurrentUser, syncCurrentUser } from "../lib/auth.js";
 import { setDebugToolsPreference, subscribeDebugTools } from "../lib/debugTools.js";
 import { assertValidEmail } from "../lib/validation.js";
 import { showToast } from '@/services/toastService.js';
+
+const SERVICE_STATUS_LABELS = {
+    connected: 'Connected',
+    available: 'Available',
+    coming_soon: 'Coming soon',
+    needs_attention: 'Needs attention',
+}
+
+const SERVICE_MONOGRAMS = {
+    gmail: 'GM',
+    calendar_sync: 'CS',
+    resume_imports: 'RI',
+}
 
 export default {
   name: "Settings",
@@ -242,6 +327,7 @@ export default {
         Card,
         ConfirmModal,
         SecretInput,
+        ServiceDetailsModal,
     },
     data() {
         return {
@@ -259,6 +345,7 @@ export default {
                 deleteAccount: { state: 'idle', message: '' },
             },
             _actionTimers: {},
+            _serviceHighlightTimer: null,
 
             changeEmailNew: '',
             changeEmailNewConfirm: '',
@@ -276,6 +363,16 @@ export default {
             connectedAccountsError: '',
             connectedAccountsBusyProvider: '',
 
+            serviceConnections: [],
+            serviceConnectionsLoading: false,
+            serviceConnectionsError: '',
+            serviceActionBusyKey: '',
+            serviceDetailsOpen: false,
+            serviceDetailsLoading: false,
+            serviceDetailsError: '',
+            activeServiceDetails: null,
+            highlightedServiceKey: '',
+
             emailNotifications: 'yes',
             reminderNotifications: 'yes',
             applicationStatusUpdates: 'yes',
@@ -287,11 +384,14 @@ export default {
             debugToolsUnsubscribe: null,
         }
     },
-    computed: {},
     async mounted() {
         await this.loadUser()
-        await this.loadConnectedAccounts()
+        await Promise.all([
+            this.loadConnectedAccounts(),
+            this.loadServiceConnections(),
+        ])
         this.handleConnectedAccountRedirectState()
+        this.handleServiceRedirectState()
         this.debugToolsUnsubscribe = subscribeDebugTools((state) => {
             this.canAccessDebugTools = state.canAccessDebugTools === true
             this.showDebugTools = state.showDebugTools === true
@@ -300,6 +400,13 @@ export default {
     beforeUnmount() {
         if (typeof this.debugToolsUnsubscribe === 'function') {
             this.debugToolsUnsubscribe()
+        }
+        Object.values(this._actionTimers).forEach((timer) => {
+            if (timer) clearTimeout(timer)
+        })
+        if (this._serviceHighlightTimer) {
+            clearTimeout(this._serviceHighlightTimer)
+            this._serviceHighlightTimer = null
         }
     },
     methods: {
@@ -357,6 +464,44 @@ export default {
                 this.$router.replace('/home')
             }
         },
+        serviceClassKey(key) {
+            return String(key || 'service').trim().toLowerCase().replaceAll('_', '-')
+        },
+        serviceMonogram(key) {
+            return SERVICE_MONOGRAMS[key] || 'SV'
+        },
+        serviceStatusLabel(status) {
+            return SERVICE_STATUS_LABELS[status] || 'Available'
+        },
+        serviceBadgeClass(status) {
+            if (status === 'connected') return 'is-connected'
+            if (status === 'coming_soon') return 'is-coming-soon'
+            if (status === 'needs_attention') return 'is-needs-attention'
+            return 'is-available'
+        },
+        serviceBusyKey(serviceKey, actionKey) {
+            return `${serviceKey || ''}:${actionKey || ''}`
+        },
+        serviceActionLabel(action, serviceKey) {
+            if (!action) return 'Unavailable'
+            const busyKey = this.serviceBusyKey(serviceKey, action.key)
+            if (this.serviceActionBusyKey !== busyKey) return action.label
+            if (action.key === 'connect') return 'Connecting…'
+            if (action.key === 'disconnect') return 'Disconnecting…'
+            return 'Working…'
+        },
+        setServiceHighlight(serviceKey) {
+            this.highlightedServiceKey = serviceKey || ''
+            if (this._serviceHighlightTimer) {
+                clearTimeout(this._serviceHighlightTimer)
+                this._serviceHighlightTimer = null
+            }
+            if (!serviceKey) return
+            this._serviceHighlightTimer = setTimeout(() => {
+                this.highlightedServiceKey = ''
+                this._serviceHighlightTimer = null
+            }, 4200)
+        },
         handleConnectedAccountRedirectState() {
             const accountsState = typeof this.$route?.query?.accounts === 'string' ? this.$route.query.accounts : ''
             const provider = typeof this.$route?.query?.provider === 'string' ? this.$route.query.provider : ''
@@ -377,6 +522,33 @@ export default {
             delete nextQuery.reason
             this.$router.replace({ path: this.$route.path, query: nextQuery })
         },
+        handleServiceRedirectState() {
+            const serviceKey = typeof this.$route?.query?.service === 'string' ? this.$route.query.service : ''
+            const serviceState = typeof this.$route?.query?.service_state === 'string' ? this.$route.query.service_state : ''
+            const reason = typeof this.$route?.query?.service_reason === 'string' ? this.$route.query.service_reason : ''
+
+            if (!serviceKey || !serviceState) return
+
+            const serviceSummary = this.serviceConnections.find((item) => item.key === serviceKey)
+            const serviceLabel = serviceSummary?.label || 'Service'
+
+            if (serviceState === 'connected') {
+                showToast(`${serviceLabel} connected`, 'success')
+            } else if (serviceState === 'disconnected') {
+                showToast(`${serviceLabel} disconnected`, 'success')
+            } else if (serviceState === 'error') {
+                const detail = reason ? ` (${reason.replaceAll('_', ' ')})` : ''
+                showToast(`Could not update ${serviceLabel}${detail}`, 'error')
+            }
+
+            this.setServiceHighlight(serviceKey)
+
+            const nextQuery = { ...this.$route.query }
+            delete nextQuery.service
+            delete nextQuery.service_state
+            delete nextQuery.service_reason
+            this.$router.replace({ path: this.$route.path, query: nextQuery })
+        },
         async loadConnectedAccounts() {
             this.connectedAccountsLoading = true
             this.connectedAccountsError = ''
@@ -393,6 +565,24 @@ export default {
                 this.connectedAccountsError = this.formatFailure('Load connected accounts', e)
             } finally {
                 this.connectedAccountsLoading = false
+            }
+        },
+        async loadServiceConnections() {
+            this.serviceConnectionsLoading = true
+            this.serviceConnectionsError = ''
+            try {
+                const res = await authedFetch('/api/integrations/services')
+                const data = await res.json().catch(() => null)
+                if (!res.ok) throw new Error(data?.detail || `HTTP ${res.status}`)
+                this.serviceConnections = Array.isArray(data) ? data : []
+            } catch (e) {
+                if (e.message === 'Session expired' || e.message === 'Not authenticated') {
+                    this.$router.push('/login')
+                    return
+                }
+                this.serviceConnectionsError = this.formatFailure('Load services', e)
+            } finally {
+                this.serviceConnectionsLoading = false
             }
         },
         async connectProvider(provider) {
@@ -435,6 +625,108 @@ export default {
                 showToast(msg, 'error')
             } finally {
                 this.connectedAccountsBusyProvider = ''
+            }
+        },
+        primeServiceDetails(service) {
+            if (!service) {
+                this.activeServiceDetails = null
+                return
+            }
+            this.activeServiceDetails = {
+                key: service.key,
+                label: service.label,
+                status: service.status,
+                connected: service.connected,
+                account_label: service.account_label,
+                availability: service.availability,
+                description: service.summary,
+                capabilities: [],
+                permissions: [],
+                readiness: {
+                    title: 'Loading details…',
+                    description: 'Fetching service details for this connection.',
+                    tone: 'neutral',
+                },
+                planned_features: [],
+                actions: service.primary_action ? [service.primary_action] : [],
+            }
+        },
+        async openServiceDetails(service) {
+            this.serviceDetailsOpen = true
+            this.serviceDetailsError = ''
+            this.primeServiceDetails(service)
+            await this.loadServiceDetails(service?.key)
+        },
+        closeServiceDetails() {
+            this.serviceDetailsOpen = false
+            this.serviceDetailsLoading = false
+            this.serviceDetailsError = ''
+            this.activeServiceDetails = null
+        },
+        async loadServiceDetails(serviceKey) {
+            if (!serviceKey) return
+
+            this.serviceDetailsLoading = true
+            this.serviceDetailsError = ''
+            try {
+                const res = await authedFetch(`/api/integrations/services/${serviceKey}`)
+                const data = await res.json().catch(() => null)
+                if (!res.ok) throw new Error(data?.detail || `HTTP ${res.status}`)
+                this.activeServiceDetails = data
+            } catch (e) {
+                if (e.message === 'Session expired' || e.message === 'Not authenticated') {
+                    this.$router.push('/login')
+                    return
+                }
+                this.serviceDetailsError = this.formatFailure('Load service details', e)
+            } finally {
+                this.serviceDetailsLoading = false
+            }
+        },
+        async runServiceAction(action, serviceKey) {
+            if (!action || !serviceKey || !action.enabled || !action.href) return
+
+            const busyKey = this.serviceBusyKey(serviceKey, action.key)
+            this.serviceActionBusyKey = busyKey
+            this.serviceConnectionsError = ''
+            if (this.activeServiceDetails?.key === serviceKey) {
+                this.serviceDetailsError = ''
+            }
+
+            try {
+                const res = await authedFetch(action.href, {
+                    method: action.method || 'POST',
+                })
+                const data = await res.json().catch(() => null)
+                if (!res.ok) throw new Error(data?.detail || `HTTP ${res.status}`)
+
+                if (action.key === 'connect') {
+                    if (!data?.authorization_url) {
+                        throw new Error('Missing authorization URL')
+                    }
+                    window.location.assign(data.authorization_url)
+                    return
+                }
+
+                const label = this.activeServiceDetails?.label || this.serviceConnections.find((item) => item.key === serviceKey)?.label || 'Service'
+                showToast(data?.message || `${label} updated`, 'success')
+                await Promise.all([
+                    this.loadServiceConnections(),
+                    this.loadUser(),
+                ])
+                if (this.activeServiceDetails?.key === serviceKey) {
+                    await this.loadServiceDetails(serviceKey)
+                }
+                this.setServiceHighlight(serviceKey)
+            } catch (e) {
+                const msg = this.formatFailure(`${action.label} service`, e)
+                if (this.activeServiceDetails?.key === serviceKey) {
+                    this.serviceDetailsError = msg
+                }
+                this.serviceConnectionsError = msg
+                showToast(msg, 'error')
+            } finally {
+                this.serviceActionBusyKey = ''
             }
         },
         async loadUser() {

--- a/frontend/src/views/css/Home.css
+++ b/frontend/src/views/css/Home.css
@@ -10,7 +10,7 @@
 }
 
 .dashboard {
-  background-color: rgba(248, 250, 252);
+  background: transparent;
   flex: 1;
   padding: 20px;
   display: grid;

--- a/frontend/src/views/css/Job-board.css
+++ b/frontend/src/views/css/Job-board.css
@@ -2,9 +2,7 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  background:
-    radial-gradient(circle at top right, rgba(14, 165, 233, 0.08), transparent 28%),
-    linear-gradient(180deg, #f8fafc 0%, #eef4f8 100%);
+  background: var(--app-page-background);
 }
 
 .greeting {

--- a/frontend/src/views/css/Login.css
+++ b/frontend/src/views/css/Login.css
@@ -6,7 +6,7 @@
 
 .page {
   min-height: 100vh;
-  background-color: var(--color-surface-muted);
+  background: var(--app-page-background);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/views/css/Notifications.css
+++ b/frontend/src/views/css/Notifications.css
@@ -10,7 +10,7 @@
 }
 
 .dashboard {
-  background-color: rgba(248, 250, 252);
+  background: transparent;
   flex: 1;
   padding: 20px;
   display: grid;

--- a/frontend/src/views/css/Resumes.css
+++ b/frontend/src/views/css/Resumes.css
@@ -7,9 +7,7 @@
 
 /* Facelift overrides */
 .page.resumes-page {
-  background:
-    radial-gradient(circle at top right, rgba(14, 165, 233, 0.08), transparent 28%),
-    linear-gradient(180deg, #f8fafc 0%, #eef4f8 100%);
+  background: var(--app-page-background);
 }
 
 .resumes-page .resume-hero {
@@ -484,7 +482,7 @@
 
 /* ── Dashboard grid ──────────────────────────────────────── */
 .dashboard {
-  background-color: rgba(248, 250, 252);
+  background: transparent;
   flex: 1;
   padding: 24px;
   display: flex;
@@ -2351,6 +2349,21 @@
   grid-area: library;
 }
 
+.resumes-page .library-preview-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px 14px;
+  padding-top: 4px;
+}
+
+.resumes-page .library-preview-note {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
 .resumes-page .dashboard--imported .resume-card--stats {
   grid-area: stats;
 }
@@ -2661,6 +2674,21 @@
   white-space: nowrap;
 }
 
+.resumes-page .library-modal-box {
+  max-width: min(980px, 94vw);
+}
+
+.resumes-page .library-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.resumes-page .resume-list--modal {
+  gap: 12px;
+}
+
 .resumes-page .pipeline-cards {
   grid-template-columns: 1fr;
 }
@@ -2685,6 +2713,10 @@
     min-width: 152px;
     padding-inline: 12px;
     font-size: 0.84rem;
+  }
+
+  .resumes-page .library-modal-header {
+    flex-direction: column;
   }
 
   .resumes-page .resume-list-item {
@@ -2790,6 +2822,11 @@
   .resumes-page .inline-actions button {
     width: 100%;
     justify-content: center;
+  }
+
+  .resumes-page .library-preview-footer {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .resumes-page .resume-card--queue .panel-header--stacked,

--- a/frontend/src/views/css/Settings.css
+++ b/frontend/src/views/css/Settings.css
@@ -18,7 +18,7 @@
 }
 
 .dashboard {
-  background-color: rgba(248, 250, 252);
+  background: transparent;
   flex: 1;
   padding: clamp(14px, 2vw, 24px);
   display: grid;
@@ -315,6 +315,18 @@
   border-color: rgba(180, 83, 9, 0.26);
 }
 
+.connected-account-badge.is-available {
+  color: #0f172a;
+  background: rgba(148, 163, 184, 0.16);
+  border-color: rgba(100, 116, 139, 0.25);
+}
+
+.connected-account-badge.is-needs-attention {
+  color: #9a3412;
+  background: rgba(251, 146, 60, 0.16);
+  border-color: rgba(194, 65, 12, 0.25);
+}
+
 .connected-account-detail {
   margin: 0;
   font-size: 0.88rem;
@@ -375,6 +387,181 @@
   transform: scale(1.1);
 }
 
+.service-connections-group {
+  width: 100%;
+}
+
+.service-connections-intro {
+  font-weight: 500;
+  color: #4b5563;
+}
+
+.service-connections-list {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+
+.service-connection-row {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 18px;
+  padding: 16px 18px;
+  border-radius: 16px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background:
+    radial-gradient(circle at top right, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0) 38%),
+    rgba(255, 255, 255, 0.82);
+  box-sizing: border-box;
+  min-width: 0;
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.service-connection-row.is-highlighted {
+  border-color: rgba(15, 23, 42, 0.28);
+  box-shadow: 0 14px 26px rgba(15, 23, 42, 0.08);
+  transform: translateY(-1px);
+}
+
+.service-connection-row.is-gmail {
+  background:
+    radial-gradient(circle at top right, rgba(254, 242, 242, 0.94), rgba(255, 255, 255, 0) 42%),
+    rgba(255, 255, 255, 0.82);
+}
+
+.service-connection-row.is-calendar-sync {
+  background:
+    radial-gradient(circle at top right, rgba(239, 246, 255, 0.96), rgba(255, 255, 255, 0) 42%),
+    rgba(255, 255, 255, 0.82);
+}
+
+.service-connection-row.is-resume-imports {
+  background:
+    radial-gradient(circle at top right, rgba(240, 253, 250, 0.96), rgba(255, 255, 255, 0) 42%),
+    rgba(255, 255, 255, 0.82);
+}
+
+.service-connection-leading {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  min-width: 0;
+  flex: 1;
+}
+
+.service-connection-chip {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 0.84rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #7f1d1d;
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.18), rgba(254, 226, 226, 0.92));
+  border: 1px solid rgba(239, 68, 68, 0.18);
+}
+
+.service-connection-chip.is-calendar-sync {
+  color: #1d4ed8;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.2), rgba(219, 234, 254, 0.95));
+  border-color: rgba(59, 130, 246, 0.22);
+}
+
+.service-connection-chip.is-resume-imports {
+  color: #0f766e;
+  background: linear-gradient(135deg, rgba(45, 212, 191, 0.2), rgba(204, 251, 241, 0.96));
+  border-color: rgba(13, 148, 136, 0.24);
+}
+
+.service-connection-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.service-connection-title {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0;
+  font-weight: 700;
+  line-height: 1.3;
+  color: #111827;
+}
+
+.service-connection-summary,
+.service-connection-detail {
+  margin: 0;
+  color: #475569;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.service-connection-summary {
+  font-size: 0.94rem;
+}
+
+.service-connection-detail {
+  font-size: 0.88rem;
+}
+
+.service-connection-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: 240px;
+  flex-wrap: wrap;
+}
+
+.service-action-button {
+  width: auto;
+  min-width: 120px;
+  min-height: 40px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.38);
+  background: #ffffff;
+  color: #1f2937;
+  font-weight: 600;
+}
+
+.service-action-button.is-primary {
+  background: #111827;
+  color: #ffffff;
+  border-color: #111827;
+}
+
+.service-action-button.is-secondary {
+  background: rgba(226, 232, 240, 0.72);
+}
+
+.service-action-button.is-muted,
+.service-action-button.is-ghost {
+  background: #ffffff;
+}
+
+.service-action-button:disabled {
+  opacity: 0.65;
+  cursor: default;
+}
+
+@media (min-width: 1080px) {
+  .settings-card--services {
+    grid-column: 1 / -1;
+  }
+}
+
 @media (max-width: 700px) {
   .greeting {
     padding: 12px 14px;
@@ -410,5 +597,24 @@
     width: 100%;
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .service-connection-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .service-connection-leading {
+    width: 100%;
+  }
+
+  .service-connection-actions {
+    width: 100%;
+    min-width: 0;
+    justify-content: flex-start;
+  }
+
+  .service-action-button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
Introduce a reusable integrations subsystem across backend and frontend. Backend: add integrations API router and service_connections service (with schemas) to represent Gmail, calendar_sync, and resume_imports; refactor gmail oauth flow to extract start/callback logic, clearer session handling, dedicated POST /connect/start, improved error redirects to Settings, and register the integrations router in main.py. Add unit tests for service_connections. Frontend: add ServiceDetailsModal component, surface Service Connections in Settings, extend localMockApi with integrations endpoints and Gmail/google connect/disconnect mocks, update App CSS background, and add a resume library modal and preview controls in Resumes.vue. These changes provide a consistent integrations UI and mock endpoints for local development and testing.
