### PR TITLE
Add contact helpers and resume UI improvements

### DIFF
--- a/backend/app/core/validation.py
+++ b/backend/app/core/validation.py
@@ -3,6 +3,30 @@ import re
 
 EMAIL_PATTERN = re.compile(r"^[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,63}$", re.IGNORECASE)
 PHONE_ALLOWED_PATTERN = re.compile(r"^[0-9+\-().\s]+$")
+PHONE_COUNTRY_CODES = (
+    {"prefix": "1", "code": "US", "label": "United States"},
+    {"prefix": "44", "code": "GB", "label": "United Kingdom"},
+    {"prefix": "49", "code": "DE", "label": "Germany"},
+    {"prefix": "61", "code": "AU", "label": "Australia"},
+    {"prefix": "81", "code": "JP", "label": "Japan"},
+    {"prefix": "91", "code": "IN", "label": "India"},
+)
+
+
+def _phone_parts(value: str | None) -> tuple[str, bool]:
+    raw = str(value or "").strip()
+    if not raw:
+        return "", False
+
+    if not PHONE_ALLOWED_PATTERN.match(raw):
+        raise ValueError("Please enter a valid phone number")
+
+    has_plus = raw.startswith("+")
+    digits = re.sub(r"\D", "", raw)
+    if len(digits) < 7 or len(digits) > 15:
+        raise ValueError("Please enter a valid phone number")
+
+    return digits, has_plus
 
 
 def normalize_email(value: str | None) -> str:
@@ -22,17 +46,9 @@ def normalize_phone(value: str | None) -> str | None:
     if value is None:
         return None
 
-    raw = str(value).strip()
-    if not raw:
+    digits, has_plus = _phone_parts(value)
+    if not digits:
         return None
-
-    if not PHONE_ALLOWED_PATTERN.match(raw):
-        raise ValueError("Please enter a valid phone number")
-
-    has_plus = raw.lstrip().startswith("+")
-    digits = re.sub(r"\D", "", raw)
-    if len(digits) < 7 or len(digits) > 15:
-        raise ValueError("Please enter a valid phone number")
 
     if not has_plus:
         if len(digits) == 10:
@@ -43,3 +59,51 @@ def normalize_phone(value: str | None) -> str | None:
     if has_plus:
         return f"+{digits}"
     return digits
+
+
+def build_mailto_href(value: str | None) -> str:
+    normalized = normalize_email(value)
+    if not normalized or not EMAIL_PATTERN.match(normalized):
+        return ""
+    return f"mailto:{normalized}"
+
+
+def build_phone_href(value: str | None) -> str:
+    try:
+        normalized = normalize_phone(value)
+    except ValueError:
+        return ""
+
+    if not normalized:
+        return ""
+
+    if normalized.startswith("+"):
+        return f"tel:{normalized}"
+
+    digits = re.sub(r"\D", "", normalized)
+    if len(digits) == 10:
+        return f"tel:+1{digits}"
+    if len(digits) == 11 and digits.startswith("1"):
+        return f"tel:+{digits}"
+    return f"tel:{digits}"
+
+
+def infer_phone_country(value: str | None) -> dict[str, str] | None:
+    try:
+        digits, has_plus = _phone_parts(value)
+    except ValueError:
+        return None
+
+    if not digits:
+        return None
+
+    if not has_plus:
+        if len(digits) == 10 or (len(digits) == 11 and digits.startswith("1")):
+            return {"code": "US", "label": "United States"}
+        return None
+
+    for candidate in PHONE_COUNTRY_CODES:
+        if digits.startswith(candidate["prefix"]):
+            return {"code": candidate["code"], "label": candidate["label"]}
+
+    return None

--- a/backend/tests/test_validation_helpers.py
+++ b/backend/tests/test_validation_helpers.py
@@ -1,0 +1,68 @@
+import unittest
+
+from app.core.validation import (
+    build_mailto_href,
+    build_phone_href,
+    infer_phone_country,
+    normalize_phone,
+    require_valid_email,
+)
+
+
+class ValidationHelperTests(unittest.TestCase):
+    def test_require_valid_email_accepts_plus_and_subdomain(self):
+        self.assertEqual(
+            require_valid_email("  Jane.Doe+alerts@sub.example.co.uk  "),
+            "jane.doe+alerts@sub.example.co.uk",
+        )
+
+    def test_require_valid_email_rejects_bad_domain(self):
+        with self.assertRaises(ValueError):
+            require_valid_email("person@example")
+
+    def test_normalize_phone_formats_us_ten_digit_number(self):
+        self.assertEqual(normalize_phone("2565550199"), "(256) 555-0199")
+
+    def test_normalize_phone_formats_us_eleven_digit_number(self):
+        self.assertEqual(normalize_phone("1 (256) 555-0199"), "(256) 555-0199")
+
+    def test_normalize_phone_accepts_international_plus_number(self):
+        self.assertEqual(normalize_phone("+44 20 7946 0958"), "+442079460958")
+
+    def test_normalize_phone_rejects_letters(self):
+        with self.assertRaises(ValueError):
+            normalize_phone("555-CALLNOW")
+
+    def test_normalize_phone_rejects_too_few_digits(self):
+        with self.assertRaises(ValueError):
+            normalize_phone("12345")
+
+    def test_normalize_phone_rejects_too_many_digits(self):
+        with self.assertRaises(ValueError):
+            normalize_phone("+1234567890123456")
+
+    def test_build_mailto_href_returns_empty_for_invalid_value(self):
+        self.assertEqual(build_mailto_href("not-an-email"), "")
+
+    def test_build_phone_href_formats_us_and_international_numbers(self):
+        self.assertEqual(build_phone_href("(256) 555-0199"), "tel:+12565550199")
+        self.assertEqual(build_phone_href("+91 98765 43210"), "tel:+919876543210")
+
+    def test_infer_phone_country_uses_us_domestic_default(self):
+        self.assertEqual(
+            infer_phone_country("(256) 555-0199"),
+            {"code": "US", "label": "United States"},
+        )
+
+    def test_infer_phone_country_recognizes_explicit_country_code(self):
+        self.assertEqual(
+            infer_phone_country("+44 20 7946 0958"),
+            {"code": "GB", "label": "United Kingdom"},
+        )
+
+    def test_infer_phone_country_hides_unknown_international_code(self):
+        self.assertIsNone(infer_phone_country("+999123456789"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -1,6 +1,7 @@
 <template>
     <footer class="footer">
         <p>&copy; 2026 UAH. All rights reserved.</p>
+        <p class="footer-credit">Icons credited to Nicholas Johnson.</p>
     <nav>
         <router-link to="/status">Status</router-link>
         <button v-if="showDebugTools" type="button" class="footer-link-button footer-link-button-dev" @click="$emit('open-debug-view')">Debug Tools · Dev only</button>

--- a/frontend/src/components/css/Footer.css
+++ b/frontend/src/components/css/Footer.css
@@ -15,6 +15,11 @@
     margin: 0;
 }
 
+.footer-credit {
+    color: var(--color-text-muted);
+    font-size: 0.88rem;
+}
+
 .footer nav {
     display: flex;
     flex-wrap: wrap;

--- a/frontend/src/lib/localMockApi.js
+++ b/frontend/src/lib/localMockApi.js
@@ -1,4 +1,5 @@
 import { getAccessToken, getCurrentUser, setAuth } from './auth.js'
+import { assertValidEmail, normalizePhone } from './validation.js'
 
 const MOCK_STATE_KEY = 'uah_mock_state_v1'
 
@@ -1354,6 +1355,22 @@ async function parseJsonBody(request) {
   }
 }
 
+function normalizeProfileContactPayload(body = {}) {
+  const next = { ...body }
+
+  if (Object.prototype.hasOwnProperty.call(next, 'email')) {
+    const rawEmail = typeof next.email === 'string' ? next.email.trim() : next.email
+    next.email = rawEmail ? assertValidEmail(rawEmail) : ''
+  }
+
+  if (Object.prototype.hasOwnProperty.call(next, 'phone')) {
+    const rawPhone = typeof next.phone === 'string' ? next.phone.trim() : next.phone
+    next.phone = rawPhone ? normalizePhone(rawPhone) : ''
+  }
+
+  return next
+}
+
 async function handleMockApiRequest(request, requestUrl, state) {
   const method = coerceMethod(request.method)
   const pathname = requestUrl.pathname
@@ -1577,7 +1594,13 @@ async function handleMockApiRequest(request, requestUrl, state) {
 
   if (pathname === '/api/account/change-email' && method === 'PUT') {
     const body = await parseJsonBody(request)
-    const nextEmail = normalizeTextLower(body.new_email)
+    let nextEmail = ''
+
+    try {
+      nextEmail = assertValidEmail(body.new_email, 'new email')
+    } catch (error) {
+      return toJsonResponse({ detail: error?.message || 'Please enter a valid email address' }, 400)
+    }
 
     if (!nextEmail) {
       return toJsonResponse({ detail: 'new_email is required' }, 400)
@@ -1774,7 +1797,12 @@ async function handleMockApiRequest(request, requestUrl, state) {
   }
 
   if ((pathname === '/api/applicant-profile/' || pathname === '/api/applicant-profile') && method === 'POST') {
-    const body = await parseJsonBody(request)
+    let body = await parseJsonBody(request)
+    try {
+      body = normalizeProfileContactPayload(body)
+    } catch (error) {
+      return toJsonResponse({ detail: error?.message || 'Please enter valid contact details' }, 400)
+    }
     const id = state.nextIds.profile
     state.nextIds.profile += 1
 
@@ -1815,7 +1843,12 @@ async function handleMockApiRequest(request, requestUrl, state) {
       return toJsonResponse({ detail: 'Profile not found' }, 404)
     }
 
-    const body = await parseJsonBody(request)
+    let body = await parseJsonBody(request)
+    try {
+      body = normalizeProfileContactPayload(body)
+    } catch (error) {
+      return toJsonResponse({ detail: error?.message || 'Please enter valid contact details' }, 400)
+    }
     state.profiles[profileIndex] = {
       ...state.profiles[profileIndex],
       ...body,

--- a/frontend/src/lib/validation.js
+++ b/frontend/src/lib/validation.js
@@ -1,5 +1,32 @@
 const EMAIL_PATTERN = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,63}$/i
 const PHONE_ALLOWED_PATTERN = /^[0-9+\-().\s]+$/
+const PHONE_COUNTRY_CODES = [
+  { prefix: '1', code: 'US', label: 'United States' },
+  { prefix: '44', code: 'GB', label: 'United Kingdom' },
+  { prefix: '49', code: 'DE', label: 'Germany' },
+  { prefix: '61', code: 'AU', label: 'Australia' },
+  { prefix: '81', code: 'JP', label: 'Japan' },
+  { prefix: '91', code: 'IN', label: 'India' },
+]
+
+function getPhoneParts(value) {
+  const raw = String(value || '').trim()
+  if (!raw) {
+    return { raw: '', digits: '', hasPlus: false }
+  }
+
+  if (!PHONE_ALLOWED_PATTERN.test(raw)) {
+    throw new Error('Please enter a valid phone number')
+  }
+
+  const hasPlus = raw.startsWith('+')
+  const digits = raw.replace(/\D/g, '')
+  if (digits.length < 7 || digits.length > 15) {
+    throw new Error('Please enter a valid phone number')
+  }
+
+  return { raw, digits, hasPlus }
+}
 
 export function normalizeEmail(value) {
   return String(value || '').trim().toLowerCase()
@@ -22,18 +49,8 @@ export function assertValidEmail(value, label = 'email') {
 }
 
 export function normalizePhone(value) {
-  const raw = String(value || '').trim()
-  if (!raw) return ''
-
-  if (!PHONE_ALLOWED_PATTERN.test(raw)) {
-    throw new Error('Please enter a valid phone number')
-  }
-
-  const hasPlus = raw.startsWith('+')
-  const digits = raw.replace(/\D/g, '')
-  if (digits.length < 7 || digits.length > 15) {
-    throw new Error('Please enter a valid phone number')
-  }
+  const { digits, hasPlus } = getPhoneParts(value)
+  if (!digits) return ''
 
   if (!hasPlus) {
     if (digits.length === 10) {
@@ -46,4 +63,59 @@ export function normalizePhone(value) {
 
   if (hasPlus) return `+${digits}`
   return digits
+}
+
+export function buildMailtoHref(value) {
+  const normalized = normalizeEmail(value)
+  if (!normalized || !isValidEmail(normalized)) return ''
+  return `mailto:${normalized}`
+}
+
+export function buildPhoneHref(value) {
+  try {
+    const normalized = normalizePhone(value)
+    if (!normalized) return ''
+
+    if (normalized.startsWith('+')) {
+      return `tel:${normalized}`
+    }
+
+    const digits = normalized.replace(/\D/g, '')
+    if (digits.length === 10) {
+      return `tel:+1${digits}`
+    }
+    if (digits.length === 11 && digits.startsWith('1')) {
+      return `tel:+${digits}`
+    }
+    return `tel:${digits}`
+  } catch {
+    return ''
+  }
+}
+
+export function inferPhoneCountry(value) {
+  try {
+    const { digits, hasPlus } = getPhoneParts(value)
+    if (!digits) return null
+
+    if (!hasPlus) {
+      if (digits.length === 10 || (digits.length === 11 && digits.startsWith('1'))) {
+        return { code: 'US', label: 'United States' }
+      }
+      return null
+    }
+
+    for (const candidate of PHONE_COUNTRY_CODES) {
+      if (digits.startsWith(candidate.prefix)) {
+        return {
+          code: candidate.code,
+          label: candidate.label,
+        }
+      }
+    }
+
+    return null
+  } catch {
+    return null
+  }
 }

--- a/frontend/src/views/Applicant-Information.vue
+++ b/frontend/src/views/Applicant-Information.vue
@@ -15,9 +15,9 @@
                     <p>Last Name</p>
                     <input id="applicant-last-name" type="text" name="last_name" autocomplete="off" v-model="lastName">
                     <p>Email</p>
-                    <input id="applicant-email" type="email" name="email" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="currentUser.email">
+                    <input id="applicant-email" type="email" name="email" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="currentUser.email" @blur="normalizeContactField('email')">
                     <p>Phone</p>
-                    <input id="applicant-phone" type="tel" name="phone" autocomplete="off" v-model="currentUser.phone">
+                    <input id="applicant-phone" type="tel" name="phone" autocomplete="off" v-model="currentUser.phone" @blur="normalizeContactField('phone')">
                     <p>LinkedIN URL</p>
                     <input id="applicant-linkedin-url" type="url" name="linkedin_url" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" v-model="currentUser.linkedin">
                     <p>Portfolio/Website</p>
@@ -138,6 +138,7 @@
 import Card from "../components/Card.vue";
 import ConfirmModal from "../components/ConfirmModal.vue";
 import { authedFetch, clearAuth, getCurrentUser, setCurrentUser, syncCurrentUser } from "../lib/auth.js";
+import { assertValidEmail, normalizePhone } from "../lib/validation.js";
 
 export default {
   name: "ApplicantInformation",
@@ -223,6 +224,21 @@ export default {
             if (!msg) return `${label} failed`
             if (msg.startsWith('HTTP ')) return `${label} failed (${msg})`
             return `${label} failed: ${msg}`
+        },
+        normalizeContactField(fieldKey) {
+            if (!this.currentUser) return
+
+            try {
+                if (fieldKey === 'email') {
+                    this.currentUser.email = this.currentUser.email ? assertValidEmail(this.currentUser.email) : ''
+                    return
+                }
+                if (fieldKey === 'phone') {
+                    this.currentUser.phone = this.currentUser.phone ? normalizePhone(this.currentUser.phone) : ''
+                }
+            } catch {
+                // Keep the user's raw value in place until a save flow validates it.
+            }
         },
         async loadUser() {
             this.currentUser = getCurrentUser()

--- a/frontend/src/views/Resumes.vue
+++ b/frontend/src/views/Resumes.vue
@@ -171,14 +171,25 @@
                             <p class="panel-eyebrow">Library</p>
                             <h3>Imported Resumes</h3>
                         </div>
-                        <button
-                            v-if="libraryHasOverflow"
-                            class="btn-secondary btn-compact"
-                            type="button"
-                            @click="showLibraryModal = true"
-                        >
-                            View All
-                        </button>
+                        <div class="library-header-actions">
+                            <label v-if="resumes.length" class="sort-control">
+                                <span>Sort</span>
+                                <select v-model="resumeSort" name="resume_sort" autocomplete="off">
+                                    <option value="newest">Newest first</option>
+                                    <option value="oldest">Oldest first</option>
+                                    <option value="name-asc">File name A-Z</option>
+                                    <option value="name-desc">File name Z-A</option>
+                                </select>
+                            </label>
+                            <button
+                                v-if="libraryHasOverflow"
+                                class="btn-secondary btn-compact"
+                                type="button"
+                                @click="showLibraryModal = true"
+                            >
+                                View All
+                            </button>
+                        </div>
                     </div>
                 </template>
 
@@ -188,7 +199,7 @@
 
                 <div v-else-if="resumesError" class="upload-error">{{ resumesError }}</div>
 
-                <div v-else-if="resumes.length" class="resume-list">
+                <div v-else-if="sortedResumes.length" class="resume-list">
                     <div v-for="r in libraryPreviewResumes" :key="r.id" class="resume-list-item">
                         <div class="pdf-icon">PDF</div>
                         <div class="resume-meta">
@@ -355,7 +366,7 @@
 
                 <p class="profile-switcher-copy">Switch the active profile or create a new one before editing the sections below.</p>
                 <div class="autosave-status-row">
-                    <p class="autosave-hint">Double-click any field to edit. Changes autosave when you click away.</p>
+                    <p class="autosave-hint">Double-click text fields to edit. Dropdowns autosave as soon as you choose an option.</p>
                     <div
                         v-if="applicantSavingField || saveStatus.message"
                         :class="[
@@ -505,9 +516,9 @@
             <Card class="resume-card resume-section resume-section--authorization" variant="job">
                 <template #header><h3>Work Authorization</h3></template>
                 <div class="appinfo-grid">
-                    <div :class="['field-group', applicantFieldGroupClass('workAuth')]" @dblclick="unlockApplicantField('workAuth', 'resume-work-authorization')" title="Double-click to edit">
+                    <div :class="['field-group', 'field-group--select']" title="Choose an option to autosave">
                         <label>Authorization Status</label>
-                        <select id="resume-work-authorization" name="authorization_status" autocomplete="off" v-model="workAuth" :disabled="isApplicantFieldLocked('workAuth')" @blur="handleApplicantFieldBlur('workAuth')">
+                        <select id="resume-work-authorization" name="authorization_status" autocomplete="off" v-model="workAuth" :disabled="working" @change="handleApplicantSelectChange('workAuth')">
                             <option value="">Select…</option>
                             <option>US Citizen</option>
                             <option>Green Card</option>
@@ -517,9 +528,9 @@
                             <option>Require Sponsorship</option>
                         </select>
                     </div>
-                    <div :class="['field-group', applicantFieldGroupClass('requiresSponsorship')]" @dblclick="unlockApplicantField('requiresSponsorship', 'resume-requires-sponsorship')" title="Double-click to edit">
+                    <div :class="['field-group', 'field-group--select']" title="Choose an option to autosave">
                         <label>Requires Sponsorship?</label>
-                        <select id="resume-requires-sponsorship" name="requires_sponsorship" autocomplete="off" v-model="requiresSponsorship" :disabled="isApplicantFieldLocked('requiresSponsorship')" @blur="handleApplicantFieldBlur('requiresSponsorship')">
+                        <select id="resume-requires-sponsorship" name="requires_sponsorship" autocomplete="off" v-model="requiresSponsorship" :disabled="working" @change="handleApplicantSelectChange('requiresSponsorship')">
                             <option value="">Select…</option>
                             <option>Yes</option>
                             <option>No</option>
@@ -606,9 +617,9 @@
             <Card class="resume-card resume-section resume-section--demographics" variant="job">
                 <template #header><h3>Demographics (Optional)</h3></template>
                 <div class="appinfo-grid">
-                    <div :class="['field-group', applicantFieldGroupClass('demographicGender')]" @dblclick="unlockApplicantField('demographicGender', 'resume-demographic-gender')" title="Double-click to edit">
+                    <div :class="['field-group', 'field-group--select']" title="Choose an option to autosave">
                         <label>Gender Identity (Optional)</label>
-                        <select id="resume-demographic-gender" name="demographic_gender" autocomplete="off" v-model="demographicGender" :disabled="isApplicantFieldLocked('demographicGender')" @blur="handleApplicantFieldBlur('demographicGender')">
+                        <select id="resume-demographic-gender" name="demographic_gender" autocomplete="off" v-model="demographicGender" :disabled="working" @change="handleApplicantSelectChange('demographicGender')">
                             <option value="">Prefer not to answer</option>
                             <option>Female</option>
                             <option>Male</option>
@@ -616,9 +627,9 @@
                             <option>Another identity</option>
                         </select>
                     </div>
-                    <div :class="['field-group', applicantFieldGroupClass('demographicEthnicity')]" @dblclick="unlockApplicantField('demographicEthnicity', 'resume-demographic-ethnicity')" title="Double-click to edit">
+                    <div :class="['field-group', 'field-group--select']" title="Choose an option to autosave">
                         <label>Ethnicity / Race (Optional)</label>
-                        <select id="resume-demographic-ethnicity" name="demographic_ethnicity" autocomplete="off" v-model="demographicEthnicity" :disabled="isApplicantFieldLocked('demographicEthnicity')" @blur="handleApplicantFieldBlur('demographicEthnicity')">
+                        <select id="resume-demographic-ethnicity" name="demographic_ethnicity" autocomplete="off" v-model="demographicEthnicity" :disabled="working" @change="handleApplicantSelectChange('demographicEthnicity')">
                             <option value="">Prefer not to answer</option>
                             <option>American Indian or Alaska Native</option>
                             <option>Asian</option>
@@ -834,11 +845,36 @@
                                 </div>
                                 <div class="view-field">
                                     <label>Email</label>
-                                    <p>{{ displayValue(viewingResume.structured_data.personal_info.email) }}</p>
+                                    <p>
+                                        <a
+                                            v-if="emailHref(viewingResume.structured_data.personal_info.email)"
+                                            class="contact-link"
+                                            :href="emailHref(viewingResume.structured_data.personal_info.email)"
+                                        >
+                                            {{ displayValue(viewingResume.structured_data.personal_info.email) }}
+                                        </a>
+                                        <span v-else>{{ displayValue(viewingResume.structured_data.personal_info.email) }}</span>
+                                    </p>
                                 </div>
                                 <div class="view-field">
                                     <label>Phone</label>
-                                    <p>{{ displayValue(viewingResume.structured_data.personal_info.phone) }}</p>
+                                    <p class="contact-line">
+                                        <span
+                                            v-if="phoneCountryBadge(viewingResume.structured_data.personal_info.phone)"
+                                            class="phone-country-badge"
+                                            :title="phoneCountryBadge(viewingResume.structured_data.personal_info.phone).label"
+                                        >
+                                            {{ phoneCountryBadge(viewingResume.structured_data.personal_info.phone).code }}
+                                        </span>
+                                        <a
+                                            v-if="phoneHref(viewingResume.structured_data.personal_info.phone)"
+                                            class="contact-link"
+                                            :href="phoneHref(viewingResume.structured_data.personal_info.phone)"
+                                        >
+                                            {{ displayValue(viewingResume.structured_data.personal_info.phone) }}
+                                        </a>
+                                        <span v-else>{{ displayValue(viewingResume.structured_data.personal_info.phone) }}</span>
+                                    </p>
                                 </div>
                                 <div class="view-field">
                                     <label>Location</label>
@@ -981,7 +1017,18 @@
                         <h2>Imported Resume Library</h2>
                         <p class="subtitle">Browse all imported resumes in one place without stretching the main page layout.</p>
                     </div>
-                    <button class="btn-secondary btn-compact" @click="showLibraryModal = false">Close</button>
+                    <div class="library-header-actions">
+                        <label v-if="resumes.length" class="sort-control">
+                            <span>Sort</span>
+                            <select v-model="resumeSort" name="resume_sort_modal" autocomplete="off">
+                                <option value="newest">Newest first</option>
+                                <option value="oldest">Oldest first</option>
+                                <option value="name-asc">File name A-Z</option>
+                                <option value="name-desc">File name Z-A</option>
+                            </select>
+                        </label>
+                        <button class="btn-secondary btn-compact" @click="showLibraryModal = false">Close</button>
+                    </div>
                 </div>
 
                 <div v-if="resumesLoading" class="loading-row">
@@ -990,8 +1037,8 @@
 
                 <div v-else-if="resumesError" class="upload-error">{{ resumesError }}</div>
 
-                <div v-else-if="resumes.length" class="resume-list resume-list--modal">
-                    <div v-for="r in resumes" :key="`modal-${r.id}`" class="resume-list-item">
+                <div v-else-if="sortedResumes.length" class="resume-list resume-list--modal">
+                    <div v-for="r in sortedResumes" :key="`modal-${r.id}`" class="resume-list-item">
                         <div class="pdf-icon">PDF</div>
                         <div class="resume-meta">
                             <p class="resume-name">{{ r.file_name }}</p>
@@ -1030,7 +1077,7 @@ import Card from '../components/Card.vue'
 import ConfirmModal from '../components/ConfirmModal.vue'
 import { authedFetch, getCurrentUser, setCurrentUser } from '../lib/auth.js'
 import { publishCurrentPageDiagnostics, clearCurrentPageDiagnostics } from '../lib/debugDiagnostics'
-import { assertValidEmail, normalizePhone } from '../lib/validation.js'
+import { assertValidEmail, buildMailtoHref, buildPhoneHref, inferPhoneCountry, normalizePhone } from '../lib/validation.js'
 import { showToast } from '../services/toastService.js'
 
 const APPINFO_KEY = 'uah_applicant_info'
@@ -1052,6 +1099,7 @@ export default {
             resumesError: null,
             deletingId: null,
             showLibraryModal: false,
+            resumeSort: 'newest',
 
             // Inline upload
             uploadStep: 'select',   // 'select' | 'confirm'
@@ -1192,15 +1240,33 @@ export default {
         portalReadyCount() {
             return this.resumes.filter(r => r.portal_ready).length
         },
+        sortedResumes() {
+            const resumes = [...this.resumes]
+
+            if (this.resumeSort === 'oldest') {
+                return resumes.sort((a, b) => new Date(a.created_at) - new Date(b.created_at))
+            }
+
+            if (this.resumeSort === 'name-asc') {
+                return resumes.sort((a, b) => (a.file_name || '').localeCompare(b.file_name || '', undefined, { sensitivity: 'base' }))
+            }
+
+            if (this.resumeSort === 'name-desc') {
+                return resumes.sort((a, b) => (b.file_name || '').localeCompare(a.file_name || '', undefined, { sensitivity: 'base' }))
+            }
+
+            return resumes.sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+        },
         libraryPreviewResumes() {
-            return this.resumes.slice(0, 3)
+            return this.sortedResumes.slice(0, 3)
         },
         libraryHasOverflow() {
             return this.resumes.length > 3
         },
         latestUploadDate() {
             if (!this.resumes.length) return '—'
-            return this.formatDate(this.resumes[0].created_at)
+            const latest = [...this.resumes].sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0]
+            return latest ? this.formatDate(latest.created_at) : '—'
         },
         parseProgressPercent() {
             if (this.parseStatus === 'queued' && this.parseQueuePosition && this.parseQueueTotal) {
@@ -1388,6 +1454,19 @@ export default {
                 this.applicantSavingField = ''
             }
         },
+        async handleApplicantSelectChange(fieldKey) {
+            this.applicantSavingField = fieldKey
+            const saved = await this.saveApplicantInfo({
+                successMessage: 'Changes autosaved.',
+                showToastOnSuccess: true,
+                showToastOnError: true,
+                isAutosave: true,
+                savingFieldKey: fieldKey,
+            })
+            if (saved) {
+                this.applicantSavingField = ''
+            }
+        },
         serializeApplicantPayload(payload = this.buildProfilePayload()) {
             return JSON.stringify(payload)
         },
@@ -1492,6 +1571,15 @@ export default {
         displayValue(value) {
             const cleaned = this.cleanTextValue(value)
             return cleaned || '—'
+        },
+        emailHref(value) {
+            return buildMailtoHref(this.cleanTextValue(value))
+        },
+        phoneHref(value) {
+            return buildPhoneHref(this.cleanTextValue(value))
+        },
+        phoneCountryBadge(value) {
+            return inferPhoneCountry(this.cleanTextValue(value))
         },
 
         parseMethodTagLabel(method) {
@@ -2235,6 +2323,7 @@ export default {
                 showToastOnSuccess = false,
                 showToastOnError = false,
                 isAutosave = false,
+                savingFieldKey = '',
             } = options
             this.working = true
             this.saveStatus = { type: '', message: '' }
@@ -2248,7 +2337,7 @@ export default {
                     return true
                 }
                 if (isAutosave) {
-                    this.applicantSavingField = this.applicantEditingField
+                    this.applicantSavingField = savingFieldKey || this.applicantEditingField
                 }
                 delete payload.name  // don't overwrite profile name on save
 

--- a/frontend/src/views/css/Resumes.css
+++ b/frontend/src/views/css/Resumes.css
@@ -146,6 +146,31 @@
   flex-wrap: wrap;
 }
 
+.resumes-page .library-header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px 12px;
+}
+
+.resumes-page .sort-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #64748b;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.resumes-page .sort-control select {
+  min-height: 36px;
+  border: 1px solid rgba(203, 213, 225, 0.95);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.96);
+  padding: 8px 10px;
+}
+
 .resumes-page .panel-header--stacked {
   align-items: flex-start;
 }
@@ -2587,6 +2612,10 @@
   color: #1d4ed8;
 }
 
+.resumes-page .field-group--select select {
+  cursor: pointer;
+}
+
 .resumes-page .field-group {
   min-width: 0;
   gap: 6px;
@@ -2610,6 +2639,39 @@
 .resumes-page .field-group--locked select:disabled {
   color: #334155;
   -webkit-text-fill-color: #334155;
+}
+
+.resumes-page .contact-line {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.resumes-page .contact-link {
+  color: var(--color-primary-600);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.resumes-page .contact-link:hover {
+  color: var(--color-primary-700);
+  text-decoration: underline;
+}
+
+.resumes-page .phone-country-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 34px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(15, 118, 110, 0.1);
+  border: 1px solid rgba(15, 118, 110, 0.25);
+  color: #0f766e;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
 }
 
 .resumes-page .field-group--editing input,
@@ -2717,6 +2779,16 @@
 
   .resumes-page .library-modal-header {
     flex-direction: column;
+  }
+
+  .resumes-page .library-header-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .resumes-page .sort-control {
+    width: 100%;
+    justify-content: space-between;
   }
 
   .resumes-page .resume-list-item {


### PR DESCRIPTION
Refactor and extend contact validation/helpers and wire them into the UI and mock API. Backend: extract phone parsing, tighten validation, add build_mailto_href, build_phone_href and infer_phone_country utilities and corresponding unit tests. Frontend: add phone/email helpers to validation.js, normalize contact payloads in local mock API, validate email change endpoint, normalize contact fields on blur in Applicant-Information, and show mailto/tel links and phone country badges in Resumes. Also add sorting controls and autosave behavior for select fields, plus related CSS and a footer credit line.
