### PR TITLE
Add provider registry, providers, and job dedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ endpoint_utilization_matrix_2026-04-11.tsv
 # Celery Beat runtime scheduler file
 celerybeat-schedule
 celerybeat.pid
+uah-test-extension/
+uah-apply-overlay-prototype/

--- a/backend/alembic/versions/20260413_03_add_job_dedup_hash.py
+++ b/backend/alembic/versions/20260413_03_add_job_dedup_hash.py
@@ -1,0 +1,134 @@
+"""add job dedup hash and sync dedup metrics
+
+Revision ID: 20260413_03
+Revises: 20260413_02
+Create Date: 2026-04-13 14:30:00.000000
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import re
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260413_03"
+down_revision = "20260413_02"
+branch_labels = None
+depends_on = None
+
+_NOISE_WORDS = (
+    "senior",
+    "sr",
+    "jr",
+    "junior",
+    "lead",
+    "staff",
+    "principal",
+    "associate",
+    "remote",
+    "hybrid",
+    "inc",
+    "llc",
+    "ltd",
+    "corp",
+    "corporation",
+    "co",
+)
+
+
+def _normalize_dedup_value(value: str | None) -> str:
+    cleaned = (value or "").strip().lower()
+    cleaned = re.sub(r"[^\w\s]", "", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    for noise in _NOISE_WORDS:
+        cleaned = re.sub(rf"\b{noise}\b", "", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned.strip()
+
+
+def _compute_dedup_hash(title: str | None, company: str | None) -> str | None:
+    normalized_title = _normalize_dedup_value(title)
+    normalized_company = _normalize_dedup_value(company)
+    if not normalized_title or not normalized_company:
+        return None
+    return hashlib.md5(f"{normalized_title}|{normalized_company}".encode("utf-8")).hexdigest()
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("dedup_hash", sa.String(length=32), nullable=True))
+    op.add_column(
+        "provider_sync_log",
+        sa.Column("jobs_deduplicated", sa.Integer(), nullable=False, server_default=sa.text("0")),
+    )
+
+    bind = op.get_bind()
+    jobs = sa.table(
+        "jobs",
+        sa.column("id", sa.String()),
+        sa.column("title", sa.String()),
+        sa.column("company", sa.String()),
+        sa.column("is_active", sa.Boolean()),
+        sa.column("first_seen_at", sa.DateTime(timezone=True)),
+        sa.column("dedup_hash", sa.String()),
+    )
+
+    rows = bind.execute(
+        sa.select(
+            jobs.c.id,
+            jobs.c.title,
+            jobs.c.company,
+            jobs.c.is_active,
+            jobs.c.first_seen_at,
+        )
+    ).mappings().all()
+
+    inactive_updates: list[tuple[str, str]] = []
+    active_groups: dict[str, list[dict]] = {}
+    for row in rows:
+        dedup_hash = _compute_dedup_hash(row.get("title"), row.get("company"))
+        if not dedup_hash:
+            continue
+        if bool(row.get("is_active")):
+            active_groups.setdefault(dedup_hash, []).append(dict(row))
+        else:
+            inactive_updates.append((row["id"], dedup_hash))
+
+    for row_id, dedup_hash in inactive_updates:
+        bind.execute(
+            jobs.update().where(jobs.c.id == row_id).values(dedup_hash=dedup_hash)
+        )
+
+    for dedup_hash, group in active_groups.items():
+        ordered = sorted(
+            group,
+            key=lambda item: (
+                item.get("first_seen_at") or datetime.max.replace(tzinfo=timezone.utc),
+                str(item.get("id") or ""),
+            ),
+        )
+        owner = ordered[0]
+        bind.execute(
+            jobs.update().where(jobs.c.id == owner["id"]).values(dedup_hash=dedup_hash)
+        )
+        for duplicate in ordered[1:]:
+            bind.execute(
+                jobs.update().where(jobs.c.id == duplicate["id"]).values(dedup_hash=None)
+            )
+
+    op.create_index(
+        "idx_jobs_dedup_hash",
+        "jobs",
+        ["dedup_hash"],
+        unique=True,
+        postgresql_where=sa.text("dedup_hash IS NOT NULL AND is_active = true"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_jobs_dedup_hash", table_name="jobs")
+    op.drop_column("provider_sync_log", "jobs_deduplicated")
+    op.drop_column("jobs", "dedup_hash")

--- a/backend/app/api/jobs.py
+++ b/backend/app/api/jobs.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
+from app.providers.registry import list_provider_statuses
 from app.services.job_search import search_local_jobs
 
 router = APIRouter()
@@ -14,10 +15,10 @@ logger = logging.getLogger(__name__)
 
 
 def _enqueue_thin_results_sync(category: str) -> None:
-    """Queue a background sweep without importing worker dependencies at module import time."""
-    from app.tasks.job_sync import sweep_category
+    """Queue provider sweeps without importing worker dependencies at module import time."""
+    from app.tasks.job_sync import queue_thin_results_sync
 
-    sweep_category.delay(provider="the_muse", category=category)
+    queue_thin_results_sync(category)
 
 
 @router.get(
@@ -71,3 +72,13 @@ def search_jobs(
 
     payload["note"] = note
     return payload
+
+
+@router.get(
+    "/providers/attribution",
+    tags=["jobs"],
+    response_description="Provider attribution metadata and current provider controls.",
+)
+def list_job_provider_attribution():
+    """Return provider attribution details and resolved provider status flags."""
+    return {"providers": list_provider_statuses()}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,6 +28,20 @@ def _env_slug(value: str) -> str:
   return cleaned or "dev"
 
 
+def _normalize_provider_control_value(value):
+  if isinstance(value, bool):
+    return value
+  if isinstance(value, (int, float)):
+    return bool(value)
+  if isinstance(value, str):
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+      return True
+    if normalized in {"0", "false", "no", "off"}:
+      return False
+  return value
+
+
 _DEFAULT_JOB_SYNC_CATEGORY_SCHEDULE = {
     "tech": {"interval_minutes": 30, "priority": 1},
     "product": {"interval_minutes": 60, "priority": 2},
@@ -171,6 +185,17 @@ class Settings:
     MUSE_LOCATION_INDEX_RETENTION_DAYS: int = int(os.getenv("MUSE_LOCATION_INDEX_RETENTION_DAYS", "45"))
     THE_MUSE_API_KEY: str = os.getenv("THE_MUSE_API_KEY", os.getenv("MUSE_API_KEY", ""))
     THE_MUSE_RATE_LIMIT_PER_HOUR: int = int(os.getenv("THE_MUSE_RATE_LIMIT_PER_HOUR", "1000"))
+    ARBEITNOW_INTER_REQUEST_DELAY: float = float(os.getenv("ARBEITNOW_INTER_REQUEST_DELAY", "3.0"))
+    FINDWORK_API_KEY: str = os.getenv("FINDWORK_API_KEY", "")
+    FINDWORK_INTER_REQUEST_DELAY: float = float(os.getenv("FINDWORK_INTER_REQUEST_DELAY", "6.0"))
+    ADZUNA_APP_ID: str = os.getenv("ADZUNA_APP_ID", "")
+    ADZUNA_APP_KEY: str = os.getenv("ADZUNA_APP_KEY", "")
+    ADZUNA_DAILY_REQUEST_BUDGET: int = int(os.getenv("ADZUNA_DAILY_REQUEST_BUDGET", "200"))
+    JOOBLE_API_KEY: str = os.getenv("JOOBLE_API_KEY", "")
+    JOOBLE_INTER_REQUEST_DELAY: float = float(os.getenv("JOOBLE_INTER_REQUEST_DELAY", "1.5"))
+    JOOBLE_PAGE_SIZE: int = int(os.getenv("JOOBLE_PAGE_SIZE", "50"))
+    JOB_DEDUP_ENABLED: bool = _env_bool("JOB_DEDUP_ENABLED", "true")
+    JOB_DEDUP_LOG_COLLISIONS: bool = _env_bool("JOB_DEDUP_LOG_COLLISIONS", "true")
 
     JOB_SYNC_STALE_THRESHOLD_HOURS: int = int(os.getenv("JOB_SYNC_STALE_THRESHOLD_HOURS", "6"))
     JOB_SYNC_SOFT_DELETE_MISSES: int = int(os.getenv("JOB_SYNC_SOFT_DELETE_MISSES", "3"))
@@ -182,6 +207,7 @@ class Settings:
     JOB_SYNC_CLEANUP_LOCK_TTL_SECONDS: int = int(os.getenv("JOB_SYNC_CLEANUP_LOCK_TTL_SECONDS", "1800"))
     JOB_SYNC_CATEGORY_SCHEDULE_JSON: str = os.getenv("JOB_SYNC_CATEGORY_SCHEDULE_JSON", "")
     JOB_SYNC_ENABLED_PROVIDERS_JSON: str = os.getenv("JOB_SYNC_ENABLED_PROVIDERS_JSON", "[\"the_muse\"]")
+    JOB_PROVIDER_CONTROLS_JSON: str = os.getenv("JOB_PROVIDER_CONTROLS_JSON", "")
 
     @property
     def DATABASE_URL(self) -> str:
@@ -264,6 +290,37 @@ class Settings:
         return ["the_muse"]
       providers = [str(value).strip() for value in parsed if str(value).strip()]
       return providers or ["the_muse"]
+
+    @property
+    def JOB_PROVIDER_CONTROLS(self) -> dict[str, dict[str, bool | str]]:
+      raw = (self.JOB_PROVIDER_CONTROLS_JSON or "").strip()
+      if not raw:
+        return {}
+      try:
+        parsed = json.loads(raw)
+      except json.JSONDecodeError:
+        return {}
+      if not isinstance(parsed, dict):
+        return {}
+
+      normalized: dict[str, dict[str, bool | str]] = {}
+      for key, value in parsed.items():
+        if not isinstance(key, str) or not isinstance(value, dict):
+          continue
+        provider_key = key.strip().lower()
+        if not provider_key:
+          continue
+        normalized_value: dict[str, bool | str] = {}
+        for field_name, field_value in value.items():
+          if not isinstance(field_name, str):
+            continue
+          normalized_field_name = field_name.strip().lower()
+          if not normalized_field_name:
+            continue
+          normalized_value[normalized_field_name] = _normalize_provider_control_value(field_value)
+        if normalized_value:
+          normalized[provider_key] = normalized_value
+      return normalized
 
     def require_secrets(self) -> None:
       missing: list[str] = []

--- a/backend/app/models/job.py
+++ b/backend/app/models/job.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import Boolean, Column, DateTime, Float, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, Column, DateTime, Float, Index, Integer, String, Text, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.sql import func
 
@@ -27,6 +27,12 @@ class Job(Base):
         Index("ix_jobs_provider_url_status", "provider_url_status"),
         Index("ix_jobs_staleness_status", "staleness_status"),
         Index("ix_jobs_first_published_at", "first_published_at"),
+        Index(
+            "idx_jobs_dedup_hash",
+            "dedup_hash",
+            unique=True,
+            postgresql_where=text("dedup_hash IS NOT NULL AND is_active = true"),
+        ),
     )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -69,6 +75,7 @@ class Job(Base):
     staleness_flags = Column(ARRAY(Text), nullable=False, default=list)
     staleness_checked_at = Column(DateTime(timezone=True), nullable=True)
     repost_count = Column(Integer, nullable=False, default=0)
+    dedup_hash = Column(String(32), nullable=True)
 
 
 class ProviderSyncLog(Base):
@@ -85,6 +92,7 @@ class ProviderSyncLog(Base):
     jobs_found = Column(Integer, nullable=False, default=0)
     jobs_new = Column(Integer, nullable=False, default=0)
     jobs_updated = Column(Integer, nullable=False, default=0)
+    jobs_deduplicated = Column(Integer, nullable=False, default=0)
     requests_used = Column(Integer, nullable=False, default=0)
     stopped_reason = Column(String(50), nullable=True)
     error_message = Column(Text, nullable=True)

--- a/backend/app/providers/adzuna.py
+++ b/backend/app/providers/adzuna.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.config import settings
+from app.providers.base import JobProvider
+from app.providers.common import (
+    clean_html_text,
+    infer_remote_flag,
+    normalize_experience_level,
+    normalize_job_type,
+    normalize_provider_categories,
+    parse_iso_datetime,
+)
+from app.schemas.job import NormalizedJob
+from app.services.provider_requests import ProviderQuotaExceeded, ProviderRequestFailed, confirm_request_budget, tracked_request
+
+PROVIDER_NOTES = """
+Adzuna API
+- Auth uses `app_id` and `app_key` query params.
+- Hourly pacing is governed by the provider's hard 25 requests/minute limit.
+- Background use must stop once UAH reaches its configured daily request budget.
+- Descriptions are snippet-length only and `redirect_url` is an Adzuna wrapper, not the direct employer apply page.
+- Salary data is mostly predicted; UAH does not surface salary-specific fields in this rollout.
+"""
+
+
+class AdzunaJobProvider(JobProvider):
+    """Provider adapter for the Adzuna jobs API."""
+
+    @property
+    def provider_name(self) -> str:
+        return "adzuna"
+
+    @property
+    def max_page_size(self) -> int:
+        return 20
+
+    @property
+    def rate_limit_per_hour(self) -> int:
+        return 1500
+
+    def map_filters(self, internal_filters: dict) -> dict:
+        """Convert canonical UAH filters into Adzuna search params."""
+        params: dict[str, Any] = {
+            "app_id": settings.ADZUNA_APP_ID,
+            "app_key": settings.ADZUNA_APP_KEY,
+            "results_per_page": self.max_page_size,
+        }
+        category = " ".join(str((internal_filters.get("category") or [None])[0] or "").split())
+        if category:
+            params["what"] = category
+        location = " ".join(str((internal_filters.get("location") or [None])[0] or "").split())
+        if location:
+            params["where"] = location
+        return params
+
+    def fetch(self, params: dict) -> list[NormalizedJob]:
+        """Fetch one Adzuna result page and normalize the payload."""
+        if not settings.ADZUNA_APP_ID or not settings.ADZUNA_APP_KEY:
+            raise ProviderRequestFailed("Adzuna credentials are not configured.")
+        if not confirm_request_budget(
+            provider_name=self.provider_name,
+            rate_limit_per_hour=self.rate_limit_per_hour,
+            daily_request_budget=max(int(settings.ADZUNA_DAILY_REQUEST_BUDGET), 1),
+        ):
+            raise ProviderQuotaExceeded("Adzuna daily request budget has been exhausted for background sync.")
+
+        page = max(int(params.get("page") or 1), 1)
+        response = tracked_request(
+            provider_name=self.provider_name,
+            rate_limit_per_hour=self.rate_limit_per_hour,
+            daily_request_budget=max(int(settings.ADZUNA_DAILY_REQUEST_BUDGET), 1),
+            method="GET",
+            url=f"https://api.adzuna.com/v1/api/jobs/us/search/{page}",
+            params=self.map_filters(params),
+            timeout_seconds=20.0,
+        )
+        if response.status_code != 200:
+            raise ProviderRequestFailed(
+                f"Adzuna request failed with status {response.status_code}: {response.text[:200]}"
+            )
+
+        payload = response.json()
+        raw_jobs = payload.get("results") if isinstance(payload, dict) else payload
+        if not isinstance(raw_jobs, list):
+            return []
+
+        normalized: list[NormalizedJob] = []
+        for item in raw_jobs:
+            title = " ".join(str(item.get("title") or "").split())
+            company = " ".join(str((item.get("company") or {}).get("display_name") or "").split()) or None
+            location = " ".join(str((item.get("location") or {}).get("display_name") or "").split()) or None
+            description = clean_html_text(item.get("description"))
+            category_label = " ".join(str((item.get("category") or {}).get("label") or "").split())
+
+            normalized.append(
+                NormalizedJob(
+                    provider=self.provider_name,
+                    provider_job_id=str(item.get("id")),
+                    provider_url=" ".join(str(item.get("redirect_url") or "").split()) or None,
+                    title=title,
+                    company=company,
+                    location=location,
+                    is_remote=infer_remote_flag(title=title, location=location, description=description),
+                    job_type=normalize_job_type([str(item.get("contract_type") or ""), str(item.get("contract_time") or "")]),
+                    experience_level=normalize_experience_level(title=title),
+                    categories=normalize_provider_categories(values=[category_label], title=title, description=description),
+                    description=description,
+                    published_at=parse_iso_datetime(item.get("created")),
+                    source_tags=["provider:adzuna", "source:adzuna_api"],
+                )
+            )
+
+        return normalized

--- a/backend/app/providers/arbeitnow.py
+++ b/backend/app/providers/arbeitnow.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.config import settings
+from app.providers.base import JobProvider
+from app.providers.common import (
+    clean_html_text,
+    dedupe_strings,
+    normalize_experience_level,
+    normalize_job_type,
+    normalize_provider_categories,
+    parse_unix_timestamp,
+)
+from app.schemas.job import NormalizedJob
+from app.services.provider_requests import ProviderRequestFailed, tracked_request
+
+ARBEITNOW_BASE_URL = "https://www.arbeitnow.com/api/job-board-api"
+
+PROVIDER_NOTES = """
+Arbeitnow job board API
+- No authentication required.
+- The API tolerates light automation, but Cloudflare blocks rapid bursts; UAH enforces a 3-second minimum page pace via the configured hourly rate.
+- `remote=true` and `visa_sponsorship=true` are not trustworthy at the API edge, so remote/visa filters are post-filtered after the response.
+- `slug` is the stable provider job id.
+- `created_at` is a unix timestamp.
+- `url` is usually a direct ATS link, so UAH stores it as both provider_url and apply_url.
+"""
+
+
+class ArbeitnowJobProvider(JobProvider):
+    """Provider adapter for the Arbeitnow job board API."""
+
+    @property
+    def provider_name(self) -> str:
+        return "arbeitnow"
+
+    @property
+    def max_page_size(self) -> int:
+        return 100
+
+    @property
+    def rate_limit_per_hour(self) -> int:
+        delay_seconds = max(float(settings.ARBEITNOW_INTER_REQUEST_DELAY), 0.1)
+        return max(int(3600 / delay_seconds), 1)
+
+    def map_filters(self, internal_filters: dict) -> dict:
+        """Convert canonical UAH filters into Arbeitnow API params."""
+        params: dict[str, Any] = {
+            # Passing explicit params avoids the default country-scoped feed behavior.
+            "page": max(int(internal_filters.get("page") or 1), 1),
+        }
+
+        if internal_filters.get("is_remote") is True:
+            params["remote"] = True
+        if internal_filters.get("visa_sponsorship") is True:
+            params["visa_sponsorship"] = True
+        return params
+
+    def fetch(self, params: dict) -> list[NormalizedJob]:
+        """Fetch one page from Arbeitnow and normalize it for ingest."""
+        provider_params = self.map_filters(params)
+        response = tracked_request(
+            provider_name=self.provider_name,
+            rate_limit_per_hour=self.rate_limit_per_hour,
+            method="GET",
+            url=ARBEITNOW_BASE_URL,
+            params=provider_params,
+            timeout_seconds=20.0,
+        )
+        if response.status_code != 200:
+            raise ProviderRequestFailed(
+                f"Arbeitnow request failed with status {response.status_code}: {response.text[:200]}"
+            )
+
+        payload = response.json()
+        raw_jobs = payload.get("data") if isinstance(payload, dict) else payload
+        if not isinstance(raw_jobs, list):
+            return []
+
+        if params.get("is_remote") is True:
+            raw_jobs = [job for job in raw_jobs if job.get("remote") is True]
+        if params.get("visa_sponsorship") is True:
+            raw_jobs = [job for job in raw_jobs if job.get("visa_sponsorship") is True]
+
+        normalized: list[NormalizedJob] = []
+        for item in raw_jobs:
+            title = " ".join(str(item.get("title") or "").split())
+            company = " ".join(str(item.get("company_name") or "").split()) or None
+            location = " ".join(str(item.get("location") or "").split()) or None
+            description = clean_html_text(item.get("description"))
+            job_types = dedupe_strings([str(value) for value in (item.get("job_types") or []) if value])
+            tags = dedupe_strings([str(value) for value in (item.get("tags") or []) if value])
+            provider_url = " ".join(str(item.get("url") or "").split()) or None
+
+            normalized.append(
+                NormalizedJob(
+                    provider=self.provider_name,
+                    provider_job_id=" ".join(str(item.get("slug") or "").split()),
+                    provider_url=provider_url,
+                    apply_url=provider_url,
+                    title=title,
+                    company=company,
+                    location=location,
+                    is_remote=bool(item.get("remote") is True),
+                    job_type=normalize_job_type(job_types),
+                    experience_level=normalize_experience_level(values=job_types + tags, title=title),
+                    categories=normalize_provider_categories(values=job_types + tags, title=title, description=description),
+                    description=description,
+                    published_at=parse_unix_timestamp(item.get("created_at")),
+                    source_tags=["provider:arbeitnow", "source:arbeitnow_api"],
+                )
+            )
+
+        return normalized

--- a/backend/app/providers/careerjet.py
+++ b/backend/app/providers/careerjet.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from app.providers.base import JobProvider
+from app.schemas.job import NormalizedJob
+
+PROVIDER_NOTES = """
+Careerjet is intentionally dormant in UAH.
+- Careerjet's API is designed around pay-per-click monetization and real user traffic.
+- Requests require end-user `user_ip` and `user_agent`, which conflicts with UAH's autonomous background ingest model.
+- The API does not provide a stable job id; URLs must be used as identifiers.
+- Descriptions are excerpt-only and controlled by `fragment_size`.
+- This mismatch is architectural, not a missing attribution or quota detail.
+"""
+
+
+class CareerjetJobProvider(JobProvider):
+    """Disabled stub for Careerjet until UAH adopts a request-per-user model."""
+
+    @property
+    def provider_name(self) -> str:
+        return "careerjet"
+
+    @property
+    def max_page_size(self) -> int:
+        return 20
+
+    @property
+    def rate_limit_per_hour(self) -> int:
+        return 1
+
+    def map_filters(self, internal_filters: dict) -> dict:
+        """Return the passthrough filter payload for the disabled stub."""
+        return dict(internal_filters or {})
+
+    def fetch(self, params: dict) -> list[NormalizedJob]:
+        """Raise an explanatory error because this provider is intentionally unsupported."""
+        raise NotImplementedError(
+            "Careerjet is disabled because its API requires real end-user IP/user-agent context and a PPC traffic model "
+            "that conflicts with UAH's background local-cache ingest architecture."
+        )

--- a/backend/app/providers/common.py
+++ b/backend/app/providers/common.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import html
+import re
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_REMOTE_RE = re.compile(r"\b(remote|work from home|telecommute|distributed|anywhere)\b", re.IGNORECASE)
+_HYBRID_RE = re.compile(r"\bhybrid\b", re.IGNORECASE)
+
+_CATEGORY_KEYWORDS = (
+    ("Software Engineering", ("engineer", "engineering", "developer", "software", "backend", "frontend", "full stack", "devops", "sre", "platform", "cloud", "security", "qa", "test automation")),
+    ("Data and Analytics", ("data", "analytics", "machine learning", "ml", "ai", "scientist", "analyst", "business intelligence")),
+    ("Design and UX", ("design", "designer", "ux", "ui", "product design", "visual design")),
+    ("Product Management", ("product manager", "product management", "product owner", "program manager", "project manager")),
+    ("Accounting and Finance", ("finance", "financial", "accounting", "accountant", "controller", "fp&a", "payroll")),
+    ("Human Resources and Recruitment", ("recruit", "recruiter", "talent", "human resources", "people ops", "people operations", "hr")),
+    ("Business Operations", ("operations", "business operations", "strategy", "chief of staff", "office manager", "program operations")),
+    ("Sales", ("sales", "account executive", "business development", "partnerships")),
+    ("Marketing", ("marketing", "growth", "seo", "brand", "content", "demand generation", "communications")),
+    ("Customer Service", ("support", "customer service", "customer success", "technical support", "help desk")),
+)
+
+
+def clean_html_text(value: str | None) -> str:
+    """Return a plain-text version of one provider HTML fragment."""
+    plain = _TAG_RE.sub(" ", value or "")
+    plain = html.unescape(plain)
+    return " ".join(plain.split())
+
+
+def dedupe_strings(values: list[str]) -> list[str]:
+    """Return a stable list of unique non-empty strings."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        normalized = " ".join((value or "").split())
+        if not normalized:
+            continue
+        key = normalized.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(normalized)
+    return result
+
+
+def parse_iso_datetime(value: str | None) -> datetime | None:
+    """Parse a provider ISO timestamp into UTC when possible."""
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def parse_unix_timestamp(value: int | float | str | None) -> datetime | None:
+    """Parse a unix timestamp value into UTC."""
+    if value in {None, ""}:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    try:
+        return datetime.fromtimestamp(numeric, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def parse_iso_datetime_with_trimmed_fraction(value: str | None) -> datetime | None:
+    """Parse an ISO timestamp while trimming unsupported 7-digit fractions."""
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    if "." in raw:
+        head, tail = raw.split(".", 1)
+        fraction = tail
+        suffix = ""
+        if "+" in tail:
+            fraction, suffix = tail.split("+", 1)
+            suffix = f"+{suffix}"
+        elif "Z" in tail:
+            fraction = tail.replace("Z", "")
+            suffix = "Z"
+        if len(fraction) > 6:
+            raw = f"{head}.{fraction[:6]}{suffix}"
+    return parse_iso_datetime(raw)
+
+
+def infer_remote_flag(*, title: str | None = None, location: str | None = None, description: str | None = None) -> bool:
+    """Infer whether a listing is remote from common text hints."""
+    haystack = " ".join([title or "", location or "", description or ""])
+    return bool(_REMOTE_RE.search(haystack))
+
+
+def infer_hybrid_flag(*, title: str | None = None, location: str | None = None, description: str | None = None) -> bool:
+    """Infer whether a listing mentions hybrid work."""
+    haystack = " ".join([title or "", location or "", description or ""])
+    return bool(_HYBRID_RE.search(haystack))
+
+
+def normalize_provider_categories(*, values: list[str] | None = None, title: str | None = None, description: str | None = None) -> list[str]:
+    """Map provider-native tags into the broad category vocabulary used by UAH."""
+    searchable = " ".join([title or "", description or "", " ".join(values or [])]).lower()
+    matched: list[str] = []
+    for category_name, keywords in _CATEGORY_KEYWORDS:
+        if any(keyword in searchable for keyword in keywords):
+            matched.append(category_name)
+    return dedupe_strings(matched)
+
+
+def normalize_job_type(values: list[str] | None, *, fallback: str | None = None) -> str | None:
+    """Normalize provider-native employment type labels."""
+    type_map = {
+        "full time": "full_time",
+        "full-time": "full_time",
+        "part time": "part_time",
+        "part-time": "part_time",
+        "contract": "contract",
+        "internship": "internship",
+        "temporary": "temporary",
+        "volunteer": "volunteer",
+        "freelance": "contract",
+    }
+    candidates = list(values or [])
+    if fallback:
+        candidates.append(fallback)
+    for value in candidates:
+        normalized = " ".join((value or "").strip().lower().split())
+        mapped = type_map.get(normalized)
+        if mapped:
+            return mapped
+    return None
+
+
+def normalize_experience_level(*, values: list[str] | None = None, title: str | None = None) -> str | None:
+    """Infer UAH experience level from provider-native labels and title text."""
+    mapping = {
+        "internship": "internship",
+        "entry": "entry",
+        "entry level": "entry",
+        "junior": "entry",
+        "jr": "entry",
+        "berufseinstieg": "entry",
+        "mid": "mid",
+        "senior": "senior",
+        "sr": "senior",
+        "lead": "manager",
+        "teamleitung": "manager",
+        "management": "manager",
+        "manager": "manager",
+        "director": "director",
+        "vp": "vp",
+        "principal": "director",
+        "staff": "director",
+    }
+    candidates = list(values or [])
+    if title:
+        candidates.append(title)
+    for value in candidates:
+        normalized = " ".join((value or "").strip().lower().split())
+        for key, mapped in mapping.items():
+            if re.search(rf"\b{re.escape(key)}\b", normalized):
+                return mapped
+    return None

--- a/backend/app/providers/findwork.py
+++ b/backend/app/providers/findwork.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.config import settings
+from app.providers.base import JobProvider
+from app.providers.common import (
+    clean_html_text,
+    dedupe_strings,
+    normalize_experience_level,
+    normalize_job_type,
+    normalize_provider_categories,
+    parse_iso_datetime,
+)
+from app.schemas.job import NormalizedJob
+from app.services.provider_requests import ProviderRequestFailed, tracked_request
+
+FINDWORK_BASE_URL = "https://findwork.dev/api/jobs/"
+
+PROVIDER_NOTES = """
+Findwork API
+- Token auth via `Authorization: Token <key>`.
+- Real-world throttling is stricter than the public docs; UAH uses a 6-second page pace.
+- `id` is a short string slug, not a safe integer.
+- `role` is the canonical job title field.
+- `remote` is reliable and is used directly.
+- `text` contains the full description.
+- `source` identifies the upstream job board and is preserved in source_tags.
+"""
+
+
+class FindworkJobProvider(JobProvider):
+    """Provider adapter for the Findwork jobs API."""
+
+    @property
+    def provider_name(self) -> str:
+        return "findwork"
+
+    @property
+    def max_page_size(self) -> int:
+        return 100
+
+    @property
+    def rate_limit_per_hour(self) -> int:
+        delay_seconds = max(float(settings.FINDWORK_INTER_REQUEST_DELAY), 0.1)
+        return max(int(3600 / delay_seconds), 1)
+
+    def map_filters(self, internal_filters: dict) -> dict:
+        """Convert canonical UAH filters into Findwork API params."""
+        params: dict[str, Any] = {
+            "page": max(int(internal_filters.get("page") or 1), 1),
+        }
+        if internal_filters.get("is_remote") is True:
+            params["remote"] = True
+        return params
+
+    def fetch(self, params: dict) -> list[NormalizedJob]:
+        """Fetch one page from Findwork and normalize the result set."""
+        provider_params = self.map_filters(params)
+        headers = {}
+        if settings.FINDWORK_API_KEY:
+            headers["Authorization"] = f"Token {settings.FINDWORK_API_KEY}"
+
+        response = tracked_request(
+            provider_name=self.provider_name,
+            rate_limit_per_hour=self.rate_limit_per_hour,
+            method="GET",
+            url=FINDWORK_BASE_URL,
+            params=provider_params,
+            headers=headers or None,
+            timeout_seconds=20.0,
+        )
+        if response.status_code != 200:
+            raise ProviderRequestFailed(
+                f"Findwork request failed with status {response.status_code}: {response.text[:200]}"
+            )
+
+        payload = response.json()
+        raw_jobs = payload.get("results") if isinstance(payload, dict) else payload
+        if not isinstance(raw_jobs, list):
+            return []
+
+        normalized: list[NormalizedJob] = []
+        for item in raw_jobs:
+            title = " ".join(str(item.get("role") or "").split())
+            company = " ".join(str(item.get("company_name") or "").split()) or None
+            location = " ".join(str(item.get("location") or "").split()) or None
+            description = clean_html_text(item.get("text"))
+            keywords = dedupe_strings([str(value) for value in (item.get("keywords") or []) if value])
+            provider_url = " ".join(str(item.get("url") or "").split()) or None
+            upstream_source = " ".join(str(item.get("source") or "").split()).lower()
+            source_tags = ["provider:findwork", "source:findwork_api"]
+            if upstream_source:
+                source_tags.append(f"upstream_source:{upstream_source}")
+
+            normalized.append(
+                NormalizedJob(
+                    provider=self.provider_name,
+                    provider_job_id=" ".join(str(item.get("id") or "").split()),
+                    provider_url=provider_url,
+                    apply_url=provider_url,
+                    title=title,
+                    company=company,
+                    location=location,
+                    is_remote=bool(item.get("remote") is True),
+                    job_type=normalize_job_type(item.get("employment_type") if isinstance(item.get("employment_type"), list) else None),
+                    experience_level=normalize_experience_level(values=keywords, title=title),
+                    categories=normalize_provider_categories(values=keywords, title=title, description=description),
+                    description=description,
+                    published_at=parse_iso_datetime(item.get("date_posted")),
+                    source_tags=source_tags,
+                )
+            )
+
+        return normalized

--- a/backend/app/providers/jooble.py
+++ b/backend/app/providers/jooble.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.config import settings
+from app.providers.base import JobProvider
+from app.providers.common import (
+    clean_html_text,
+    infer_remote_flag,
+    normalize_experience_level,
+    normalize_job_type,
+    normalize_provider_categories,
+)
+from app.schemas.job import NormalizedJob
+from app.services.provider_requests import ProviderRequestFailed, tracked_request
+
+PROVIDER_NOTES = """
+Jooble API
+- Auth uses the API key in the request path and requires POST + JSON body.
+- Job ids can be large negative integers, so UAH stores them as strings.
+- `updated` is a crawl timestamp, not a trustworthy original publish date, so UAH does not map it to `published_at`.
+- `link` is usually a Jooble redirect wrapper, not the downstream employer apply URL.
+- Jooble heavily re-aggregates third-party boards, so cross-provider deduplication is especially important.
+"""
+
+
+class JoobleJobProvider(JobProvider):
+    """Provider adapter for the Jooble jobs API."""
+
+    @property
+    def provider_name(self) -> str:
+        return "jooble"
+
+    @property
+    def max_page_size(self) -> int:
+        return max(int(settings.JOOBLE_PAGE_SIZE), 1)
+
+    @property
+    def rate_limit_per_hour(self) -> int:
+        delay_seconds = max(float(settings.JOOBLE_INTER_REQUEST_DELAY), 0.1)
+        return max(int(3600 / delay_seconds), 1)
+
+    def map_filters(self, internal_filters: dict) -> dict:
+        """Convert canonical UAH filters into a Jooble POST body."""
+        payload: dict[str, Any] = {
+            "page": max(int(internal_filters.get("page") or 1), 1),
+            "ResultOnPage": self.max_page_size,
+        }
+        keywords = " ".join(str(internal_filters.get("keywords") or "").split())
+        if keywords:
+            payload["keywords"] = keywords
+        location = " ".join(str(internal_filters.get("location") or "").split())
+        if location:
+            payload["location"] = location
+        radius = " ".join(str(internal_filters.get("radius") or "").split())
+        if radius:
+            payload["radius"] = radius
+        salary = internal_filters.get("salary")
+        if salary not in {None, ""}:
+            payload["salary"] = int(salary)
+        if internal_filters.get("companysearch") is True:
+            payload["companysearch"] = "true"
+        return payload
+
+    def fetch(self, params: dict) -> list[NormalizedJob]:
+        """Fetch one page from Jooble and normalize the response."""
+        api_key = (settings.JOOBLE_API_KEY or "").strip()
+        if not api_key:
+            raise ProviderRequestFailed("Jooble API key is not configured.")
+
+        response = tracked_request(
+            provider_name=self.provider_name,
+            rate_limit_per_hour=self.rate_limit_per_hour,
+            method="POST",
+            url=f"https://jooble.org/api/{api_key}",
+            json_body=self.map_filters(params),
+            timeout_seconds=20.0,
+        )
+        if response.status_code != 200:
+            raise ProviderRequestFailed(
+                f"Jooble request failed with status {response.status_code}: {response.text[:200]}"
+            )
+
+        payload = response.json()
+        raw_jobs = payload.get("jobs") if isinstance(payload, dict) else payload
+        if not isinstance(raw_jobs, list):
+            return []
+
+        normalized: list[NormalizedJob] = []
+        for item in raw_jobs:
+            title = " ".join(str(item.get("title") or "").split())
+            company = " ".join(str(item.get("company") or "").split()) or None
+            location = " ".join(str(item.get("location") or "").split()) or None
+            description = clean_html_text(item.get("snippet"))
+            source = " ".join(str(item.get("source") or "").split()).lower()
+            type_value = " ".join(str(item.get("type") or "").split()) or None
+            source_tags = ["provider:jooble", "source:jooble_api"]
+            if source:
+                source_tags.append(f"upstream_source:{source}")
+
+            normalized.append(
+                NormalizedJob(
+                    provider=self.provider_name,
+                    provider_job_id=str(item.get("id")),
+                    provider_url=" ".join(str(item.get("link") or "").split()) or None,
+                    title=title,
+                    company=company,
+                    location=location,
+                    is_remote=infer_remote_flag(title=title, location=location, description=description),
+                    job_type=normalize_job_type([type_value] if type_value else []),
+                    experience_level=normalize_experience_level(title=title),
+                    categories=normalize_provider_categories(values=[type_value or "", source], title=title, description=description),
+                    description=description,
+                    published_at=None,
+                    source_tags=source_tags,
+                )
+            )
+
+        return normalized

--- a/backend/app/providers/registry.py
+++ b/backend/app/providers/registry.py
@@ -1,18 +1,266 @@
 from __future__ import annotations
 
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+from app.core.config import settings
+from app.providers.adzuna import AdzunaJobProvider
+from app.providers.arbeitnow import ArbeitnowJobProvider
 from app.providers.base import JobProvider
+from app.providers.careerjet import CareerjetJobProvider
+from app.providers.findwork import FindworkJobProvider
+from app.providers.jooble import JoobleJobProvider
 from app.providers.the_muse import TheMuseJobProvider
 
-_REGISTERED_PROVIDERS: dict[str, type[JobProvider]] = {
-    "the_muse": TheMuseJobProvider,
+SweepMode = Literal["category", "global", "matrix", "disabled"]
+ProviderState = Literal["active", "dormant"]
+
+
+@dataclass(frozen=True)
+class ProviderAttribution:
+    """Frontend attribution details for one provider."""
+
+    label: str
+    url: str
+    required: bool
+    logo_url: str | None = None
+    salary_label: str | None = None
+    salary_url: str | None = None
+
+
+@dataclass(frozen=True)
+class ProviderDefinition:
+    """Registry entry describing one upstream jobs provider."""
+
+    name: str
+    adapter_cls: type[JobProvider]
+    default_state: ProviderState
+    sweep_mode: SweepMode
+    scheduled_interval_minutes: int | None
+    attribution: ProviderAttribution
+    daily_request_budget: int | None = None
+    enable_in_thin_sync: bool = True
+
+
+@dataclass(frozen=True)
+class ProviderControls:
+    """Resolved enable/disable flags for one provider."""
+
+    ingest_enabled: bool
+    display_enabled: bool
+    scheduled_enabled: bool
+    status: str
+
+
+PROVIDER_ATTRIBUTION: dict[str, dict[str, str | bool | None]] = {
+    "the_muse": {
+        "label": "The Muse",
+        "url": "https://www.themuse.com",
+        "required": True,
+        "logo_url": None,
+    },
+    "adzuna": {
+        "label": "Jobs by Adzuna",
+        "url": "https://www.adzuna.co.uk",
+        "required": True,
+        "logo_url": "https://www.adzuna.co.uk/press.html",
+        "salary_label": "Adzuna Jobsworth",
+        "salary_url": "https://www.adzuna.co.uk/jobs/salary-predictor.html",
+    },
+    "arbeitnow": {
+        "label": "Arbeitnow",
+        "url": "https://www.arbeitnow.com",
+        "required": False,
+        "logo_url": None,
+    },
+    "findwork": {
+        "label": "Findwork",
+        "url": "https://findwork.dev",
+        "required": False,
+        "logo_url": None,
+    },
+    "jooble": {
+        "label": "Jooble",
+        "url": "https://jooble.org",
+        "required": False,
+        "logo_url": None,
+    },
+    "careerjet": {
+        "label": "Careerjet",
+        "url": "https://www.careerjet.com",
+        "required": False,
+        "logo_url": None,
+    },
 }
+
+_PROVIDER_DEFINITIONS: dict[str, ProviderDefinition] = {
+    # TODO: Register future providers here and extend the env control defaults at the same time.
+    "the_muse": ProviderDefinition(
+        name="the_muse",
+        adapter_cls=TheMuseJobProvider,
+        default_state="active",
+        sweep_mode="category",
+        scheduled_interval_minutes=None,
+        attribution=ProviderAttribution(**PROVIDER_ATTRIBUTION["the_muse"]),
+    ),
+    "arbeitnow": ProviderDefinition(
+        name="arbeitnow",
+        adapter_cls=ArbeitnowJobProvider,
+        default_state="active",
+        sweep_mode="global",
+        scheduled_interval_minutes=120,
+        attribution=ProviderAttribution(**PROVIDER_ATTRIBUTION["arbeitnow"]),
+    ),
+    "findwork": ProviderDefinition(
+        name="findwork",
+        adapter_cls=FindworkJobProvider,
+        default_state="dormant",
+        sweep_mode="global",
+        scheduled_interval_minutes=240,
+        attribution=ProviderAttribution(**PROVIDER_ATTRIBUTION["findwork"]),
+    ),
+    "jooble": ProviderDefinition(
+        name="jooble",
+        adapter_cls=JoobleJobProvider,
+        default_state="dormant",
+        sweep_mode="matrix",
+        scheduled_interval_minutes=360,
+        attribution=ProviderAttribution(**PROVIDER_ATTRIBUTION["jooble"]),
+    ),
+    "adzuna": ProviderDefinition(
+        name="adzuna",
+        adapter_cls=AdzunaJobProvider,
+        default_state="dormant",
+        sweep_mode="category",
+        scheduled_interval_minutes=720,
+        attribution=ProviderAttribution(**PROVIDER_ATTRIBUTION["adzuna"]),
+        daily_request_budget=max(int(settings.ADZUNA_DAILY_REQUEST_BUDGET), 1),
+    ),
+    "careerjet": ProviderDefinition(
+        name="careerjet",
+        adapter_cls=CareerjetJobProvider,
+        default_state="dormant",
+        sweep_mode="disabled",
+        scheduled_interval_minutes=None,
+        attribution=ProviderAttribution(**PROVIDER_ATTRIBUTION["careerjet"]),
+        enable_in_thin_sync=False,
+    ),
+}
+
+
+def _default_controls(definition: ProviderDefinition) -> ProviderControls:
+    ingest_enabled = definition.default_state == "active"
+    display_enabled = definition.default_state == "active"
+    scheduled_enabled = ingest_enabled and definition.sweep_mode != "disabled"
+    return ProviderControls(
+        ingest_enabled=ingest_enabled,
+        display_enabled=display_enabled,
+        scheduled_enabled=scheduled_enabled,
+        status="active" if ingest_enabled or display_enabled or scheduled_enabled else "dormant",
+    )
+
+
+def _resolve_status(*, ingest_enabled: bool, display_enabled: bool, scheduled_enabled: bool, default_state: ProviderState) -> str:
+    if ingest_enabled and display_enabled and (scheduled_enabled or default_state == "dormant"):
+        return "active"
+    if not ingest_enabled and not display_enabled and not scheduled_enabled:
+        return "dormant"
+    return "partial"
+
+
+def get_provider_catalog() -> dict[str, ProviderDefinition]:
+    """Return the full provider registry keyed by provider slug."""
+    return dict(_PROVIDER_DEFINITIONS)
+
+
+def get_provider_definition(provider_name: str) -> ProviderDefinition:
+    """Return one provider definition by its stable slug."""
+    normalized = (provider_name or "").strip().lower()
+    definition = _PROVIDER_DEFINITIONS.get(normalized)
+    if definition is None:
+        raise ValueError(f"Unsupported job provider '{provider_name}'")
+    return definition
+
+
+def get_provider_controls(provider_name: str) -> ProviderControls:
+    """Resolve ingest/display/schedule controls for one provider."""
+    definition = get_provider_definition(provider_name)
+    defaults = _default_controls(definition)
+    configured = settings.JOB_PROVIDER_CONTROLS.get(definition.name, {})
+
+    ingest_enabled = bool(configured.get("ingest_enabled", defaults.ingest_enabled))
+    display_enabled = bool(configured.get("display_enabled", defaults.display_enabled))
+    scheduled_enabled = bool(configured.get("scheduled_enabled", defaults.scheduled_enabled))
+
+    # Backward compatibility: legacy scheduled provider list can explicitly opt providers in.
+    if definition.name in settings.JOB_SYNC_ENABLED_PROVIDERS and definition.sweep_mode != "disabled":
+        scheduled_enabled = True
+
+    if not ingest_enabled:
+        scheduled_enabled = False
+
+    return ProviderControls(
+        ingest_enabled=ingest_enabled,
+        display_enabled=display_enabled,
+        scheduled_enabled=scheduled_enabled,
+        status=_resolve_status(
+            ingest_enabled=ingest_enabled,
+            display_enabled=display_enabled,
+            scheduled_enabled=scheduled_enabled,
+            default_state=definition.default_state,
+        ),
+    )
+
+
+def list_provider_statuses() -> list[dict[str, object]]:
+    """Return provider metadata plus resolved status flags for API consumers."""
+    statuses: list[dict[str, object]] = []
+    for definition in _PROVIDER_DEFINITIONS.values():
+        controls = get_provider_controls(definition.name)
+        statuses.append(
+            {
+                "provider": definition.name,
+                "default_state": definition.default_state,
+                "sweep_mode": definition.sweep_mode,
+                "scheduled_interval_minutes": definition.scheduled_interval_minutes,
+                "ingest_enabled": controls.ingest_enabled,
+                "display_enabled": controls.display_enabled,
+                "scheduled_enabled": controls.scheduled_enabled,
+                "status": controls.status,
+                "attribution": asdict(definition.attribution),
+            }
+        )
+    return statuses
+
+
+def list_enabled_provider_names(*, control_name: Literal["ingest", "display", "scheduled"]) -> list[str]:
+    """Return provider slugs that are enabled for the requested control plane."""
+    enabled: list[str] = []
+    for definition in _PROVIDER_DEFINITIONS.values():
+        controls = get_provider_controls(definition.name)
+        if control_name == "ingest" and controls.ingest_enabled:
+            enabled.append(definition.name)
+        elif control_name == "display" and controls.display_enabled:
+            enabled.append(definition.name)
+        elif control_name == "scheduled" and controls.scheduled_enabled:
+            enabled.append(definition.name)
+    return enabled
+
+
+def list_thin_sync_provider_names() -> list[str]:
+    """Return providers that should participate in thin-result sync triggers."""
+    providers: list[str] = []
+    for definition in _PROVIDER_DEFINITIONS.values():
+        controls = get_provider_controls(definition.name)
+        if not controls.ingest_enabled or not controls.scheduled_enabled or not definition.enable_in_thin_sync:
+            continue
+        if definition.sweep_mode == "disabled":
+            continue
+        providers.append(definition.name)
+    return providers
 
 
 def get_adapter(provider_name: str) -> JobProvider:
     """Return a provider adapter instance for the requested provider."""
-    normalized = (provider_name or "").strip().lower()
-    provider_cls = _REGISTERED_PROVIDERS.get(normalized)
-    if provider_cls is None:
-        raise ValueError(f"Unsupported job provider '{provider_name}'")
-    # TODO: If UAH adds pluggable providers later, load adapters from a registry/config module here.
-    return provider_cls()
+    definition = get_provider_definition(provider_name)
+    return definition.adapter_cls()

--- a/backend/app/services/ingest.py
+++ b/backend/app/services/ingest.py
@@ -14,7 +14,7 @@ from app.api.routes import _expand_category_for_muse
 from app.core.config import settings
 from app.db.session import session_scope
 from app.models.job import Job
-from app.providers.registry import get_adapter
+from app.providers.registry import get_adapter, get_provider_controls
 from app.schemas.job import NormalizedJob
 from app.services.job_link_health import (
     build_source_tags,
@@ -26,6 +26,24 @@ from app.services.job_link_health import (
 logger = logging.getLogger(__name__)
 
 _SPAM_PUNCTUATION_RE = re.compile(r"[!$#?*]{3,}")
+_DEDUP_NOISE_WORDS = (
+    "senior",
+    "sr",
+    "jr",
+    "junior",
+    "lead",
+    "staff",
+    "principal",
+    "associate",
+    "remote",
+    "hybrid",
+    "inc",
+    "llc",
+    "ltd",
+    "corp",
+    "corporation",
+    "co",
+)
 
 
 def compute_display_tier(*, is_active: bool, last_seen_at: datetime | None, reference_time: datetime | None = None) -> str:
@@ -133,6 +151,27 @@ def compute_content_fingerprint(job: NormalizedJob) -> str:
         ]
     )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def compute_dedup_hash(title: str | None, company: str | None) -> str | None:
+    """Return a normalized cross-provider dedup hash from title and company."""
+    if not title or not company:
+        return None
+
+    def normalize(value: str) -> str:
+        cleaned = value.lower().strip()
+        cleaned = re.sub(r"[^\w\s]", "", cleaned)
+        cleaned = re.sub(r"\s+", " ", cleaned)
+        for noise in _DEDUP_NOISE_WORDS:
+            cleaned = re.sub(rf"\b{noise}\b", "", cleaned)
+        cleaned = re.sub(r"\s+", " ", cleaned)
+        return cleaned.strip()
+
+    normalized_title = normalize(title)
+    normalized_company = normalize(company)
+    if not normalized_title or not normalized_company:
+        return None
+    return hashlib.md5(f"{normalized_title}|{normalized_company}".encode("utf-8")).hexdigest()
 
 
 def _merge_unique_values(*collections: list[str]) -> list[str]:
@@ -381,12 +420,16 @@ def _build_job_payload(job: NormalizedJob, *, existing: Job | None, link_health:
             "staleness_flags": list(staleness["staleness_flags"] or []),
             "staleness_checked_at": staleness["staleness_checked_at"],
             "repost_count": staleness["repost_count"],
+            "dedup_hash": compute_dedup_hash(job.title, job.company),
         },
     }
 
 
 def upsert_job(job: NormalizedJob, db_session=None, provider_adapter=None) -> tuple[str, bool]:
     """Insert or update a normalized job and refresh its link-health and stale-listing metadata."""
+    controls = get_provider_controls(job.provider)
+    if not controls.ingest_enabled:
+        return "disabled", False
     adapter = provider_adapter or get_adapter(job.provider)
     reference_time = datetime.now(timezone.utc)
     manager = nullcontext(db_session) if db_session is not None else session_scope()
@@ -402,6 +445,56 @@ def upsert_job(job: NormalizedJob, db_session=None, provider_adapter=None) -> tu
             return "rejected", False
 
         payload = payload_result["payload"]
+        dedup_hash = payload.get("dedup_hash")
+        duplicate_owner = None
+        if settings.JOB_DEDUP_ENABLED and dedup_hash:
+            duplicate_query = (
+                db.query(Job)
+                .filter(
+                    Job.dedup_hash == dedup_hash,
+                    Job.is_active.is_(True),
+                    Job.provider != job.provider,
+                )
+                .order_by(Job.first_seen_at.asc(), Job.id.asc())
+            )
+            if existing is not None:
+                duplicate_query = duplicate_query.filter(Job.id != existing.id)
+            duplicate_owner = duplicate_query.first()
+
+        if duplicate_owner is not None:
+            duplicate_owner.last_seen_at = reference_time
+            duplicate_owner.consecutive_misses = 0
+            duplicate_owner.display_tier = compute_display_tier(
+                is_active=bool(duplicate_owner.is_active),
+                last_seen_at=reference_time,
+                reference_time=reference_time,
+            )
+            duplicate_owner.source_tags = _merge_unique_values(
+                list(duplicate_owner.source_tags or []),
+                [f"duplicate_provider:{job.provider}"],
+            )
+            if existing is not None and existing.id != duplicate_owner.id:
+                existing.is_active = False
+                existing.display_tier = compute_display_tier(
+                    is_active=False,
+                    last_seen_at=reference_time,
+                    reference_time=reference_time,
+                )
+                existing.last_seen_at = reference_time
+                existing.consecutive_misses = 0
+                existing.dedup_hash = None
+            db.commit()
+            if settings.JOB_DEDUP_LOG_COLLISIONS:
+                logger.info(
+                    "Cross-provider dedup matched %s/%s to %s/%s via %s",
+                    job.provider,
+                    job.provider_job_id,
+                    duplicate_owner.provider,
+                    duplicate_owner.provider_job_id,
+                    dedup_hash,
+                )
+            return "duplicate", False
+
         statement = insert(Job).values(**payload)
         statement = statement.on_conflict_do_update(
             index_elements=["provider", "provider_job_id"],
@@ -441,6 +534,7 @@ def upsert_job(job: NormalizedJob, db_session=None, provider_adapter=None) -> tu
                 "staleness_flags": payload["staleness_flags"],
                 "staleness_checked_at": payload["staleness_checked_at"],
                 "repost_count": payload["repost_count"],
+                "dedup_hash": payload["dedup_hash"],
             },
         )
         db.execute(statement)

--- a/backend/app/services/job_search.py
+++ b/backend/app/services/job_search.py
@@ -7,6 +7,7 @@ from sqlalchemy import or_
 
 from app.api.routes import _build_jobs_filter_metadata_payload, _expand_category_for_muse, _parse_posted_after_input
 from app.models.job import Job
+from app.providers.registry import list_enabled_provider_names
 
 
 def _dedupe(values: list[str]) -> list[str]:
@@ -113,9 +114,14 @@ def search_local_jobs(
     posted_after: str | None = None,
 ) -> dict:
     """Query locally cached jobs only and return compatibility pagination metadata."""
+    display_enabled_providers = list_enabled_provider_names(control_name="display")
     query = db.query(Job).filter(Job.is_active.is_(True)).filter(
         or_(Job.provider_url_status.is_(None), Job.provider_url_status != "bad")
     )
+    if not display_enabled_providers:
+        query = query.filter(False)
+    else:
+        query = query.filter(Job.provider.in_(display_enabled_providers))
 
     normalized_tier = (tier or "active").strip().lower()
     if normalized_tier == "active":

--- a/backend/app/services/provider_requests.py
+++ b/backend/app/services/provider_requests.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 import logging
 
 import httpx
+from sqlalchemy import func
 
 from app.db.session import session_scope
 from app.models.job import QuotaUsage
@@ -38,6 +39,42 @@ def _confirm_quota(provider_name: str, rate_limit_per_hour: int, db) -> bool:
     return int(row.request_count or 0) < threshold
 
 
+def _daily_request_count(provider_name: str, db, *, day: date | None = None) -> int:
+    reference_day = day or datetime.now(timezone.utc).date()
+    count = (
+        db.query(func.coalesce(func.sum(QuotaUsage.request_count), 0))
+        .filter(
+            QuotaUsage.provider == provider_name,
+            func.date(QuotaUsage.hour_bucket) == reference_day,
+        )
+        .scalar()
+    )
+    return int(count or 0)
+
+
+def _confirm_daily_budget(provider_name: str, daily_request_budget: int, db) -> bool:
+    if int(daily_request_budget or 0) <= 0:
+        return True
+    return _daily_request_count(provider_name, db) < max(int(daily_request_budget), 1)
+
+
+def confirm_request_budget(
+    *,
+    provider_name: str,
+    rate_limit_per_hour: int,
+    daily_request_budget: int | None = None,
+    db_session=None,
+) -> bool:
+    """Return True when a provider is still within its configured request budgets."""
+    manager = nullcontext(db_session) if db_session is not None else session_scope()
+    with manager as db:
+        if not _confirm_quota(provider_name, rate_limit_per_hour, db):
+            return False
+        if daily_request_budget is not None and not _confirm_daily_budget(provider_name, daily_request_budget, db):
+            return False
+        return True
+
+
 def tracked_request(
     *,
     provider_name: str,
@@ -46,7 +83,9 @@ def tracked_request(
     url: str,
     params: dict | None = None,
     headers: dict | None = None,
+    json_body: dict | None = None,
     timeout_seconds: float = 10.0,
+    daily_request_budget: int | None = None,
     db_session=None,
 ):
     """Perform one tracked outbound provider request and increment hourly quota usage."""
@@ -55,6 +94,10 @@ def tracked_request(
         if not _confirm_quota(provider_name, rate_limit_per_hour, db):
             raise ProviderQuotaExceeded(
                 f"Provider '{provider_name}' is at or above its configured hourly quota threshold."
+            )
+        if daily_request_budget is not None and not _confirm_daily_budget(provider_name, daily_request_budget, db):
+            raise ProviderQuotaExceeded(
+                f"Provider '{provider_name}' is at or above its configured daily request budget."
             )
 
         bucket = _hour_bucket()
@@ -72,7 +115,13 @@ def tracked_request(
 
     try:
         with httpx.Client(timeout=max(float(timeout_seconds), 1.0)) as client:
-            return client.request(method=method.upper(), url=url, params=params, headers=headers)
+            return client.request(
+                method=method.upper(),
+                url=url,
+                params=params,
+                headers=headers,
+                json=json_body,
+            )
     except httpx.HTTPError as exc:
         logger.warning("Provider request failed for %s %s: %s", provider_name, url, exc)
         raise ProviderRequestFailed(str(exc)) from exc

--- a/backend/app/tasks/job_sync.py
+++ b/backend/app/tasks/job_sync.py
@@ -9,8 +9,14 @@ import redis
 
 from app.core.config import settings
 from app.db.session import session_scope
-from app.models.job import Job, ProviderSyncLog, QuotaUsage
-from app.providers.registry import get_adapter
+from app.models.job import Job, ProviderSyncLog
+from app.providers.registry import (
+    get_adapter,
+    get_provider_controls,
+    get_provider_definition,
+    list_enabled_provider_names,
+    list_thin_sync_provider_names,
+)
 from app.services.ingest import (
     audit_stale_jobs_batch,
     backfill_job_health_batch,
@@ -18,16 +24,34 @@ from app.services.ingest import (
     run_cleanup,
     upsert_job,
 )
-from app.services.provider_requests import ProviderQuotaExceeded
+from app.services.provider_requests import ProviderQuotaExceeded, confirm_request_budget
 from app.worker import celery_app
 
 logger = logging.getLogger(__name__)
 
+JOOBLE_KEYWORDS = [
+    "software engineer",
+    "product manager",
+    "data engineer",
+    "devops",
+    "designer",
+]
+JOOBLE_LOCATIONS = [
+    "United States",
+    "Remote",
+    "New York",
+    "San Francisco",
+    "Boston",
+    "Seattle",
+    "Austin",
+]
+
 _redis_client: redis.Redis | None = None
 
 
-def _lock_key(provider: str, category: str) -> str:
-    return f"uah:job_sync:lock:{provider}:{category}"
+def _lock_key(provider: str, category: str | None = None) -> str:
+    suffix = (category or "__all__").strip().lower()
+    return f"uah:job_sync:lock:{provider}:{suffix}"
 
 
 def _cleanup_lock_key() -> str:
@@ -71,7 +95,7 @@ def _release_lock(key: str) -> None:
         logger.debug("Failed to release Redis lock %s", key)
 
 
-def _lock_exists(provider: str, category: str) -> bool:
+def _lock_exists(provider: str, category: str | None = None) -> bool:
     client = _get_redis_client()
     if client is None:
         return False
@@ -86,21 +110,10 @@ def _category_sort_key(item: tuple[str, dict[str, int]]) -> tuple[int, str]:
     return (int(config.get("priority", 100)), category)
 
 
-def confirm_quota(provider: str, db_session=None) -> bool:
-    """Return True when the provider is still below the soft hourly quota threshold."""
-    adapter = get_adapter(provider)
-    manager = nullcontext(db_session) if db_session is not None else session_scope()
-    with manager as db:
-        bucket = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
-        row = (
-            db.query(QuotaUsage)
-            .filter(QuotaUsage.provider == provider, QuotaUsage.hour_bucket == bucket)
-            .first()
-        )
-        if row is None:
-            return True
-        threshold = max(int(adapter.rate_limit_per_hour * 0.8), 1)
-        return int(row.request_count or 0) < threshold
+def _sync_anchor(row: ProviderSyncLog | None) -> datetime | None:
+    if row is None:
+        return None
+    return row.completed_at or row.started_at
 
 
 def _compute_fresh_ratio(provider: str, jobs: list, db_session=None) -> float:
@@ -123,10 +136,232 @@ def _compute_fresh_ratio(provider: str, jobs: list, db_session=None) -> float:
         return fresh_matches / len(provider_job_ids)
 
 
-def _sync_anchor(row: ProviderSyncLog | None) -> datetime | None:
-    if row is None:
-        return None
-    return row.completed_at or row.started_at
+def _page_start_for_provider(provider: str) -> int:
+    if provider == "the_muse":
+        return 0
+    return 1
+
+
+def _provider_sleep_seconds(provider: str) -> float:
+    adapter = get_adapter(provider)
+    return max(3600 / max(adapter.rate_limit_per_hour, 1), 0.0)
+
+
+def confirm_quota(provider: str, db_session=None) -> bool:
+    """Return True when the provider is still below its configured request budgets."""
+    definition = get_provider_definition(provider)
+    adapter = get_adapter(provider)
+    return confirm_request_budget(
+        provider_name=provider,
+        rate_limit_per_hour=adapter.rate_limit_per_hour,
+        daily_request_budget=definition.daily_request_budget,
+        db_session=db_session,
+    )
+
+
+def _create_sync_log(provider: str, category: str | None = None):
+    with session_scope() as db:
+        log_row = ProviderSyncLog(
+            provider=provider,
+            category=category,
+            started_at=datetime.now(timezone.utc),
+        )
+        db.add(log_row)
+        db.commit()
+        db.refresh(log_row)
+        return log_row.id
+
+
+def _finalize_sync_log(
+    *,
+    log_id: str | None,
+    pages_fetched: int = 0,
+    jobs_found: int = 0,
+    jobs_new: int = 0,
+    jobs_updated: int = 0,
+    jobs_deduplicated: int = 0,
+    requests_used: int = 0,
+    stopped_reason: str | None = None,
+    error_message: str | None = None,
+) -> None:
+    if log_id is None:
+        return
+    with session_scope() as db:
+        log_row = db.query(ProviderSyncLog).filter(ProviderSyncLog.id == log_id).first()
+        if log_row is None:
+            return
+        log_row.completed_at = datetime.now(timezone.utc)
+        log_row.pages_fetched = pages_fetched
+        log_row.jobs_found = jobs_found
+        log_row.jobs_new = jobs_new
+        log_row.jobs_updated = jobs_updated
+        log_row.jobs_deduplicated = jobs_deduplicated
+        log_row.requests_used = requests_used
+        log_row.stopped_reason = stopped_reason
+        log_row.error_message = error_message
+        db.commit()
+
+
+def _process_jobs_page(provider: str, jobs: list, seen_ids: set[str]) -> tuple[int, int, int, float]:
+    jobs_new = 0
+    jobs_updated = 0
+    jobs_deduplicated = 0
+    fresh_ratio = _compute_fresh_ratio(provider, jobs)
+    with session_scope() as db:
+        adapter = get_adapter(provider)
+        for job in jobs:
+            seen_ids.add(job.provider_job_id)
+            state, _ = upsert_job(job, db_session=db, provider_adapter=adapter)
+            if state == "inserted":
+                jobs_new += 1
+            elif state == "updated":
+                jobs_updated += 1
+            elif state == "duplicate":
+                jobs_deduplicated += 1
+    return jobs_new, jobs_updated, jobs_deduplicated, fresh_ratio
+
+
+def _run_linear_page_sweep(provider: str, base_params: dict, seen_ids: set[str]) -> dict[str, int | str]:
+    adapter = get_adapter(provider)
+    page = max(int(base_params.get("page") or _page_start_for_provider(provider)), _page_start_for_provider(provider))
+    pages_fetched = 0
+    jobs_found = 0
+    jobs_new = 0
+    jobs_updated = 0
+    jobs_deduplicated = 0
+    requests_used = 0
+    stop_reason = "no_more_pages"
+
+    while True:
+        if not confirm_quota(provider):
+            stop_reason = "quota_threshold_hit"
+            break
+
+        params = dict(base_params)
+        params["page"] = page
+        jobs = adapter.fetch(params)
+        requests_used += 1
+        pages_fetched += 1
+
+        if not jobs:
+            stop_reason = "no_more_pages"
+            break
+
+        jobs_found += len(jobs)
+        page_new, page_updated, page_deduplicated, fresh_ratio = _process_jobs_page(provider, jobs, seen_ids)
+        jobs_new += page_new
+        jobs_updated += page_updated
+        jobs_deduplicated += page_deduplicated
+
+        if fresh_ratio >= 0.80:
+            stop_reason = "threshold_hit"
+            break
+
+        if len(jobs) < adapter.max_page_size:
+            stop_reason = "no_more_pages"
+            break
+
+        page += 1
+        sleep_seconds = _provider_sleep_seconds(provider)
+        if sleep_seconds > 0:
+            time.sleep(min(sleep_seconds, 10.0))
+
+    return {
+        "pages_fetched": pages_fetched,
+        "jobs_found": jobs_found,
+        "jobs_new": jobs_new,
+        "jobs_updated": jobs_updated,
+        "jobs_deduplicated": jobs_deduplicated,
+        "requests_used": requests_used,
+        "stopped_reason": stop_reason,
+    }
+
+
+def _run_provider_sweep(provider: str, *, category: str | None = None) -> dict[str, int | str | None]:
+    definition = get_provider_definition(provider)
+    controls = get_provider_controls(provider)
+    if not controls.ingest_enabled:
+        return {"status": "disabled", "provider": provider, "category": category}
+
+    seen_ids: set[str] = set()
+    totals = {
+        "pages_fetched": 0,
+        "jobs_found": 0,
+        "jobs_new": 0,
+        "jobs_updated": 0,
+        "jobs_deduplicated": 0,
+        "requests_used": 0,
+        "stopped_reason": "no_more_pages",
+    }
+
+    if definition.sweep_mode == "category":
+        stats = _run_linear_page_sweep(provider, {"category": [category] if category else []}, seen_ids)
+        totals.update(stats)
+        mark_unseen_jobs(provider=provider, category=category, seen_ids=seen_ids)
+    elif definition.sweep_mode == "global":
+        stats = _run_linear_page_sweep(provider, {}, seen_ids)
+        totals.update(stats)
+        mark_unseen_jobs(provider=provider, category=None, seen_ids=seen_ids)
+    elif definition.sweep_mode == "matrix":
+        stop_reason = "matrix_complete"
+        for keyword in JOOBLE_KEYWORDS:
+            for location in JOOBLE_LOCATIONS:
+                stats = _run_linear_page_sweep(provider, {"keywords": keyword, "location": location}, seen_ids)
+                for key in ("pages_fetched", "jobs_found", "jobs_new", "jobs_updated", "jobs_deduplicated", "requests_used"):
+                    totals[key] += int(stats[key])
+                stop_reason = str(stats["stopped_reason"])
+                if stop_reason == "quota_threshold_hit":
+                    totals["stopped_reason"] = stop_reason
+                    mark_unseen_jobs(provider=provider, category=None, seen_ids=seen_ids)
+                    return totals
+        totals["stopped_reason"] = stop_reason
+        mark_unseen_jobs(provider=provider, category=None, seen_ids=seen_ids)
+    else:
+        return {"status": "disabled", "provider": provider, "category": category}
+
+    return totals
+
+
+def _provider_due_for_dispatch(provider: str, *, category: str | None = None, interval_minutes: int) -> bool:
+    if _lock_exists(provider, category):
+        return False
+    now = datetime.now(timezone.utc)
+    with session_scope() as db:
+        latest = (
+            db.query(ProviderSyncLog)
+            .filter(ProviderSyncLog.provider == provider, ProviderSyncLog.category == category)
+            .order_by(ProviderSyncLog.started_at.desc())
+            .first()
+        )
+    anchor = _sync_anchor(latest)
+    if anchor is None:
+        return True
+    return (now - anchor) >= timedelta(minutes=max(int(interval_minutes), 5))
+
+
+def _rotated_category_items(now: datetime) -> list[tuple[str, dict[str, int]]]:
+    items = sorted(settings.JOB_SYNC_CATEGORY_SCHEDULE.items(), key=_category_sort_key)
+    if not items:
+        return []
+    index = now.toordinal() % len(items)
+    return [items[index]]
+
+
+def queue_thin_results_sync(category: str) -> list[dict[str, str]]:
+    """Queue provider sweeps that can help refill thin local job results."""
+    # TODO: When a future provider needs special thin-result behavior, branch on its sweep mode here.
+    queued: list[dict[str, str]] = []
+    for provider in list_thin_sync_provider_names():
+        definition = get_provider_definition(provider)
+        if definition.sweep_mode == "category":
+            if not _lock_exists(provider, category):
+                sweep_category.delay(provider=provider, category=category)
+                queued.append({"provider": provider, "category": category})
+        elif definition.sweep_mode in {"global", "matrix"}:
+            if not _lock_exists(provider, None):
+                sweep_provider.delay(provider=provider)
+                queued.append({"provider": provider, "category": ""})
+    return queued
 
 
 @celery_app.task(
@@ -138,111 +373,70 @@ def _sync_anchor(row: ProviderSyncLog | None) -> datetime | None:
     retry_kwargs={"max_retries": 3},
 )
 def sweep_category(self, provider: str, category: str):
-    """Fetch one provider/category slice, upsert rows, and expire unseen jobs."""
+    """Fetch one provider/category slice, upsert rows, and expire unseen jobs for that category."""
     lock_key = _lock_key(provider, category)
     if not _acquire_lock(lock_key, int(settings.JOB_SYNC_LOCK_TTL_SECONDS)):
         return {"status": "skipped_locked", "provider": provider, "category": category}
 
     log_id = None
     try:
-        adapter = get_adapter(provider)
-        with session_scope() as db:
-            log_row = ProviderSyncLog(provider=provider, category=category, started_at=datetime.now(timezone.utc))
-            db.add(log_row)
-            db.commit()
-            db.refresh(log_row)
-            log_id = log_row.id
+        definition = get_provider_definition(provider)
+        if definition.sweep_mode != "category":
+            return {"status": "unsupported_scope", "provider": provider, "category": category}
 
-        seen_ids: set[str] = set()
-        pages_fetched = 0
-        jobs_found = 0
-        jobs_new = 0
-        jobs_updated = 0
-        requests_used = 0
-        stop_reason = "no_more_pages"
-        page = 0
-        min_interval = 3600 / max(adapter.rate_limit_per_hour, 1)
+        log_id = _create_sync_log(provider=provider, category=category)
+        stats = _run_provider_sweep(provider, category=category)
+        if stats.get("status") == "disabled":
+            _finalize_sync_log(log_id=log_id, stopped_reason="disabled")
+            return stats
 
-        while True:
-            if not confirm_quota(provider):
-                stop_reason = "quota_threshold_hit"
-                break
-
-            jobs = adapter.fetch({"category": [category], "page": page})
-            requests_used += 1
-            pages_fetched += 1
-
-            if not jobs:
-                stop_reason = "no_more_pages"
-                break
-
-            jobs_found += len(jobs)
-            fresh_ratio = _compute_fresh_ratio(provider, jobs)
-
-            with session_scope() as db:
-                for job in jobs:
-                    seen_ids.add(job.provider_job_id)
-                    state, _ = upsert_job(job, db_session=db)
-                    if state == "inserted":
-                        jobs_new += 1
-                    elif state == "updated":
-                        jobs_updated += 1
-
-            if fresh_ratio >= 0.80:
-                stop_reason = "threshold_hit"
-                break
-
-            if len(jobs) < adapter.max_page_size:
-                stop_reason = "no_more_pages"
-                break
-
-            page += 1
-            if min_interval > 0:
-                time.sleep(min(min_interval, 10.0))
-
-        mark_unseen_jobs(provider=provider, category=category, seen_ids=seen_ids)
-
-        with session_scope() as db:
-            log_row = db.query(ProviderSyncLog).filter(ProviderSyncLog.id == log_id).first()
-            if log_row is not None:
-                log_row.completed_at = datetime.now(timezone.utc)
-                log_row.pages_fetched = pages_fetched
-                log_row.jobs_found = jobs_found
-                log_row.jobs_new = jobs_new
-                log_row.jobs_updated = jobs_updated
-                log_row.requests_used = requests_used
-                log_row.stopped_reason = stop_reason
-                db.commit()
-
-        return {
-            "status": "completed",
-            "provider": provider,
-            "category": category,
-            "pages_fetched": pages_fetched,
-            "jobs_found": jobs_found,
-            "jobs_new": jobs_new,
-            "jobs_updated": jobs_updated,
-            "requests_used": requests_used,
-            "stopped_reason": stop_reason,
-        }
+        _finalize_sync_log(log_id=log_id, **stats)
+        status = "quota_threshold_hit" if stats.get("stopped_reason") == "quota_threshold_hit" else "completed"
+        return {"status": status, "provider": provider, "category": category, **stats}
     except ProviderQuotaExceeded:
-        with session_scope() as db:
-            if log_id is not None:
-                log_row = db.query(ProviderSyncLog).filter(ProviderSyncLog.id == log_id).first()
-                if log_row is not None:
-                    log_row.completed_at = datetime.now(timezone.utc)
-                    log_row.stopped_reason = "quota_threshold_hit"
-                    db.commit()
+        _finalize_sync_log(log_id=log_id, stopped_reason="quota_threshold_hit")
         return {"status": "quota_threshold_hit", "provider": provider, "category": category}
     except Exception as exc:
-        with session_scope() as db:
-            if log_id is not None:
-                log_row = db.query(ProviderSyncLog).filter(ProviderSyncLog.id == log_id).first()
-                if log_row is not None:
-                    log_row.completed_at = datetime.now(timezone.utc)
-                    log_row.stopped_reason = "error"
-                    log_row.error_message = str(exc)
-                    db.commit()
+        _finalize_sync_log(log_id=log_id, stopped_reason="error", error_message=str(exc))
+        raise
+    finally:
+        _release_lock(lock_key)
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.job_sync.sweep_provider",
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+    retry_jitter=True,
+    retry_kwargs={"max_retries": 3},
+)
+def sweep_provider(self, provider: str):
+    """Fetch one provider-wide sweep scope for global or matrix providers."""
+    lock_key = _lock_key(provider, None)
+    if not _acquire_lock(lock_key, int(settings.JOB_SYNC_LOCK_TTL_SECONDS)):
+        return {"status": "skipped_locked", "provider": provider}
+
+    log_id = None
+    try:
+        definition = get_provider_definition(provider)
+        if definition.sweep_mode not in {"global", "matrix"}:
+            return {"status": "unsupported_scope", "provider": provider}
+
+        log_id = _create_sync_log(provider=provider, category=None)
+        stats = _run_provider_sweep(provider, category=None)
+        if stats.get("status") == "disabled":
+            _finalize_sync_log(log_id=log_id, stopped_reason="disabled")
+            return stats
+
+        _finalize_sync_log(log_id=log_id, **stats)
+        status = "quota_threshold_hit" if stats.get("stopped_reason") == "quota_threshold_hit" else "completed"
+        return {"status": status, "provider": provider, **stats}
+    except ProviderQuotaExceeded:
+        _finalize_sync_log(log_id=log_id, stopped_reason="quota_threshold_hit")
+        return {"status": "quota_threshold_hit", "provider": provider}
+    except Exception as exc:
+        _finalize_sync_log(log_id=log_id, stopped_reason="error", error_message=str(exc))
         raise
     finally:
         _release_lock(lock_key)
@@ -257,34 +451,39 @@ def sweep_category(self, provider: str, category: str):
     retry_kwargs={"max_retries": 3},
 )
 def dispatch_scheduled_sweeps(self):
-    """Queue sweeps for provider/category pairs that are currently due."""
+    """Queue scheduled provider sweeps based on the provider registry and controls."""
     if not settings.JOB_SYNC_ENABLED:
         return {"queued": []}
 
     queued: list[dict[str, str]] = []
     now = datetime.now(timezone.utc)
-    schedule = settings.JOB_SYNC_CATEGORY_SCHEDULE
+    # TODO: Add provider-specific dispatch rules here when a future provider needs a custom cadence.
+    for provider in sorted(list_enabled_provider_names(control_name="scheduled")):
+        definition = get_provider_definition(provider)
+        controls = get_provider_controls(provider)
+        if not controls.scheduled_enabled:
+            continue
+        if not confirm_quota(provider):
+            continue
 
-    with session_scope() as db:
-        # TODO: If UAH adds provider-specific schedules or enablement rules, branch that logic here.
-        for provider in settings.JOB_SYNC_ENABLED_PROVIDERS:
-            for category, config in sorted(schedule.items(), key=_category_sort_key):
-                if _lock_exists(provider, category):
+        if definition.sweep_mode == "category":
+            category_items = sorted(settings.JOB_SYNC_CATEGORY_SCHEDULE.items(), key=_category_sort_key)
+            if provider == "adzuna":
+                category_items = _rotated_category_items(now)
+            for category, config in category_items:
+                interval = int(config.get("interval_minutes", definition.scheduled_interval_minutes or 60))
+                if definition.scheduled_interval_minutes is not None:
+                    interval = max(interval, int(definition.scheduled_interval_minutes))
+                if not _provider_due_for_dispatch(provider, category=category, interval_minutes=interval):
                     continue
-
-                latest = (
-                    db.query(ProviderSyncLog)
-                    .filter(ProviderSyncLog.provider == provider, ProviderSyncLog.category == category)
-                    .order_by(ProviderSyncLog.started_at.desc())
-                    .first()
-                )
-                anchor = _sync_anchor(latest)
-                interval_minutes = max(int(config.get("interval_minutes", 60)), 5)
-                if anchor is not None and (now - anchor) < timedelta(minutes=interval_minutes):
-                    continue
-
                 sweep_category.delay(provider=provider, category=category)
                 queued.append({"provider": provider, "category": category})
+        elif definition.sweep_mode in {"global", "matrix"}:
+            interval = max(int(definition.scheduled_interval_minutes or 60), 5)
+            if not _provider_due_for_dispatch(provider, category=None, interval_minutes=interval):
+                continue
+            sweep_provider.delay(provider=provider)
+            queued.append({"provider": provider, "category": ""})
 
     return {"queued": queued}
 

--- a/backend/tests/test_jobs_ingest.py
+++ b/backend/tests/test_jobs_ingest.py
@@ -9,6 +9,7 @@ from app.services.ingest import (
     _build_job_payload,
     _evaluate_staleness,
     build_short_description,
+    compute_dedup_hash,
     compute_content_fingerprint,
     compute_display_tier,
     compute_quality_score,
@@ -76,6 +77,13 @@ class IngestServiceTests(unittest.TestCase):
         self.assertGreaterEqual(score, 0.0)
         self.assertLess(score, 1.0)
         self.assertLessEqual(len(short), 40)
+
+    def test_compute_dedup_hash_normalizes_common_noise(self):
+        first = compute_dedup_hash("Senior Software Engineer - Remote", "Acme, Inc.")
+        second = compute_dedup_hash("Software Engineer", "Acme")
+
+        self.assertIsNotNone(first)
+        self.assertEqual(first, second)
 
     def test_display_tier_windows(self):
         now = datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc)
@@ -187,6 +195,10 @@ class IngestServiceTests(unittest.TestCase):
         self.assertTrue(stored["should_store"])
         self.assertEqual(stored["payload"]["apply_portal"], "ashby")
         self.assertIn("apply_portal:ashby", stored["payload"]["source_tags"])
+        self.assertEqual(
+            stored["payload"]["dedup_hash"],
+            compute_dedup_hash("Software Engineer", "Acme"),
+        )
 
     def test_backfill_and_stale_audit_guards(self):
         now = datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc)

--- a/backend/tests/test_jobs_provider_arbeitnow.py
+++ b/backend/tests/test_jobs_provider_arbeitnow.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import unittest
+from unittest.mock import patch
+
+from app.providers.arbeitnow import ArbeitnowJobProvider
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class ArbeitnowProviderTests(unittest.TestCase):
+    def test_map_filters_keeps_page_and_optional_flags(self):
+        provider = ArbeitnowJobProvider()
+        params = provider.map_filters({"page": 2, "is_remote": True, "visa_sponsorship": True})
+
+        self.assertEqual(params["page"], 2)
+        self.assertTrue(params["remote"])
+        self.assertTrue(params["visa_sponsorship"])
+
+    def test_fetch_normalizes_payload_and_post_filters_remote(self):
+        provider = ArbeitnowJobProvider()
+        payload = {
+            "data": [
+                {
+                    "slug": "backend-engineer",
+                    "title": "Backend Engineer",
+                    "company_name": "Acme GmbH",
+                    "location": "Berlin",
+                    "description": "<p>Build backend APIs and platform services for customers.</p>",
+                    "remote": True,
+                    "url": "https://jobs.ashbyhq.com/acme/123",
+                    "job_types": ["full-time", "berufseinstieg"],
+                    "tags": ["python", "backend"],
+                    "created_at": 1713000000,
+                },
+                {
+                    "slug": "office-manager",
+                    "title": "Office Manager",
+                    "company_name": "Acme GmbH",
+                    "location": "Berlin",
+                    "description": "<p>Support office operations.</p>",
+                    "remote": False,
+                    "url": "https://jobs.ashbyhq.com/acme/456",
+                    "job_types": ["full-time"],
+                    "tags": ["operations"],
+                    "created_at": 1713000000,
+                },
+            ]
+        }
+
+        with patch("app.providers.arbeitnow.tracked_request", return_value=_FakeResponse(payload=payload)):
+            jobs = provider.fetch({"page": 1, "is_remote": True})
+
+        self.assertEqual(len(jobs), 1)
+        job = jobs[0]
+        self.assertEqual(job.provider, "arbeitnow")
+        self.assertEqual(job.provider_job_id, "backend-engineer")
+        self.assertEqual(job.apply_url, "https://jobs.ashbyhq.com/acme/123")
+        self.assertTrue(job.is_remote)
+        self.assertEqual(job.job_type, "full_time")
+        self.assertEqual(job.experience_level, "entry")
+        self.assertIn("Software Engineering", job.categories)
+        self.assertEqual(job.published_at, datetime.fromtimestamp(1713000000, tz=timezone.utc))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_jobs_provider_careerjet.py
+++ b/backend/tests/test_jobs_provider_careerjet.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import unittest
+
+from app.providers.careerjet import CareerjetJobProvider
+
+
+class CareerjetProviderTests(unittest.TestCase):
+    def test_fetch_raises_explanatory_not_implemented(self):
+        provider = CareerjetJobProvider()
+
+        with self.assertRaises(NotImplementedError) as ctx:
+            provider.fetch({})
+
+        self.assertIn("background local-cache ingest architecture", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_jobs_provider_jooble.py
+++ b/backend/tests/test_jobs_provider_jooble.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from app.providers.jooble import JoobleJobProvider
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class JoobleProviderTests(unittest.TestCase):
+    def test_map_filters_builds_post_body(self):
+        provider = JoobleJobProvider()
+        payload = provider.map_filters(
+            {
+                "page": 3,
+                "keywords": "software engineer",
+                "location": "Remote",
+                "radius": "0",
+                "salary": 120000,
+                "companysearch": True,
+            }
+        )
+
+        self.assertEqual(payload["page"], 3)
+        self.assertEqual(payload["ResultOnPage"], provider.max_page_size)
+        self.assertEqual(payload["keywords"], "software engineer")
+        self.assertEqual(payload["location"], "Remote")
+        self.assertEqual(payload["radius"], "0")
+        self.assertEqual(payload["salary"], 120000)
+        self.assertEqual(payload["companysearch"], "true")
+
+    def test_fetch_keeps_negative_ids_as_strings_and_omits_published_at(self):
+        provider = JoobleJobProvider()
+        payload = {
+            "jobs": [
+                {
+                    "id": -2572280757938267395,
+                    "title": "Remote Software Engineer",
+                    "company": "Acme",
+                    "location": "Remote",
+                    "snippet": "<b>Build</b> APIs and distributed systems.",
+                    "type": "Full-time",
+                    "link": "https://jooble.org/away/job/123",
+                    "source": "linkedin",
+                    "updated": "2026-04-13T00:00:00.0000000",
+                }
+            ]
+        }
+
+        with patch("app.providers.jooble.settings.JOOBLE_API_KEY", "demo-key"), patch(
+            "app.providers.jooble.tracked_request",
+            return_value=_FakeResponse(payload=payload),
+        ):
+            jobs = provider.fetch({"page": 1, "keywords": "software engineer", "location": "Remote"})
+
+        self.assertEqual(len(jobs), 1)
+        job = jobs[0]
+        self.assertEqual(job.provider_job_id, "-2572280757938267395")
+        self.assertIsNone(job.published_at)
+        self.assertTrue(job.is_remote)
+        self.assertEqual(job.provider_url, "https://jooble.org/away/job/123")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_jobs_provider_registry.py
+++ b/backend/tests/test_jobs_provider_registry.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import unittest
+
+from app.providers.registry import (
+    get_provider_controls,
+    get_provider_definition,
+    list_enabled_provider_names,
+    list_provider_statuses,
+)
+
+
+class ProviderRegistryTests(unittest.TestCase):
+    def test_default_provider_controls_match_rollout_expectations(self):
+        muse = get_provider_controls("the_muse")
+        arbeitnow = get_provider_controls("arbeitnow")
+        jooble = get_provider_controls("jooble")
+
+        self.assertTrue(muse.ingest_enabled)
+        self.assertTrue(muse.display_enabled)
+        self.assertTrue(muse.scheduled_enabled)
+        self.assertTrue(arbeitnow.ingest_enabled)
+        self.assertTrue(arbeitnow.display_enabled)
+        self.assertTrue(arbeitnow.scheduled_enabled)
+        self.assertFalse(jooble.ingest_enabled)
+        self.assertFalse(jooble.display_enabled)
+        self.assertFalse(jooble.scheduled_enabled)
+
+    def test_registry_exposes_attribution_and_sweep_metadata(self):
+        definition = get_provider_definition("adzuna")
+        payload = list_provider_statuses()
+        provider_names = {row["provider"] for row in payload}
+
+        self.assertEqual(definition.sweep_mode, "category")
+        self.assertIn("adzuna", provider_names)
+        adzuna_row = next(row for row in payload if row["provider"] == "adzuna")
+        self.assertEqual(adzuna_row["attribution"]["label"], "Jobs by Adzuna")
+        self.assertTrue("the_muse" in list_enabled_provider_names(control_name="display"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/env-examples/beta/.env.example
+++ b/env-examples/beta/.env.example
@@ -40,6 +40,18 @@ POSTGRES_HOST=db
 MUSE_API_KEY=placeholder_beta_muse_api_key
 THE_MUSE_API_KEY=placeholder_beta_muse_api_key
 THE_MUSE_RATE_LIMIT_PER_HOUR=1000
+ARBEITNOW_INTER_REQUEST_DELAY=3.0
+FINDWORK_API_KEY=
+FINDWORK_INTER_REQUEST_DELAY=6.0
+ADZUNA_APP_ID=
+ADZUNA_APP_KEY=
+ADZUNA_DAILY_REQUEST_BUDGET=200
+JOOBLE_API_KEY=
+JOOBLE_INTER_REQUEST_DELAY=1.5
+JOOBLE_PAGE_SIZE=50
+JOB_DEDUP_ENABLED=true
+JOB_DEDUP_LOG_COLLISIONS=true
+JOB_PROVIDER_CONTROLS_JSON={"the_muse":{"ingest_enabled":true,"display_enabled":true,"scheduled_enabled":true},"arbeitnow":{"ingest_enabled":true,"display_enabled":true,"scheduled_enabled":true},"findwork":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false},"jooble":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false},"adzuna":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false},"careerjet":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false}}
 
 # --- Google OAuth (user sign-in) ---
 GOOGLE_CLIENT_ID=placeholder_beta_google_client_id
@@ -210,7 +222,7 @@ JOB_STALE_AUDIT_BATCH_SIZE=25
 JOB_STALE_AUDIT_INTERVAL_SECONDS=21600
 JOB_STALE_AUDIT_RECHECK_HOURS=24
 JOB_SYNC_CATEGORY_SCHEDULE_JSON=
-JOB_SYNC_ENABLED_PROVIDERS_JSON=["the_muse"]
+JOB_SYNC_ENABLED_PROVIDERS_JSON=["the_muse","arbeitnow"]
 
 # --- TLS inside frontend container ---
 # Cloudflare tunnel commonly terminates TLS, so beta can run HTTP internally.

--- a/env-examples/dev/.env.example
+++ b/env-examples/dev/.env.example
@@ -49,6 +49,18 @@ POSTGRES_HOST=db
 MUSE_API_KEY=placeholder_dev_muse_api_key
 THE_MUSE_API_KEY=placeholder_dev_muse_api_key
 THE_MUSE_RATE_LIMIT_PER_HOUR=1000
+ARBEITNOW_INTER_REQUEST_DELAY=3.0
+FINDWORK_API_KEY=
+FINDWORK_INTER_REQUEST_DELAY=6.0
+ADZUNA_APP_ID=
+ADZUNA_APP_KEY=
+ADZUNA_DAILY_REQUEST_BUDGET=200
+JOOBLE_API_KEY=
+JOOBLE_INTER_REQUEST_DELAY=1.5
+JOOBLE_PAGE_SIZE=50
+JOB_DEDUP_ENABLED=true
+JOB_DEDUP_LOG_COLLISIONS=true
+JOB_PROVIDER_CONTROLS_JSON={"the_muse":{"ingest_enabled":true,"display_enabled":true,"scheduled_enabled":true},"arbeitnow":{"ingest_enabled":true,"display_enabled":true,"scheduled_enabled":true},"findwork":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false},"jooble":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false},"adzuna":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false},"careerjet":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false}}
 
 # --- Google OAuth (user sign-in) ---
 # OAuth client credentials from Google Cloud Console.
@@ -248,7 +260,7 @@ JOB_STALE_AUDIT_BATCH_SIZE=25
 JOB_STALE_AUDIT_INTERVAL_SECONDS=21600
 JOB_STALE_AUDIT_RECHECK_HOURS=24
 JOB_SYNC_CATEGORY_SCHEDULE_JSON=
-JOB_SYNC_ENABLED_PROVIDERS_JSON=["the_muse"]
+JOB_SYNC_ENABLED_PROVIDERS_JSON=["the_muse","arbeitnow"]
 
 # --- TLS settings for frontend container ---
 # Dev stack commonly serves behind VPN with cert mounted from host.

--- a/env-examples/local/.env.example
+++ b/env-examples/local/.env.example
@@ -71,6 +71,18 @@ PUBLIC_APP_URL=http://localhost:5173
 MUSE_API_KEY=
 THE_MUSE_API_KEY=
 THE_MUSE_RATE_LIMIT_PER_HOUR=1000
+ARBEITNOW_INTER_REQUEST_DELAY=3.0
+FINDWORK_API_KEY=
+FINDWORK_INTER_REQUEST_DELAY=6.0
+ADZUNA_APP_ID=
+ADZUNA_APP_KEY=
+ADZUNA_DAILY_REQUEST_BUDGET=200
+JOOBLE_API_KEY=
+JOOBLE_INTER_REQUEST_DELAY=1.5
+JOOBLE_PAGE_SIZE=50
+JOB_DEDUP_ENABLED=true
+JOB_DEDUP_LOG_COLLISIONS=true
+JOB_PROVIDER_CONTROLS_JSON={"the_muse":{"ingest_enabled":true,"display_enabled":true,"scheduled_enabled":true},"arbeitnow":{"ingest_enabled":true,"display_enabled":true,"scheduled_enabled":true},"findwork":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false},"jooble":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false},"adzuna":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false},"careerjet":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false}}
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=
@@ -99,7 +111,7 @@ JOB_STALE_AUDIT_BATCH_SIZE=25
 JOB_STALE_AUDIT_INTERVAL_SECONDS=21600
 JOB_STALE_AUDIT_RECHECK_HOURS=24
 JOB_SYNC_CATEGORY_SCHEDULE_JSON=
-JOB_SYNC_ENABLED_PROVIDERS_JSON=["the_muse"]
+JOB_SYNC_ENABLED_PROVIDERS_JSON=["the_muse","arbeitnow"]
 
 # --- Frontend local-mode controls ---
 # Mode options:

--- a/env-examples/prod/.env.example
+++ b/env-examples/prod/.env.example
@@ -57,6 +57,18 @@ VITE_LOCAL_MODE=backend
 MUSE_API_KEY=placeholder_prod_muse_api_key
 THE_MUSE_API_KEY=placeholder_prod_muse_api_key
 THE_MUSE_RATE_LIMIT_PER_HOUR=1000
+ARBEITNOW_INTER_REQUEST_DELAY=3.0
+FINDWORK_API_KEY=
+FINDWORK_INTER_REQUEST_DELAY=6.0
+ADZUNA_APP_ID=
+ADZUNA_APP_KEY=
+ADZUNA_DAILY_REQUEST_BUDGET=200
+JOOBLE_API_KEY=
+JOOBLE_INTER_REQUEST_DELAY=1.5
+JOOBLE_PAGE_SIZE=50
+JOB_DEDUP_ENABLED=true
+JOB_DEDUP_LOG_COLLISIONS=true
+JOB_PROVIDER_CONTROLS_JSON={"the_muse":{"ingest_enabled":true,"display_enabled":true,"scheduled_enabled":true},"arbeitnow":{"ingest_enabled":true,"display_enabled":true,"scheduled_enabled":true},"findwork":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false},"jooble":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false},"adzuna":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false},"careerjet":{"ingest_enabled":false,"display_enabled":false,"scheduled_enabled":false}}
 # Z.AI OCR/LLM key.
 ZAI_API_KEY=placeholder_prod_zai_api_key
 # Google OAuth credentials.
@@ -79,4 +91,4 @@ JOB_STALE_AUDIT_BATCH_SIZE=25
 JOB_STALE_AUDIT_INTERVAL_SECONDS=21600
 JOB_STALE_AUDIT_RECHECK_HOURS=24
 JOB_SYNC_CATEGORY_SCHEDULE_JSON=
-JOB_SYNC_ENABLED_PROVIDERS_JSON=["the_muse"]
+JOB_SYNC_ENABLED_PROVIDERS_JSON=["the_muse","arbeitnow"]

--- a/frontend/src/components/JobPosting.vue
+++ b/frontend/src/components/JobPosting.vue
@@ -24,6 +24,21 @@
 
             <p class="job-teaser">{{ teaserText }}</p>
 
+            <div v-if="attributionText" class="job-attribution">
+                <a
+                    v-if="attributionHref"
+                    :href="attributionHref"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    :class="{ required: attributionRequired }"
+                >
+                    {{ attributionText }}
+                </a>
+                <span v-else :class="{ required: attributionRequired }">
+                    {{ attributionText }}
+                </span>
+            </div>
+
             <div class="job-actions">
                 <button type="button" class="secondary" @click="openDetails">Details</button>
                 <button type="button" class="primary" @click="apply">Apply Now</button>
@@ -69,8 +84,8 @@
                 </div>
 
                 <div class="job-modal-actions">
-                    <a v-if="job.link" :href="job.link" target="_blank" rel="noopener noreferrer">
-                        <button type="button" class="primary">Apply on The Muse</button>
+                    <a v-if="applicationLink" :href="applicationLink" target="_blank" rel="noopener noreferrer">
+                        <button type="button" class="primary">Open Application</button>
                     </a>
                     <button type="button" class="secondary" @click="closeDetails">Close</button>
                 </div>
@@ -88,6 +103,10 @@ export default {
     },
     props: {
         job: Object,
+        providerAttribution: {
+            type: Object,
+            default: null,
+        },
         showDebugMeta: {
             type: Boolean,
             default: false,
@@ -160,6 +179,22 @@ export default {
             }
 
             return pills
+        },
+        applicationLink() {
+            return this.job?.apply_link || this.job?.link || ""
+        },
+        attributionText() {
+            const attribution = this.providerAttribution || {}
+            const label = (attribution.label || "").toString().trim()
+            if (label) return label
+            const provider = (this.job?.provider || "").toString().trim()
+            return provider ? `Source: ${provider}` : ""
+        },
+        attributionHref() {
+            return (this.providerAttribution?.url || "").toString().trim()
+        },
+        attributionRequired() {
+            return this.providerAttribution?.required === true
         }
     },
     methods: {
@@ -170,8 +205,8 @@ export default {
             this.detailsOpen = false
         },
         apply() {
-            if (this.job?.link) {
-                window.open(this.job.link, "_blank", "noopener")
+            if (this.applicationLink) {
+                window.open(this.applicationLink, "_blank", "noopener")
                 return
             }
             this.openDetails()
@@ -255,6 +290,22 @@ export default {
     color: #334155;
     line-height: 1.45;
     font-size: 0.93rem;
+}
+
+.job-attribution {
+    margin-top: 10px;
+    font-size: 0.82rem;
+}
+
+.job-attribution a,
+.job-attribution span {
+    color: #475569;
+    text-decoration: none;
+}
+
+.job-attribution .required {
+    color: #0f172a;
+    font-weight: 600;
 }
 
 .job-actions {

--- a/frontend/src/views/Job-Board.vue
+++ b/frontend/src/views/Job-Board.vue
@@ -333,6 +333,7 @@
                 v-for="job in jobs"
                 :key="job.id"
                 :job="job"
+                :provider-attribution="providerAttributionByName[job.provider] || null"
                 :show-debug-meta="showDebugTools"
             />
         </div>
@@ -584,6 +585,7 @@ export default {
 
     return {
       jobs: [],
+      providerAttributionByName: {},
       loading: false,
       error: "",
       page: 1,
@@ -1202,6 +1204,22 @@ export default {
         this.applyFilterMetadata(payload)
       } catch (error) {
         console.error("Failed to load jobs filter metadata", error)
+      }
+    },
+    async fetchProviderAttribution() {
+      try {
+        const payload = await this.fetchJson("/api/providers/attribution")
+        const providers = Array.isArray(payload?.providers) ? payload.providers : []
+        const next = {}
+        for (const item of providers) {
+          const provider = (item?.provider || "").toString().trim()
+          if (!provider) continue
+          next[provider] = item.attribution || {}
+        }
+        this.providerAttributionByName = next
+      } catch (e) {
+        console.error("Failed to load provider attribution", e)
+        this.providerAttributionByName = {}
       }
     },
     async fetchCountryOptions() {
@@ -1842,6 +1860,7 @@ export default {
 
         const mappedJobs = (data.jobs || []).map(job => ({
           id: job.id,
+          provider: job.provider,
           title: job.name,
           short_name: job.short_name || "",
           company: job.company,
@@ -1860,6 +1879,7 @@ export default {
           local_compatibility_reason: job.local_compatibility_reason || "",
           location_constraints: job.location_constraints || {},
           publication_date: job.publication_date,
+          apply_link: job.apply_url || job.job_url,
           link: job.job_url,
           contents: job.contents || ""
         }))
@@ -1968,6 +1988,7 @@ export default {
       this.showDebugTools = state.showDebugTools === true
     })
     await this.fetchFilterMetadata()
+    await this.fetchProviderAttribution()
     await this.fetchCountryOptions()
 
     const cached = getCachedLocation()

--- a/test.txt
+++ b/test.txt
@@ -1,16 +1,5 @@
-
-
-add nice regex for phone numbers and emails and stuff globally.
-
-add cool area code flag render for phone numbers idk
-
-add phone number linking ability
-
-
 standardize connected accounts button/card sizes
-
-
-
+    
 NATURAL LANGUAGE MODEL FILTER APPLICATION?? yes this
 
 pin drop map featue for job search
@@ -32,4 +21,4 @@ just enough so she knows it wasnt stolen/ai
 
 fix dropdowns in resume profile stuff to make them usable
 
-one more pass on filters and stuff's function
+one more pass on filters and stuff's function once full job stuff is working


### PR DESCRIPTION
Introduce a provider registry and multiple new provider adapters (adzuna, arbeitnow, careerjet, findwork, jooble) plus common provider utilities used to normalize and parse provider payloads. Add provider controls/attribution metadata and APIs: new registry resolves ingest/display/scheduled flags, lists provider statuses, and exposes /providers/attribution. Add Settings parsing for provider controls and several provider-specific env settings. Implement cross-provider deduplication: add dedup_hash column and partial unique index to Job, add jobs_deduplicated to ProviderSyncLog, and include an Alembic migration that backfills dedup hashes and creates the index. Ingest path updated to compute dedup hashes, gate ingestion by provider controls, and treat duplicates by marking/merging owners (with optional collision logging). Misc: provider-related tests added, small .gitignore updates, and related service/api wiring changes.
