### PR TITLE
Add resume review & canonical profile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .env
 .env.*
 !env-examples/**/.env.example
+!frontend/.env.local.example
+!uah-browser-extension/.env.local.example
 
 # ----- Docker volumes (database data, etc.) -----
 volumes/

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ Notes:
 
 Use this path when you want to test the browser extension against a real local backend without relaxing the extension's HTTPS-only build rules.
 
+Quick helper:
+
+```powershell
+pwsh -File .\scripts\local\lifecycle\local-extension-test.ps1
+```
+
 1. Generate trusted localhost certs with `mkcert`:
 
 ```bash
@@ -186,6 +192,8 @@ Notes:
 - The Vite dev server remains the single browser-facing origin for both app pages and `/api` requests.
 - Google OAuth is intentionally out of scope for the localhost harness; use email/password for local extension testing.
 - Cert files under `volumes/certs/local/` stay ignored by git through the existing `volumes/` ignore rule.
+- The helper script expects repo-root `.env`, `frontend/.env.local`, and `uah-browser-extension/.env.local` to already exist.
+- The helper script starts backend-local, launches the HTTPS frontend in a new PowerShell window, builds the extension, and prints the manual Chrome smoke-test steps.
 
 ### Environment template
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ npm install
 npm run dev
 ```
 
-Open `http://127.0.0.1:5173`.
+Open `http://localhost:5173`.
 
 - `npm run dev` defaults to mock mode.
 - API calls are handled by an in-browser mock API layer.
@@ -142,9 +142,55 @@ Notes:
 - Backend mode refuses non-local API targets by default.
 - To intentionally target a non-local API in backend mode, set `VITE_ALLOW_REMOTE_API=true`.
 
+### Local HTTPS harness for the browser extension
+
+Use this path when you want to test the browser extension against a real local backend without relaxing the extension's HTTPS-only build rules.
+
+1. Generate trusted localhost certs with `mkcert`:
+
+```bash
+mkdir -p volumes/certs/local
+mkcert -install
+mkcert -cert-file volumes/certs/local/tls.crt -key-file volumes/certs/local/tls.key localhost 127.0.0.1 ::1
+```
+
+2. Create the root local env file from `env-examples/local/.env.example` and set at least:
+   - `SESSION_COOKIE_HTTPS_ONLY=true`
+   - `PUBLIC_APP_URL=https://localhost:5173`
+   - optional seeded login:
+     - `DEV_AUTH_TEST_ACCOUNT_ENABLED=true`
+     - `DEV_AUTH_TEST_PASSWORD=<your local password>`
+
+3. Create `frontend/.env.local` from `frontend/.env.local.example`.
+
+4. Start the local backend:
+
+```bash
+docker compose -f docker-compose.local.yml --profile backend up -d db-local backend-local
+```
+
+5. Start the frontend over HTTPS:
+
+```bash
+cd frontend
+npm install
+npm run dev:backend
+```
+
+6. Open `https://localhost:5173` and confirm the browser trusts the cert before loading the extension.
+
+7. Create `uah-browser-extension/.env.local` from `uah-browser-extension/.env.local.example`, then build and load the extension unpacked.
+
+Notes:
+
+- The Vite dev server remains the single browser-facing origin for both app pages and `/api` requests.
+- Google OAuth is intentionally out of scope for the localhost harness; use email/password for local extension testing.
+- Cert files under `volumes/certs/local/` stay ignored by git through the existing `volumes/` ignore rule.
+
 ### Environment template
 
 - Use `env-examples/local/.env.example` as the starting point for local root `.env` values.
+- Use `frontend/.env.local.example` as the starting point for frontend HTTPS backend-mode values.
 
 For host-run backend workflows (`uvicorn` outside Docker), continue using the **[Backend Local Development Guide](./docs/backend/README.md)**.
 

--- a/backend/app/api/applicant_profile.py
+++ b/backend/app/api/applicant_profile.py
@@ -8,10 +8,41 @@ from app.api.deps import get_current_user
 from app.schemas.applicant_profile import (
     ProfileCreate, ProfileUpdate, ProfileResponse, ProfileListItem,
 )
+from app.services.applicant_profile_canonical import sync_profile_storage, apply_profile_updates_to_canonical
 
 router = APIRouter(prefix="/api/applicant-profile", tags=["applicant-profile"])
 
 MAX_PROFILES_PER_USER = 10
+
+
+def _sync_profiles_if_needed(db: Session, profiles: list[ApplicantProfile]) -> None:
+    dirty = False
+    for profile in profiles:
+        before_canonical = profile.canonical_data
+        before_token_map = profile.token_map
+        before_summary = (
+            profile.first_name,
+            profile.last_name,
+            profile.job_title,
+            profile.city,
+            profile.state,
+            profile.updated_at,
+        )
+        sync_profile_storage(profile)
+        after_summary = (
+            profile.first_name,
+            profile.last_name,
+            profile.job_title,
+            profile.city,
+            profile.state,
+            profile.updated_at,
+        )
+        if before_canonical != profile.canonical_data or before_token_map != profile.token_map or before_summary != after_summary:
+            dirty = True
+    if dirty:
+        db.commit()
+        for profile in profiles:
+            db.refresh(profile)
 
 
 @router.get("/", response_model=list[ProfileListItem])
@@ -29,12 +60,15 @@ def list_profiles(
     Response codes:
     - 200: Profiles returned successfully (possibly empty list).
     """
-    return (
+    profiles = (
         db.query(ApplicantProfile)
         .filter(ApplicantProfile.user_id == current_user.id)
         .order_by(ApplicantProfile.is_active.desc(), ApplicantProfile.updated_at.desc())
         .all()
     )
+    if profiles:
+        _sync_profiles_if_needed(db, profiles)
+    return profiles
 
 
 @router.get("/active", response_model=ProfileResponse)
@@ -58,6 +92,7 @@ def get_active_profile(
     )
     if not profile:
         raise HTTPException(status_code=404, detail="No active profile found")
+    _sync_profiles_if_needed(db, [profile])
     return profile
 
 
@@ -93,6 +128,7 @@ def create_profile(
         **payload.model_dump(),
     )
     db.add(profile)
+    sync_profile_storage(profile)
     db.commit()
     db.refresh(profile)
     return profile
@@ -118,6 +154,7 @@ def get_profile(
     ).first()
     if not profile:
         raise HTTPException(status_code=404, detail="Profile not found")
+    _sync_profiles_if_needed(db, [profile])
     return profile
 
 
@@ -144,9 +181,13 @@ def update_profile(
     if not profile:
         raise HTTPException(status_code=404, detail="Profile not found")
 
-    for key, value in payload.model_dump(exclude_unset=True).items():
+    updates = payload.model_dump(exclude_unset=True)
+    for key, value in updates.items():
         setattr(profile, key, value)
 
+    if "canonical_data" not in updates:
+        profile.canonical_data = apply_profile_updates_to_canonical(profile.canonical_data or {}, updates)
+    sync_profile_storage(profile)
     db.commit()
     db.refresh(profile)
     return profile
@@ -181,6 +222,7 @@ def activate_profile(
     ).update({"is_active": False})
 
     profile.is_active = True
+    sync_profile_storage(profile)
     db.commit()
     db.refresh(profile)
     return profile

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -6,7 +6,12 @@ import os
 from app.db.session import get_db
 from app.models.user import User
 from app.schemas.user import UserRegister, UserLogin, UserResponse, TokenResponse, MessageResponse
-from app.core.security import hash_password, verify_password, create_access_token
+from app.core.security import hash_password, verify_password
+from app.core.auth_session import (
+    access_token_expire_seconds_for_client,
+    create_access_token_for_client,
+    resolve_auth_client,
+)
 from app.core.auth_cookie import clear_auth_cookie, set_auth_cookie, set_no_store_headers
 from app.core.validation import normalize_email, require_valid_email
 from app.core.rate_limit import enforce_ip_rate_limit, enforce_subject_rate_limit
@@ -133,8 +138,9 @@ def register(
     db.commit()
     db.refresh(user)
 
-    token = create_access_token(data={"sub": str(user.id)})
-    set_auth_cookie(response, token)
+    auth_client = resolve_auth_client(request)
+    token = create_access_token_for_client(data={"sub": str(user.id)}, client=auth_client)
+    set_auth_cookie(response, token, max_age=access_token_expire_seconds_for_client(auth_client))
     return TokenResponse(
         access_token=token,
         user=UserResponse.model_validate(user),
@@ -189,8 +195,9 @@ def login(
             detail="Account is deactivated",
         )
 
-    token = create_access_token(data={"sub": str(user.id)})
-    set_auth_cookie(response, token)
+    auth_client = resolve_auth_client(request)
+    token = create_access_token_for_client(data={"sub": str(user.id)}, client=auth_client)
+    set_auth_cookie(response, token, max_age=access_token_expire_seconds_for_client(auth_client))
     return TokenResponse(
         access_token=token,
         user=UserResponse.model_validate(user),
@@ -248,8 +255,9 @@ def token_login(
             detail="Account is deactivated",
         )
 
-    token = create_access_token(data={"sub": str(user.id)})
-    set_auth_cookie(response, token)
+    auth_client = resolve_auth_client(request)
+    token = create_access_token_for_client(data={"sub": str(user.id)}, client=auth_client)
+    set_auth_cookie(response, token, max_age=access_token_expire_seconds_for_client(auth_client))
     return {
         "access_token": token,
         "token_type": "bearer",

--- a/backend/app/api/resume.py
+++ b/backend/app/api/resume.py
@@ -529,7 +529,8 @@ def update_review_draft(
     resume = db.query(Resume).filter(Resume.id == resume_id, Resume.user_id == current_user.id).first()
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
-    if not isinstance(resume.structured_data, dict):
+    current_review_draft = _current_review_draft(resume)
+    if current_review_draft is None and not isinstance(resume.structured_data, dict):
         raise HTTPException(status_code=400, detail="Resume has not been parsed yet")
 
     _set_review_draft(resume, payload.review_draft, status="pending")

--- a/backend/app/api/resume.py
+++ b/backend/app/api/resume.py
@@ -1,8 +1,9 @@
 import asyncio
 import logging
 import os
+import copy
 from datetime import datetime, timezone, timedelta
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, BackgroundTasks, Path, Query
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, BackgroundTasks, Path, Query, Body
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
 from sqlalchemy import func
@@ -10,13 +11,18 @@ from app.db.session import get_db
 from app.models.user import User
 from app.models.resume import Resume
 from app.models.parse_job import ParseJob
+from app.models.applicant_profile import ApplicantProfile
 from app.api.deps import get_current_user
 from app.core.config import settings
 from app.schemas.resume import (
     ResumeUploadResponse, ResumeResponse, ResumeListItem,
     PortalCheckResponse, ParseRequest,
     ParseJobResponse, ParseJobStartResponse,
+    ResumeReviewDraftUpdate, ResumeReviewDraftResponse,
+    ResumeReviewConflictRequest, ResumeReviewConflictResponse,
+    ResumeReviewApplyRequest, ResumeReviewApplyResponse,
 )
+from app.schemas.applicant_profile import ProfileResponse
 from app.services.parse_job_runner import run_parse_job
 from app.services.parse_queue import (
     enqueue_parse_job,
@@ -32,12 +38,20 @@ from app.services.resume_parser import (
     get_parse_input_text,
     check_portal_required,
 )
+from app.services.applicant_profile_canonical import (
+    normalize_canonical_data,
+    sync_profile_storage,
+    merge_review_into_profile,
+    generate_review_conflicts,
+    build_profile_from_review,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/resume", tags=["resume"])
 
 MAX_RESUMES_PER_USER = 10
+MAX_PROFILES_PER_USER = 10
 MAX_FILE_SIZE = 5 * 1024 * 1024
 UPLOAD_COOLDOWN_SECONDS = 30
 ALLOWED_PDF_CONTENT_TYPES = {
@@ -106,6 +120,25 @@ def _refresh_resume_validation_if_needed(resume: Resume) -> bool:
         resume.structured_data = validated
         resume.portal_ready = recalculated_ready
     return changed
+
+
+def _current_review_draft(resume: Resume) -> dict | None:
+    draft = resume.review_draft if isinstance(resume.review_draft, dict) else None
+    if draft:
+        return copy.deepcopy(draft)
+    if isinstance(resume.structured_data, dict):
+        return copy.deepcopy(resume.structured_data)
+    return None
+
+
+def _set_review_draft(
+    resume: Resume,
+    review_draft: dict,
+    status: str = "pending",
+) -> None:
+    resume.review_draft = validate_and_fix(copy.deepcopy(review_draft or {}))
+    resume.review_status = status
+    resume.review_updated_at = datetime.now(timezone.utc)
 
 
 async def _build_queue_status_payload(
@@ -407,6 +440,7 @@ async def parse_resume(
     resume.structured_data = structured
     resume.parse_method = method
     resume.portal_ready = structured.get("_validation", {}).get("portal_ready", False)
+    _set_review_draft(resume, structured, status="pending")
     db.commit()
     db.refresh(resume)
 
@@ -459,6 +493,175 @@ def get_resume(
         db.commit()
         db.refresh(resume)
     return resume
+
+
+@router.get("/{resume_id}/review-draft", response_model=ResumeReviewDraftResponse)
+def get_review_draft(
+    resume_id: int = Path(..., ge=1, description="Resume ID whose persisted review draft should be returned."),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    resume = db.query(Resume).filter(Resume.id == resume_id, Resume.user_id == current_user.id).first()
+    if not resume:
+        raise HTTPException(status_code=404, detail="Resume not found")
+
+    review_draft = _current_review_draft(resume)
+    if not review_draft:
+        raise HTTPException(status_code=400, detail="Resume has not been parsed yet")
+
+    return ResumeReviewDraftResponse(
+        resume_id=resume.id,
+        file_name=resume.file_name,
+        parse_method=resume.parse_method,
+        review_status=resume.review_status,
+        review_updated_at=resume.review_updated_at,
+        review_draft=review_draft,
+    )
+
+
+@router.put("/{resume_id}/review-draft", response_model=ResumeReviewDraftResponse)
+def update_review_draft(
+    payload: ResumeReviewDraftUpdate,
+    resume_id: int = Path(..., ge=1, description="Resume ID whose review draft should be updated."),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    resume = db.query(Resume).filter(Resume.id == resume_id, Resume.user_id == current_user.id).first()
+    if not resume:
+        raise HTTPException(status_code=404, detail="Resume not found")
+    if not isinstance(resume.structured_data, dict):
+        raise HTTPException(status_code=400, detail="Resume has not been parsed yet")
+
+    _set_review_draft(resume, payload.review_draft, status="pending")
+    db.commit()
+    db.refresh(resume)
+
+    return ResumeReviewDraftResponse(
+        resume_id=resume.id,
+        file_name=resume.file_name,
+        parse_method=resume.parse_method,
+        review_status=resume.review_status,
+        review_updated_at=resume.review_updated_at,
+        review_draft=_current_review_draft(resume) or {},
+    )
+
+
+@router.post("/{resume_id}/review-conflicts", response_model=ResumeReviewConflictResponse)
+def review_conflicts(
+    payload: ResumeReviewConflictRequest,
+    resume_id: int = Path(..., ge=1, description="Resume ID whose reviewed data should be compared against a target applicant profile."),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    resume = db.query(Resume).filter(Resume.id == resume_id, Resume.user_id == current_user.id).first()
+    if not resume:
+        raise HTTPException(status_code=404, detail="Resume not found")
+
+    profile = db.query(ApplicantProfile).filter(
+        ApplicantProfile.id == payload.profile_id,
+        ApplicantProfile.user_id == current_user.id,
+    ).first()
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+
+    sync_profile_storage(profile)
+    reviewed_data = payload.reviewed_data or _current_review_draft(resume)
+    if not isinstance(reviewed_data, dict):
+        raise HTTPException(status_code=400, detail="Resume has no review draft")
+
+    incoming_canonical = normalize_canonical_data(reviewed_data)
+    existing_canonical = normalize_canonical_data(profile.canonical_data or {})
+    conflicts = generate_review_conflicts(existing_canonical, incoming_canonical)
+
+    return ResumeReviewConflictResponse(
+        profile_id=profile.id,
+        conflict_count=len(conflicts),
+        conflicts=conflicts,
+    )
+
+
+@router.post("/{resume_id}/apply-review", response_model=ResumeReviewApplyResponse)
+def apply_review(
+    payload: ResumeReviewApplyRequest,
+    resume_id: int = Path(..., ge=1, description="Resume ID whose reviewed draft should be applied to the applicant profile system."),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    resume = db.query(Resume).filter(Resume.id == resume_id, Resume.user_id == current_user.id).first()
+    if not resume:
+        raise HTTPException(status_code=404, detail="Resume not found")
+
+    incoming_canonical = normalize_canonical_data(payload.reviewed_data)
+    if payload.mode not in {"existing", "new"}:
+        raise HTTPException(status_code=400, detail="Mode must be 'existing' or 'new'")
+
+    profile: ApplicantProfile | None = None
+    conflicts: list[dict] = []
+
+    if payload.mode == "existing":
+        if payload.profile_id is None:
+            raise HTTPException(status_code=400, detail="profile_id is required when mode='existing'")
+        profile = db.query(ApplicantProfile).filter(
+            ApplicantProfile.id == payload.profile_id,
+            ApplicantProfile.user_id == current_user.id,
+        ).first()
+        if not profile:
+            raise HTTPException(status_code=404, detail="Profile not found")
+
+        sync_profile_storage(profile)
+        merged_canonical, conflicts = merge_review_into_profile(
+            normalize_canonical_data(profile.canonical_data or {}),
+            incoming_canonical,
+            payload.conflict_resolutions or {},
+        )
+        profile.canonical_data = merged_canonical
+        sync_profile_storage(profile)
+    else:
+        count = db.query(func.count(ApplicantProfile.id)).filter(
+            ApplicantProfile.user_id == current_user.id
+        ).scalar()
+        if count >= MAX_PROFILES_PER_USER:
+            raise HTTPException(status_code=429, detail=f"Max {MAX_PROFILES_PER_USER} applicant profiles allowed")
+
+        suggested_name = (
+            (payload.profile_name or "").strip()
+            or " ".join(
+                part for part in [
+                    incoming_canonical.get("personal_info", {}).get("first_name"),
+                    incoming_canonical.get("personal_info", {}).get("last_name"),
+                ]
+                if part
+            )
+            or os.path.splitext(resume.file_name)[0]
+            or "Imported Profile"
+        )
+        profile = ApplicantProfile(
+            user_id=current_user.id,
+            name=suggested_name[:100],
+            is_active=True,
+        )
+        db.add(profile)
+        db.flush()
+        build_profile_from_review(profile, incoming_canonical)
+
+    db.query(ApplicantProfile).filter(
+        ApplicantProfile.user_id == current_user.id,
+        ApplicantProfile.id != profile.id,
+    ).update({"is_active": False})
+    profile.is_active = True
+
+    _set_review_draft(resume, payload.reviewed_data, status="applied")
+    db.commit()
+    db.refresh(profile)
+    db.refresh(resume)
+
+    return ResumeReviewApplyResponse(
+        resume_id=resume.id,
+        profile_id=profile.id,
+        review_status=resume.review_status or "applied",
+        conflict_count=len(conflicts),
+        profile=ProfileResponse.model_validate(profile).model_dump(),
+    )
 
 
 @router.get("/{resume_id}/pdf")

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -61,7 +61,11 @@ from app.models.user import User, SavedJob
 from app.db.session import get_db
 from app.google.service import GoogleAuthService
 from app.schemas.user import SaveJobRequest
-from app.core.security import create_access_token
+from app.core.auth_session import (
+    access_token_expire_seconds_for_client,
+    create_access_token_for_client,
+    resolve_auth_client,
+)
 from app.core.auth_cookie import set_auth_cookie
 from typing import Optional, List, Any
 from app.services.geolocation import (
@@ -2764,6 +2768,7 @@ def _clear_google_oauth_session(request: Request) -> None:
     request.session.pop("oauth_user_id", None)
     request.session.pop("oauth_next", None)
     request.session.pop("oauth_intent", None)
+    request.session.pop("oauth_client", None)
 
 
 def _oauth_login_error(reason: str, intent: str = "login") -> RedirectResponse:
@@ -2797,6 +2802,7 @@ async def google_oauth(
     request: Request,
     intent: str = Query("login", description="Optional UI intent for telemetry. Supported: login, register."),
     next: str | None = Query(None, description="Optional post-login app path, e.g. /home or /job-board."),
+    client: str | None = Query(None, description="Optional client hint. Use `extension` for browser-extension sign-in."),
 ):
     """
     Start Google OAuth flow for unauthenticated sign-in/up.
@@ -2814,6 +2820,7 @@ async def google_oauth(
     request.session["oauth_mode"] = "login"
     request.session["oauth_intent"] = normalized_intent
     request.session["oauth_next"] = _sanitize_next_path(next)
+    request.session["oauth_client"] = resolve_auth_client(request, query_client=client)
 
     return RedirectResponse(_build_google_authorization_url(state, redirect_uri, client_id))
 
@@ -2837,6 +2844,7 @@ async def start_google_connect(
     request.session["oauth_mode"] = "connect"
     request.session["oauth_user_id"] = int(current_user.id)
     request.session["oauth_next"] = "/settings"
+    request.session["oauth_client"] = resolve_auth_client(request)
 
     return {"authorization_url": _build_google_authorization_url(state, redirect_uri, client_id)}
 
@@ -2943,6 +2951,7 @@ async def google_oauth_callback(
     oauth_mode = (request.session.get("oauth_mode") or "login").strip().lower()
     oauth_user_id = request.session.get("oauth_user_id")
     oauth_next = _sanitize_next_path(request.session.get("oauth_next"))
+    oauth_client = resolve_auth_client(query_client=request.session.get("oauth_client"))
 
     if not expected_state or state != expected_state:
         _clear_google_oauth_session(request)
@@ -3049,7 +3058,7 @@ async def google_oauth_callback(
         _clear_google_oauth_session(request)
         return _oauth_login_error("account_inactive", intent=oauth_intent)
 
-    user_access_token = create_access_token(data={"sub": str(user.id)})
+    user_access_token = create_access_token_for_client(data={"sub": str(user.id)}, client=oauth_client)
     redirect_url = _frontend_url(
         "/oauth-callback",
         query={
@@ -3058,7 +3067,11 @@ async def google_oauth_callback(
         },
     )
     redirect_response = RedirectResponse(redirect_url, status_code=302)
-    set_auth_cookie(redirect_response, user_access_token)
+    set_auth_cookie(
+        redirect_response,
+        user_access_token,
+        max_age=access_token_expire_seconds_for_client(oauth_client),
+    )
     _clear_google_oauth_session(request)
     return redirect_response
 

--- a/backend/app/core/auth_cookie.py
+++ b/backend/app/core/auth_cookie.py
@@ -8,7 +8,7 @@ def set_no_store_headers(response: Response) -> None:
     response.headers["Pragma"] = "no-cache"
 
 
-def set_auth_cookie(response: Response, token: str) -> None:
+def set_auth_cookie(response: Response, token: str, *, max_age: int | None = None) -> None:
     set_no_store_headers(response)
     response.set_cookie(
         key=settings.AUTH_COOKIE_NAME,
@@ -17,7 +17,7 @@ def set_auth_cookie(response: Response, token: str) -> None:
         secure=settings.SESSION_COOKIE_HTTPS_ONLY,
         samesite=settings.SESSION_COOKIE_SAMESITE,
         path=settings.SESSION_COOKIE_PATH,
-        max_age=settings.ACCESS_TOKEN_EXPIRE_SECONDS,
+        max_age=max_age if max_age is not None else settings.ACCESS_TOKEN_EXPIRE_SECONDS,
     )
 
 

--- a/backend/app/core/auth_session.py
+++ b/backend/app/core/auth_session.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from fastapi import Request
+
+from app.core.config import settings
+from app.core.security import create_access_token
+
+AUTH_CLIENT_HEADER = "X-UAH-Client"
+DEFAULT_AUTH_CLIENT = "web"
+EXTENSION_AUTH_CLIENT = "extension"
+
+
+def normalize_auth_client(value: str | None) -> str:
+    normalized = (value or "").strip().lower()
+    if normalized == EXTENSION_AUTH_CLIENT:
+        return EXTENSION_AUTH_CLIENT
+    return DEFAULT_AUTH_CLIENT
+
+
+def resolve_auth_client(
+    request: Request | None = None,
+    *,
+    query_client: str | None = None,
+) -> str:
+    if query_client and query_client.strip():
+        return normalize_auth_client(query_client)
+    if request is None:
+        return DEFAULT_AUTH_CLIENT
+    return normalize_auth_client(request.headers.get(AUTH_CLIENT_HEADER))
+
+
+def access_token_expire_minutes_for_client(client: str | None = None) -> int:
+    normalized = normalize_auth_client(client)
+    if normalized == EXTENSION_AUTH_CLIENT:
+        return max(int(settings.EXTENSION_ACCESS_TOKEN_EXPIRE_MINUTES), 1)
+    return max(int(settings.ACCESS_TOKEN_EXPIRE_MINUTES), 1)
+
+
+def access_token_expire_seconds_for_client(client: str | None = None) -> int:
+    return access_token_expire_minutes_for_client(client) * 60
+
+
+def create_access_token_for_client(data: dict, client: str | None = None) -> str:
+    return create_access_token(
+        data=data,
+        expires_delta=timedelta(seconds=access_token_expire_seconds_for_client(client)),
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -79,6 +79,7 @@ class Settings:
     )
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
+    EXTENSION_ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("EXTENSION_ACCESS_TOKEN_EXPIRE_MINUTES", "1440"))
     GMAIL_TOKEN_ENCRYPTION_KEY: str = os.getenv("GMAIL_TOKEN_ENCRYPTION_KEY", "")
 
     # Environment

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -133,7 +133,7 @@ def _ensure_users_table_columns(engine) -> None:
 
 
 def _ensure_resumes_table_columns(engine) -> None:
-    """Dev safety net: add pdf_data column to existing resumes table if missing."""
+    """Dev safety net: add newer resume columns to existing resumes table if missing."""
     try:
         from sqlalchemy import inspect, text
     except Exception:
@@ -145,12 +145,62 @@ def _ensure_resumes_table_columns(engine) -> None:
             return
 
         existing = {col["name"] for col in inspector.get_columns("resumes")}
-        if "pdf_data" not in existing:
+
+        ddl_statements: list[str] = []
+        required_columns: dict[str, str] = {
+            "pdf_data": "BYTEA",
+            "review_status": "VARCHAR(50)",
+            "review_draft": "JSONB",
+            "review_updated_at": "TIMESTAMPTZ",
+        }
+        for column_name, column_ddl in required_columns.items():
+            if column_name in existing:
+                continue
+            ddl_statements.append(
+                f"ALTER TABLE resumes ADD COLUMN IF NOT EXISTS {column_name} {column_ddl}"
+            )
+
+        if ddl_statements:
             with engine.begin() as conn:
-                conn.execute(text("ALTER TABLE resumes ADD COLUMN IF NOT EXISTS pdf_data BYTEA"))
-            logger.warning("Added pdf_data column to resumes table")
+                for ddl in ddl_statements:
+                    conn.execute(text(ddl))
+            logger.warning("Applied dev schema fixups to resumes table")
     except Exception as exc:
         logger.exception("Resumes table schema fixup failed: %s", exc)
+
+
+def _ensure_applicant_profiles_table_columns(engine) -> None:
+    """Dev safety net: add newer applicant profile columns when DB schema lags."""
+    try:
+        from sqlalchemy import inspect, text
+    except Exception:
+        return
+
+    try:
+        inspector = inspect(engine)
+        if "applicant_profiles" not in inspector.get_table_names():
+            return
+
+        existing = {col["name"] for col in inspector.get_columns("applicant_profiles")}
+        ddl_statements: list[str] = []
+        required_columns: dict[str, str] = {
+            "canonical_data": "JSONB",
+            "token_map": "JSONB",
+        }
+        for column_name, column_ddl in required_columns.items():
+            if column_name in existing:
+                continue
+            ddl_statements.append(
+                f"ALTER TABLE applicant_profiles ADD COLUMN IF NOT EXISTS {column_name} {column_ddl}"
+            )
+
+        if ddl_statements:
+            with engine.begin() as conn:
+                for ddl in ddl_statements:
+                    conn.execute(text(ddl))
+            logger.warning("Applied dev schema fixups to applicant_profiles table")
+    except Exception as exc:
+        logger.exception("Applicant profiles table schema fixup failed: %s", exc)
 
 
 def _bootstrap_admin_user_if_enabled() -> None:
@@ -324,6 +374,7 @@ async def lifespan(app: FastAPI):
     Base.metadata.create_all(bind=engine, tables=LEGACY_STARTUP_TABLES)
     _ensure_users_table_columns(engine)
     _ensure_resumes_table_columns(engine)
+    _ensure_applicant_profiles_table_columns(engine)
     _enforce_email_first_identity_mirror()
     _bootstrap_admin_user_if_enabled()
     _ensure_dev_test_user_if_enabled()

--- a/backend/app/models/applicant_profile.py
+++ b/backend/app/models/applicant_profile.py
@@ -47,6 +47,8 @@ class ApplicantProfile(Base):
     professional_links_text = Column(Text, nullable=True)
     education_history_text = Column(Text, nullable=True)
     employment_history_text = Column(Text, nullable=True)
+    canonical_data = Column(JSON, nullable=True)
+    token_map = Column(JSON, nullable=True)
 
     # Demographics
     demographic_gender = Column(String(50), nullable=True)

--- a/backend/app/models/resume.py
+++ b/backend/app/models/resume.py
@@ -14,9 +14,16 @@ class Resume(Base):
     structured_data = Column(JSON, nullable=True)
     portal_ready = Column(Boolean, default=False)
     parse_method = Column(String(50), nullable=True)
+    review_status = Column(String(50), nullable=True)
+    review_draft = Column(JSON, nullable=True)
+    review_updated_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     @property
     def has_pdf(self):
         return self.pdf_data is not None
+
+    @property
+    def has_review_draft(self):
+        return self.review_draft is not None

--- a/backend/app/schemas/applicant_profile.py
+++ b/backend/app/schemas/applicant_profile.py
@@ -35,6 +35,8 @@ class ProfileBase(BaseModel):
     professional_links_text: str | None = Field(default=None, max_length=6000, description="Additional professional links not captured in dedicated URL fields.", examples=["GitHub: https://github.com/janedoe; Medium: https://medium.com/@janedoe"])
     education_history_text: str | None = Field(default=None, max_length=12000, description="Detailed education history block used for longer application forms.", examples=["B.S. Computer Science, UAH, 2022-2026, GPA 3.84"])
     employment_history_text: str | None = Field(default=None, max_length=20000, description="Detailed employment history used for autofill and resume generation.", examples=["Software Engineer Intern, Acme Corp (Summer 2025): built API endpoints and dashboards."])
+    canonical_data: dict | None = Field(default=None, description="Canonical structured applicant data aligned to the resume parser schema for downstream autofill.", examples=[{"personal_info": {"first_name": "Jane"}, "education": [], "work_experience": []}])
+    token_map: dict | None = Field(default=None, description="Flattened token map derived from canonical_data and prepared for extension autofill consumers.", examples=[{"personal_info.first_name": "Jane"}])
     demographic_gender: str | None = Field(default=None, max_length=80, description="Optional self-identified gender for EEO forms.", examples=["Prefer not to say"])
     demographic_ethnicity: str | None = Field(default=None, max_length=120, description="Optional self-identified ethnicity for EEO forms.", examples=["Prefer not to say"])
     veteran_status: str | None = Field(default=None, max_length=120, description="Optional veteran status answer used in compliance forms.", examples=["Not a protected veteran"])
@@ -84,7 +86,11 @@ class ProfileListItem(BaseModel):
     is_active: bool = Field(..., description="Whether this profile is currently active for autofill operations.", examples=[False])
     first_name: str | None = Field(default=None, description="Applicant first name snapshot for quick list display.", examples=["Jane"])
     last_name: str | None = Field(default=None, description="Applicant last name snapshot for quick list display.", examples=["Doe"])
+    city: str | None = Field(default=None, description="City snapshot used to distinguish applicant profiles quickly.", examples=["Huntsville"])
+    state: str | None = Field(default=None, description="State snapshot used to distinguish applicant profiles quickly.", examples=["AL"])
+    job_title: str | None = Field(default=None, description="Current or target role snapshot used in the profile picker.", examples=["Software Engineer"])
     created_at: datetime = Field(..., description="UTC timestamp when this profile was first created.", examples=["2026-03-31T13:45:01.120000Z"])
+    updated_at: datetime = Field(..., description="UTC timestamp when this profile was last updated.", examples=["2026-03-31T14:10:40.550000Z"])
 
     class Config:
         from_attributes = True

--- a/backend/app/schemas/resume.py
+++ b/backend/app/schemas/resume.py
@@ -48,6 +48,21 @@ class ResumeResponse(BaseModel):
         description="Parser mode used most recently for this resume. Supported values: 'cloud', 'local', or 'rules'.",
         examples=["local"],
     )
+    review_status: str | None = Field(
+        default=None,
+        description="Review state for parsed resume data before it is merged into an applicant profile.",
+        examples=["pending"],
+    )
+    has_review_draft: bool = Field(
+        default=False,
+        description="True when this resume has a persisted review draft that can be resumed later.",
+        examples=[True],
+    )
+    review_updated_at: datetime | None = Field(
+        default=None,
+        description="UTC timestamp when the persisted review draft was last updated.",
+        examples=["2026-04-14T14:25:19.987654Z"],
+    )
     has_pdf: bool = Field(
         default=False,
         description="Indicates whether original binary PDF content is still available for download/preview.",
@@ -87,6 +102,16 @@ class ResumeListItem(BaseModel):
         default=None,
         description="Most recent parse engine used for this resume.",
         examples=["cloud"],
+    )
+    review_status: str | None = Field(
+        default=None,
+        description="Review state for the resume's persisted parse draft.",
+        examples=["pending"],
+    )
+    has_review_draft: bool = Field(
+        default=False,
+        description="Whether a persisted review draft is available for resume-review resumption.",
+        examples=[True],
     )
     has_pdf: bool = Field(
         default=False,
@@ -234,3 +259,47 @@ class ParseJobStartResponse(BaseModel):
         description="Initial parse job state, typically 'queued'.",
         examples=["queued"],
     )
+
+
+class ResumeReviewDraftUpdate(BaseModel):
+    review_draft: dict = Field(
+        ...,
+        description="Edited review draft based on parsed structured resume data.",
+        examples=[{"personal_info": {"first_name": "Jane"}}],
+    )
+
+
+class ResumeReviewDraftResponse(BaseModel):
+    resume_id: int = Field(..., description="Resume identifier whose review draft is being inspected.", examples=[101])
+    file_name: str = Field(..., description="Stored resume filename.", examples=["Jane_Doe_Resume.pdf"])
+    parse_method: str | None = Field(default=None, description="Parser method used to produce the draft.", examples=["local"])
+    review_status: str | None = Field(default=None, description="Current review lifecycle state for this draft.", examples=["pending"])
+    review_updated_at: datetime | None = Field(default=None, description="UTC timestamp of the latest persisted review draft update.", examples=["2026-04-14T14:25:19.987654Z"])
+    review_draft: dict = Field(..., description="Editable structured review draft returned to the frontend.", examples=[{"personal_info": {"first_name": "Jane"}}])
+
+
+class ResumeReviewConflictRequest(BaseModel):
+    profile_id: int = Field(..., description="Applicant profile identifier selected for merge preview.", examples=[15])
+    reviewed_data: dict | None = Field(default=None, description="Optional reviewed draft override from the UI before merge preview.", examples=[{"personal_info": {"first_name": "Jane"}}])
+
+
+class ResumeReviewConflictResponse(BaseModel):
+    profile_id: int = Field(..., description="Applicant profile identifier used for conflict evaluation.", examples=[15])
+    conflict_count: int = Field(..., description="Number of conflicting non-empty values between the selected profile and reviewed draft.", examples=[4])
+    conflicts: list[dict] = Field(default_factory=list, description="Conflict items keyed by canonical path for frontend review resolution.")
+
+
+class ResumeReviewApplyRequest(BaseModel):
+    mode: str = Field(..., description="Apply mode: 'existing' to merge into a profile or 'new' to create one.", examples=["existing"])
+    reviewed_data: dict = Field(..., description="Final reviewed structured data to commit into the applicant profile system.", examples=[{"personal_info": {"first_name": "Jane"}}])
+    profile_id: int | None = Field(default=None, description="Existing applicant profile identifier when mode='existing'.", examples=[15])
+    profile_name: str | None = Field(default=None, description="Name for the new applicant profile when mode='new'.", examples=["Spring 2026 Profile"])
+    conflict_resolutions: dict | None = Field(default=None, description="Per-path resolution map. Use 'incoming' to override an existing profile value.", examples=[{"personal_info.email": "incoming"}])
+
+
+class ResumeReviewApplyResponse(BaseModel):
+    resume_id: int = Field(..., description="Resume identifier whose review draft was applied.", examples=[101])
+    profile_id: int = Field(..., description="Applicant profile identifier that received the reviewed data.", examples=[15])
+    review_status: str = Field(..., description="Review status after apply completes.", examples=["applied"])
+    conflict_count: int = Field(..., description="Total number of conflicts that were evaluated during merge.", examples=[4])
+    profile: dict = Field(..., description="Updated applicant profile payload after the review draft was applied.")

--- a/backend/app/services/applicant_profile_canonical.py
+++ b/backend/app/services/applicant_profile_canonical.py
@@ -1,0 +1,883 @@
+import copy
+import re
+from typing import Any
+
+
+PLACEHOLDER_VALUES = {
+    "null",
+    "none",
+    "n/a",
+    "na",
+    "unknown",
+    "not provided",
+    "not available",
+    "-",
+    "--",
+}
+
+
+def _clean_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    if cleaned.lower() in PLACEHOLDER_VALUES:
+        return None
+    return cleaned
+
+
+def _clean_list(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        item = _clean_string(value)
+        if not item:
+            continue
+        key = item.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        cleaned.append(item)
+    return cleaned
+
+
+def _split_inline_list(text: str | None) -> list[str]:
+    raw = _clean_string(text)
+    if not raw:
+        return []
+    chunks = re.split(r"[\n,;]+", raw)
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for chunk in chunks:
+        item = _clean_string(chunk)
+        if not item:
+            continue
+        key = item.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        cleaned.append(item)
+    return cleaned
+
+
+def _compact_entry(entry: Any) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    for key, value in entry.items():
+        if isinstance(value, list):
+            cleaned = _clean_list(value)
+            if cleaned:
+                compact[key] = cleaned
+            continue
+        if isinstance(value, bool):
+            compact[key] = value
+            continue
+        cleaned_value = _clean_string(value)
+        if cleaned_value is not None:
+            compact[key] = cleaned_value
+    return compact
+
+
+def _dedupe_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    deduped: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for entry in entries:
+        compact = _compact_entry(entry)
+        if not compact:
+            continue
+        signature = repr(compact)
+        if signature in seen:
+            continue
+        seen.add(signature)
+        deduped.append(compact)
+    return deduped
+
+
+def split_date_tokens(value: str | None) -> dict[str, str | bool | None]:
+    raw = _clean_string(value)
+    if not raw:
+        return {"month": None, "year": None, "is_present": False}
+
+    if raw.lower() == "present":
+        return {"month": None, "year": None, "is_present": True}
+
+    match = re.match(r"^\s*([A-Za-z]+)\s+(\d{4})\s*$", raw)
+    if match:
+        return {"month": match.group(1), "year": match.group(2), "is_present": False}
+
+    year_match = re.match(r"^\s*(\d{4})\s*$", raw)
+    if year_match:
+        return {"month": None, "year": year_match.group(1), "is_present": False}
+
+    return {"month": None, "year": None, "is_present": False}
+
+
+def empty_canonical_profile() -> dict[str, Any]:
+    return {
+        "personal_info": {},
+        "summary": None,
+        "education": [],
+        "work_experience": [],
+        "skills": {
+            "technical": [],
+            "languages": [],
+            "tools": [],
+            "soft_skills": [],
+        },
+        "projects": [],
+        "certifications": [],
+        "awards": [],
+        "activities": [],
+        "volunteer": [],
+    }
+
+
+def normalize_canonical_data(data: Any) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        data = {}
+
+    canonical = empty_canonical_profile()
+
+    personal_info = data.get("personal_info", {}) if isinstance(data.get("personal_info"), dict) else {}
+    canonical["personal_info"] = {
+        key: value
+        for key, value in {
+            "first_name": _clean_string(personal_info.get("first_name")),
+            "last_name": _clean_string(personal_info.get("last_name")),
+            "email": _clean_string(personal_info.get("email")),
+            "phone": _clean_string(personal_info.get("phone")),
+            "address": _clean_string(personal_info.get("address")),
+            "city": _clean_string(personal_info.get("city")),
+            "state": _clean_string(personal_info.get("state")),
+            "zip": _clean_string(personal_info.get("zip")),
+            "linkedin": _clean_string(personal_info.get("linkedin")),
+            "website": _clean_string(personal_info.get("website")),
+        }.items()
+        if value is not None
+    }
+
+    canonical["summary"] = _clean_string(data.get("summary"))
+
+    education: list[dict[str, Any]] = []
+    for item in data.get("education", []) if isinstance(data.get("education"), list) else []:
+        if not isinstance(item, dict):
+            continue
+        entry = {
+            "institution": _clean_string(item.get("institution")),
+            "degree": _clean_string(item.get("degree")),
+            "field_of_study": _clean_string(item.get("field_of_study")),
+            "gpa": _clean_string(item.get("gpa")),
+            "start_date": _clean_string(item.get("start_date")),
+            "end_date": _clean_string(item.get("end_date")),
+            "honors": _clean_list(item.get("honors")),
+            "relevant_coursework": _clean_list(item.get("relevant_coursework")),
+        }
+        compact = {key: value for key, value in entry.items() if value not in (None, [], {})}
+        if compact:
+            education.append(compact)
+    canonical["education"] = _dedupe_entries(education)
+
+    work_experience: list[dict[str, Any]] = []
+    for item in data.get("work_experience", []) if isinstance(data.get("work_experience"), list) else []:
+        if not isinstance(item, dict):
+            continue
+        entry = {
+            "company": _clean_string(item.get("company")),
+            "title": _clean_string(item.get("title")),
+            "location": _clean_string(item.get("location")),
+            "start_date": _clean_string(item.get("start_date")),
+            "end_date": _clean_string(item.get("end_date")),
+            "is_current": bool(item.get("is_current")) if item.get("is_current") is not None else None,
+            "bullets": _clean_list(item.get("bullets")),
+        }
+        if entry.get("end_date") and entry["end_date"].lower() == "present":
+            entry["is_current"] = True
+        compact = {key: value for key, value in entry.items() if value not in (None, [], {})}
+        if compact:
+            work_experience.append(compact)
+    canonical["work_experience"] = _dedupe_entries(work_experience)
+
+    skills = data.get("skills", {}) if isinstance(data.get("skills"), dict) else {}
+    canonical["skills"] = {
+        "technical": _clean_list(skills.get("technical")),
+        "languages": _clean_list(skills.get("languages")),
+        "tools": _clean_list(skills.get("tools")),
+        "soft_skills": _clean_list(skills.get("soft_skills")),
+    }
+
+    projects: list[dict[str, Any]] = []
+    for item in data.get("projects", []) if isinstance(data.get("projects"), list) else []:
+        if not isinstance(item, dict):
+            continue
+        entry = {
+            "name": _clean_string(item.get("name")),
+            "description": _clean_string(item.get("description")),
+            "technologies": _clean_list(item.get("technologies")),
+            "date": _clean_string(item.get("date")),
+        }
+        compact = {key: value for key, value in entry.items() if value not in (None, [], {})}
+        if compact:
+            projects.append(compact)
+    canonical["projects"] = _dedupe_entries(projects)
+
+    certifications: list[dict[str, Any]] = []
+    for item in data.get("certifications", []) if isinstance(data.get("certifications"), list) else []:
+        if isinstance(item, str):
+            entry = {"name": _clean_string(item)}
+        elif isinstance(item, dict):
+            entry = {
+                "name": _clean_string(item.get("name")),
+                "issuer": _clean_string(item.get("issuer")),
+                "date": _clean_string(item.get("date")),
+            }
+        else:
+            continue
+        compact = {key: value for key, value in entry.items() if value not in (None, [], {})}
+        if compact:
+            certifications.append(compact)
+    canonical["certifications"] = _dedupe_entries(certifications)
+
+    canonical["awards"] = _clean_list(data.get("awards"))
+    canonical["activities"] = _clean_list(data.get("activities"))
+    canonical["volunteer"] = _clean_list(data.get("volunteer"))
+
+    return canonical
+
+
+def _parse_education_history(text: str | None) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    raw = _clean_string(text)
+    if not raw:
+        return entries
+
+    for line in raw.splitlines():
+        cleaned = _clean_string(line)
+        if not cleaned:
+            continue
+        parts = [part.strip() for part in cleaned.split("|")]
+        entry = {
+            "institution": _clean_string(parts[0]) if len(parts) > 0 else None,
+            "degree": _clean_string(parts[1]) if len(parts) > 1 else None,
+            "field_of_study": _clean_string(parts[2]) if len(parts) > 2 else None,
+            "start_date": _clean_string(parts[3]) if len(parts) > 3 else None,
+            "end_date": _clean_string(parts[4]) if len(parts) > 4 else None,
+            "gpa": _clean_string(parts[5]) if len(parts) > 5 else None,
+        }
+        compact = {key: value for key, value in entry.items() if value is not None}
+        if compact:
+            entries.append(compact)
+    return entries
+
+
+def _parse_employment_history(text: str | None) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    raw = _clean_string(text)
+    if not raw:
+        return entries
+
+    for line in raw.splitlines():
+        cleaned = _clean_string(line)
+        if not cleaned:
+            continue
+        parts = [part.strip() for part in cleaned.split("|")]
+        entry = {
+            "company": _clean_string(parts[0]) if len(parts) > 0 else None,
+            "title": _clean_string(parts[1]) if len(parts) > 1 else None,
+            "location": _clean_string(parts[2]) if len(parts) > 2 else None,
+            "start_date": _clean_string(parts[3]) if len(parts) > 3 else None,
+            "end_date": _clean_string(parts[4]) if len(parts) > 4 else None,
+        }
+        compact = {key: value for key, value in entry.items() if value is not None}
+        if compact:
+            if compact.get("end_date", "").lower() == "present":
+                compact["is_current"] = True
+            entries.append(compact)
+    return entries
+
+
+def _parse_certifications(text: str | None) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    raw = _clean_string(text)
+    if not raw:
+        return entries
+    for line in raw.splitlines():
+        cleaned = _clean_string(line)
+        if not cleaned:
+            continue
+        entries.append({"name": cleaned})
+    return entries
+
+
+def derive_canonical_from_profile_fields(values: dict[str, Any]) -> dict[str, Any]:
+    personal_info = {
+        "first_name": _clean_string(values.get("first_name")),
+        "last_name": _clean_string(values.get("last_name")),
+        "email": _clean_string(values.get("email")),
+        "phone": _clean_string(values.get("phone")),
+        "address": _clean_string(values.get("street_address")),
+        "city": _clean_string(values.get("city")),
+        "state": _clean_string(values.get("state")),
+        "zip": _clean_string(values.get("zip")),
+        "linkedin": _clean_string(values.get("linkedin")),
+        "website": _clean_string(values.get("portfolio")),
+    }
+
+    education: list[dict[str, Any]] = []
+    primary_education = {
+        "institution": _clean_string(values.get("university")),
+        "degree": _clean_string(values.get("degree")),
+        "field_of_study": _clean_string(values.get("major")),
+        "gpa": _clean_string(values.get("gpa")),
+        "end_date": _clean_string(values.get("grad_year")),
+    }
+    primary_education = {key: value for key, value in primary_education.items() if value is not None}
+    if primary_education:
+        education.append(primary_education)
+    education.extend(_parse_education_history(values.get("education_history_text")))
+
+    work_experience: list[dict[str, Any]] = []
+    work_experience.extend(_parse_employment_history(values.get("employment_history_text")))
+    if not work_experience and _clean_string(values.get("job_title")):
+        entry = {"title": _clean_string(values.get("job_title"))}
+        work_experience.append(entry)
+
+    certifications = _parse_certifications(values.get("certifications_text"))
+
+    canonical = {
+        "personal_info": personal_info,
+        "summary": _clean_string(values.get("summary")),
+        "education": education,
+        "work_experience": work_experience,
+        "skills": {
+            "technical": _split_inline_list(values.get("skills_text")),
+            "languages": [],
+            "tools": [],
+            "soft_skills": [],
+        },
+        "projects": [],
+        "certifications": certifications,
+        "awards": [],
+        "activities": [],
+        "volunteer": [],
+    }
+    return normalize_canonical_data(canonical)
+
+
+def apply_profile_updates_to_canonical(
+    existing_canonical: dict[str, Any],
+    updates: dict[str, Any],
+) -> dict[str, Any]:
+    canonical = normalize_canonical_data(existing_canonical)
+    updates = updates or {}
+
+    personal_map = {
+        "first_name": "first_name",
+        "last_name": "last_name",
+        "email": "email",
+        "phone": "phone",
+        "street_address": "address",
+        "city": "city",
+        "state": "state",
+        "zip": "zip",
+        "linkedin": "linkedin",
+        "portfolio": "website",
+    }
+    for field_name, canonical_key in personal_map.items():
+        if field_name not in updates:
+            continue
+        value = _clean_string(updates.get(field_name))
+        if value is None:
+            canonical.setdefault("personal_info", {}).pop(canonical_key, None)
+        else:
+            canonical.setdefault("personal_info", {})[canonical_key] = value
+
+    if "summary" in updates:
+        canonical["summary"] = _clean_string(updates.get("summary"))
+
+    primary_education_fields = {
+        "degree": "degree",
+        "major": "field_of_study",
+        "university": "institution",
+        "grad_year": "end_date",
+        "gpa": "gpa",
+    }
+    if any(field in updates for field in primary_education_fields):
+        education = list(canonical.get("education", []))
+        primary = dict(education[0]) if education else {}
+        for field_name, canonical_key in primary_education_fields.items():
+            if field_name not in updates:
+                continue
+            value = _clean_string(updates.get(field_name))
+            if value is None:
+                primary.pop(canonical_key, None)
+            else:
+                primary[canonical_key] = value
+        if primary:
+            if education:
+                education[0] = primary
+            else:
+                education = [primary]
+        elif education:
+            education = education[1:]
+        canonical["education"] = _dedupe_entries(education)
+
+    if "education_history_text" in updates:
+        education = list(canonical.get("education", []))
+        primary = education[:1]
+        additional = _parse_education_history(updates.get("education_history_text"))
+        canonical["education"] = _dedupe_entries(primary + additional)
+
+    if "job_title" in updates:
+        work_experience = list(canonical.get("work_experience", []))
+        primary = dict(work_experience[0]) if work_experience else {}
+        value = _clean_string(updates.get("job_title"))
+        if value is None:
+            primary.pop("title", None)
+        else:
+            primary["title"] = value
+        if primary:
+            if work_experience:
+                work_experience[0] = primary
+            else:
+                work_experience = [primary]
+        elif work_experience:
+            work_experience = work_experience[1:]
+        canonical["work_experience"] = _dedupe_entries(work_experience)
+
+    if "employment_history_text" in updates:
+        work_experience = list(canonical.get("work_experience", []))
+        primary = work_experience[:1]
+        additional = _parse_employment_history(updates.get("employment_history_text"))
+        canonical["work_experience"] = _dedupe_entries(primary + additional)
+
+    if "skills_text" in updates:
+        technical = _split_inline_list(updates.get("skills_text"))
+        canonical.setdefault("skills", {})
+        canonical["skills"]["technical"] = technical
+
+    if "certifications_text" in updates:
+        canonical["certifications"] = _dedupe_entries(_parse_certifications(updates.get("certifications_text")))
+
+    return normalize_canonical_data(canonical)
+
+
+def _unique_in_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        item = _clean_string(value)
+        if not item:
+            continue
+        key = item.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        ordered.append(item)
+    return ordered
+
+
+def _format_education_entry(entry: dict[str, Any]) -> str:
+    parts = [
+        entry.get("institution") or "",
+        entry.get("degree") or "",
+        entry.get("field_of_study") or "",
+        entry.get("start_date") or "",
+        entry.get("end_date") or "",
+    ]
+    if entry.get("gpa"):
+        parts.append(entry["gpa"])
+    return " | ".join(parts).strip()
+
+
+def _format_work_entry(entry: dict[str, Any]) -> str:
+    end_date = entry.get("end_date") or ("Present" if entry.get("is_current") else "")
+    parts = [
+        entry.get("company") or "",
+        entry.get("title") or "",
+        entry.get("location") or "",
+        entry.get("start_date") or "",
+        end_date or "",
+    ]
+    return " | ".join(parts).strip()
+
+
+def derive_profile_fields_from_canonical(canonical_data: dict[str, Any], existing: dict[str, Any] | None = None) -> dict[str, Any]:
+    canonical = normalize_canonical_data(canonical_data)
+    existing = existing or {}
+    personal_info = canonical.get("personal_info", {})
+    education = canonical.get("education", [])
+    work_experience = canonical.get("work_experience", [])
+    primary_education = education[0] if education else {}
+    primary_experience = work_experience[0] if work_experience else {}
+
+    skills = canonical.get("skills", {})
+    all_skills = _unique_in_order(
+        list(skills.get("technical", []))
+        + list(skills.get("languages", []))
+        + list(skills.get("tools", []))
+        + list(skills.get("soft_skills", []))
+    )
+
+    return {
+        "first_name": personal_info.get("first_name"),
+        "last_name": personal_info.get("last_name"),
+        "email": personal_info.get("email"),
+        "phone": personal_info.get("phone"),
+        "linkedin": personal_info.get("linkedin"),
+        "portfolio": personal_info.get("website"),
+        "street_address": personal_info.get("address"),
+        "city": personal_info.get("city"),
+        "state": personal_info.get("state"),
+        "zip": personal_info.get("zip"),
+        "summary": canonical.get("summary"),
+        "degree": primary_education.get("degree"),
+        "major": primary_education.get("field_of_study"),
+        "university": primary_education.get("institution"),
+        "grad_year": primary_education.get("end_date"),
+        "gpa": primary_education.get("gpa"),
+        "job_title": primary_experience.get("title") or existing.get("job_title"),
+        "years_experience": existing.get("years_experience"),
+        "skills_text": ", ".join(all_skills) if all_skills else None,
+        "certifications_text": "\n".join(
+            item.get("name") or ""
+            for item in canonical.get("certifications", [])
+            if isinstance(item, dict) and _clean_string(item.get("name"))
+        ) or None,
+        "professional_links_text": existing.get("professional_links_text"),
+        "education_history_text": "\n".join(
+            _format_education_entry(item)
+            for item in education[1:]
+            if isinstance(item, dict)
+        ) or None,
+        "employment_history_text": "\n".join(
+            _format_work_entry(item)
+            for item in work_experience[1:]
+            if isinstance(item, dict)
+        ) or None,
+    }
+
+
+def flatten_canonical_data(canonical_data: dict[str, Any], include_derived: bool = False) -> dict[str, Any]:
+    canonical = normalize_canonical_data(canonical_data)
+    tokens: dict[str, Any] = {}
+
+    personal_info = canonical.get("personal_info", {})
+    for key, value in personal_info.items():
+        if value not in (None, "", [], {}):
+            tokens[f"personal_info.{key}"] = value
+
+    if canonical.get("summary"):
+        tokens["summary"] = canonical["summary"]
+
+    for index, entry in enumerate(canonical.get("education", [])):
+        if not isinstance(entry, dict):
+            continue
+        for key, value in entry.items():
+            if value in (None, "", [], {}):
+                continue
+            tokens[f"education[{index}].{key}"] = value if not isinstance(value, list) else ", ".join(value)
+        if include_derived:
+            start = split_date_tokens(entry.get("start_date"))
+            end = split_date_tokens(entry.get("end_date"))
+            if start.get("month"):
+                tokens[f"education[{index}].start_month"] = start["month"]
+            if start.get("year"):
+                tokens[f"education[{index}].start_year"] = start["year"]
+            if end.get("is_present"):
+                tokens[f"education[{index}].is_current"] = True
+            else:
+                if end.get("month"):
+                    tokens[f"education[{index}].end_month"] = end["month"]
+                if end.get("year"):
+                    tokens[f"education[{index}].end_year"] = end["year"]
+
+    for index, entry in enumerate(canonical.get("work_experience", [])):
+        if not isinstance(entry, dict):
+            continue
+        for key, value in entry.items():
+            if value in (None, "", [], {}):
+                continue
+            if isinstance(value, list):
+                tokens[f"work_experience[{index}].{key}"] = "\n".join(value)
+            else:
+                tokens[f"work_experience[{index}].{key}"] = value
+        if include_derived:
+            start = split_date_tokens(entry.get("start_date"))
+            end = split_date_tokens(entry.get("end_date"))
+            if start.get("month"):
+                tokens[f"work_experience[{index}].start_month"] = start["month"]
+            if start.get("year"):
+                tokens[f"work_experience[{index}].start_year"] = start["year"]
+            if entry.get("is_current") or end.get("is_present"):
+                tokens[f"work_experience[{index}].is_current"] = True
+            else:
+                if end.get("month"):
+                    tokens[f"work_experience[{index}].end_month"] = end["month"]
+                if end.get("year"):
+                    tokens[f"work_experience[{index}].end_year"] = end["year"]
+
+    for category, items in canonical.get("skills", {}).items():
+        if isinstance(items, list) and items:
+            tokens[f"skills.{category}"] = ", ".join(items)
+
+    for index, entry in enumerate(canonical.get("projects", [])):
+        if not isinstance(entry, dict):
+            continue
+        for key, value in entry.items():
+            if value in (None, "", [], {}):
+                continue
+            tokens[f"projects[{index}].{key}"] = value if not isinstance(value, list) else ", ".join(value)
+
+    for index, entry in enumerate(canonical.get("certifications", [])):
+        if not isinstance(entry, dict):
+            continue
+        for key, value in entry.items():
+            if value in (None, "", [], {}):
+                continue
+            tokens[f"certifications[{index}].{key}"] = value
+
+    for key in ("awards", "activities", "volunteer"):
+        items = canonical.get(key, [])
+        if isinstance(items, list) and items:
+            tokens[key] = "\n".join(items)
+
+    return tokens
+
+
+_PATH_PART_RE = re.compile(r"([^\[\]]+)(?:\[(\d+)\])?$")
+
+
+def _set_nested_value(target: dict[str, Any], path: str, value: Any) -> None:
+    current: Any = target
+    parts = path.split(".")
+    for index, part in enumerate(parts):
+        match = _PATH_PART_RE.match(part)
+        if not match:
+            return
+        key = match.group(1)
+        list_index = int(match.group(2)) if match.group(2) is not None else None
+        is_last = index == len(parts) - 1
+
+        if list_index is None:
+            if is_last:
+                current[key] = value
+                return
+            if key not in current or not isinstance(current[key], dict):
+                current[key] = {}
+            current = current[key]
+            continue
+
+        if key not in current or not isinstance(current[key], list):
+            current[key] = []
+        while len(current[key]) <= list_index:
+            current[key].append({})
+        if is_last:
+            current[key][list_index] = value
+            return
+        if not isinstance(current[key][list_index], dict):
+            current[key][list_index] = {}
+        current = current[key][list_index]
+
+
+def inflate_canonical_from_tokens(token_map: dict[str, Any]) -> dict[str, Any]:
+    base = empty_canonical_profile()
+    if not isinstance(token_map, dict):
+        return base
+
+    for path, value in token_map.items():
+        if value in (None, "", [], {}):
+            continue
+        if path.endswith(".start_month") or path.endswith(".start_year") or path.endswith(".end_month") or path.endswith(".end_year"):
+            continue
+        if path.endswith(".is_current") and "[" in path:
+            _set_nested_value(base, path, bool(value))
+            continue
+        if path.startswith("skills.") and isinstance(value, str):
+            _set_nested_value(base, path, _split_inline_list(value))
+            continue
+        if path in {"awards", "activities", "volunteer"} and isinstance(value, str):
+            _set_nested_value(base, path, [item for item in value.splitlines() if _clean_string(item)])
+            continue
+        if (path.endswith(".bullets") or path.endswith(".honors") or path.endswith(".relevant_coursework")) and isinstance(value, str):
+            if path.endswith(".bullets"):
+                _set_nested_value(base, path, [item for item in value.splitlines() if _clean_string(item)])
+            else:
+                _set_nested_value(base, path, _split_inline_list(value))
+            continue
+        if path.endswith(".technologies") and isinstance(value, str):
+            _set_nested_value(base, path, _split_inline_list(value))
+            continue
+        _set_nested_value(base, path, value)
+
+    return normalize_canonical_data(base)
+
+
+def profile_to_values(profile: Any) -> dict[str, Any]:
+    return {
+        "name": getattr(profile, "name", None),
+        "first_name": getattr(profile, "first_name", None),
+        "last_name": getattr(profile, "last_name", None),
+        "email": getattr(profile, "email", None),
+        "phone": getattr(profile, "phone", None),
+        "linkedin": getattr(profile, "linkedin", None),
+        "portfolio": getattr(profile, "portfolio", None),
+        "street_address": getattr(profile, "street_address", None),
+        "city": getattr(profile, "city", None),
+        "state": getattr(profile, "state", None),
+        "zip": getattr(profile, "zip", None),
+        "summary": getattr(profile, "summary", None),
+        "work_auth": getattr(profile, "work_auth", None),
+        "requires_sponsorship": getattr(profile, "requires_sponsorship", None),
+        "degree": getattr(profile, "degree", None),
+        "major": getattr(profile, "major", None),
+        "university": getattr(profile, "university", None),
+        "grad_year": getattr(profile, "grad_year", None),
+        "gpa": getattr(profile, "gpa", None),
+        "years_experience": getattr(profile, "years_experience", None),
+        "job_title": getattr(profile, "job_title", None),
+        "skills_text": getattr(profile, "skills_text", None),
+        "certifications_text": getattr(profile, "certifications_text", None),
+        "professional_links_text": getattr(profile, "professional_links_text", None),
+        "education_history_text": getattr(profile, "education_history_text", None),
+        "employment_history_text": getattr(profile, "employment_history_text", None),
+        "demographic_gender": getattr(profile, "demographic_gender", None),
+        "demographic_ethnicity": getattr(profile, "demographic_ethnicity", None),
+        "veteran_status": getattr(profile, "veteran_status", None),
+        "disability_status": getattr(profile, "disability_status", None),
+        "california_resident": getattr(profile, "california_resident", None),
+        "canonical_data": copy.deepcopy(getattr(profile, "canonical_data", None)),
+        "token_map": copy.deepcopy(getattr(profile, "token_map", None)),
+    }
+
+
+def sync_profile_storage(profile: Any) -> dict[str, Any]:
+    values = profile_to_values(profile)
+    if isinstance(values.get("canonical_data"), dict) and values["canonical_data"]:
+        canonical = normalize_canonical_data(values["canonical_data"])
+    else:
+        canonical = derive_canonical_from_profile_fields(values)
+
+    flat_updates = derive_profile_fields_from_canonical(canonical, existing=values)
+    for key, value in flat_updates.items():
+        setattr(profile, key, value)
+
+    profile.canonical_data = canonical
+    profile.token_map = flatten_canonical_data(canonical, include_derived=True)
+    return canonical
+
+
+def build_profile_from_review(profile: Any, reviewed_data: dict[str, Any]) -> dict[str, Any]:
+    canonical = normalize_canonical_data(reviewed_data)
+    profile.canonical_data = canonical
+    return sync_profile_storage(profile)
+
+
+def _append_unique_entries(target: list[dict[str, Any]], incoming: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    combined = [_compact_entry(entry) for entry in target]
+    filtered = [entry for entry in combined if entry]
+    seen = {repr(entry) for entry in filtered}
+    for entry in incoming:
+        compact = _compact_entry(entry)
+        if not compact:
+            continue
+        signature = repr(compact)
+        if signature in seen:
+            continue
+        seen.add(signature)
+        filtered.append(compact)
+    return filtered
+
+
+def friendly_path_label(path: str) -> str:
+    label = path
+    label = re.sub(r"personal_info\.", "", label)
+    label = label.replace("work_experience", "Work Experience")
+    label = label.replace("education", "Education")
+    label = label.replace("certifications", "Certifications")
+    label = label.replace("projects", "Projects")
+    label = label.replace("skills.", "Skills ")
+    label = label.replace("_", " ")
+    label = re.sub(r"\[(\d+)\]", lambda match: f" #{int(match.group(1)) + 1}", label)
+    return " ".join(part.capitalize() for part in label.split())
+
+
+def generate_review_conflicts(existing_canonical: dict[str, Any], incoming_canonical: dict[str, Any]) -> list[dict[str, Any]]:
+    existing_tokens = flatten_canonical_data(existing_canonical, include_derived=False)
+    incoming_tokens = flatten_canonical_data(incoming_canonical, include_derived=False)
+    conflicts: list[dict[str, Any]] = []
+    for path, incoming_value in incoming_tokens.items():
+        existing_value = existing_tokens.get(path)
+        if existing_value in (None, "", [], {}) or incoming_value in (None, "", [], {}):
+            continue
+        if existing_value == incoming_value:
+            continue
+        conflicts.append(
+            {
+                "id": path,
+                "path": path,
+                "label": friendly_path_label(path),
+                "existing_value": existing_value,
+                "incoming_value": incoming_value,
+                "resolution": "existing",
+            }
+        )
+    conflicts.sort(key=lambda item: item["label"])
+    return conflicts
+
+
+def merge_review_into_profile(
+    existing_canonical: dict[str, Any],
+    incoming_canonical: dict[str, Any],
+    conflict_resolutions: dict[str, str] | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    conflict_resolutions = conflict_resolutions or {}
+    existing_tokens = flatten_canonical_data(existing_canonical, include_derived=False)
+    incoming_tokens = flatten_canonical_data(incoming_canonical, include_derived=False)
+    conflicts = generate_review_conflicts(existing_canonical, incoming_canonical)
+
+    merged_tokens = dict(existing_tokens)
+    conflict_paths = {item["path"] for item in conflicts}
+
+    for path, value in incoming_tokens.items():
+        if value in (None, "", [], {}):
+            continue
+        if path not in merged_tokens or merged_tokens[path] in (None, "", [], {}):
+            merged_tokens[path] = value
+            continue
+        if path in conflict_paths:
+            if conflict_resolutions.get(path) == "incoming":
+                merged_tokens[path] = value
+            continue
+        merged_tokens[path] = value
+
+    merged = inflate_canonical_from_tokens(merged_tokens)
+
+    # Preserve richer array sections by appending unique incoming items after token merge.
+    for section in ("education", "work_experience", "projects", "certifications"):
+        merged[section] = _append_unique_entries(
+            merged.get(section, []) if isinstance(merged.get(section), list) else [],
+            incoming_canonical.get(section, []) if isinstance(incoming_canonical.get(section), list) else [],
+        )
+
+    for section in ("awards", "activities", "volunteer"):
+        merged[section] = _unique_in_order(
+            list(existing_canonical.get(section, []) if isinstance(existing_canonical.get(section), list) else [])
+            + list(incoming_canonical.get(section, []) if isinstance(incoming_canonical.get(section), list) else [])
+        )
+
+    for category in ("technical", "languages", "tools", "soft_skills"):
+        existing_items = existing_canonical.get("skills", {}).get(category, [])
+        incoming_items = incoming_canonical.get("skills", {}).get(category, [])
+        merged.setdefault("skills", {})
+        merged["skills"][category] = _unique_in_order(
+            list(existing_items if isinstance(existing_items, list) else [])
+            + list(incoming_items if isinstance(incoming_items, list) else [])
+        )
+
+    return normalize_canonical_data(merged), conflicts

--- a/backend/app/services/parse_job_runner.py
+++ b/backend/app/services/parse_job_runner.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timezone
 
 from app.db.session import SessionLocal
 from app.models.parse_job import ParseJob
@@ -136,6 +137,9 @@ async def run_parse_job(job_id: int) -> bool:
         resume.structured_data = structured
         resume.parse_method = method
         resume.portal_ready = structured.get("_validation", {}).get("portal_ready", False)
+        resume.review_status = "pending"
+        resume.review_draft = structured
+        resume.review_updated_at = datetime.now(timezone.utc)
 
         validation = structured.get("_validation", {})
         job.status = "success"

--- a/backend/tests/test_applicant_profile_canonical.py
+++ b/backend/tests/test_applicant_profile_canonical.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+import unittest
+
+from app.services.applicant_profile_canonical import (
+    apply_profile_updates_to_canonical,
+    derive_canonical_from_profile_fields,
+    flatten_canonical_data,
+    merge_review_into_profile,
+    normalize_canonical_data,
+    sync_profile_storage,
+)
+
+
+class ApplicantProfileCanonicalTests(unittest.TestCase):
+    def test_sync_profile_storage_generates_canonical_and_token_map_from_flat_fields(self):
+        profile = SimpleNamespace(
+            first_name="Local",
+            last_name="Developer",
+            email="local@example.com",
+            phone="",
+            linkedin="https://linkedin.com/in/localdev",
+            portfolio="https://local.dev",
+            street_address="123 Main St",
+            city="Huntsville",
+            state="AL",
+            zip="35801",
+            summary="Frontend-focused builder.",
+            degree="B.S.",
+            major="Computer Science",
+            university="UAH",
+            grad_year="2025",
+            gpa="3.8",
+            years_experience="5",
+            job_title="Frontend Engineer",
+            skills_text="Vue, Python, SQL",
+            certifications_text="AWS CCP",
+            professional_links_text="GitHub: https://github.com/localdev",
+            education_history_text="",
+            employment_history_text="UAH | Frontend Engineer | Huntsville, AL | 2023 | Present",
+            demographic_gender="",
+            demographic_ethnicity="",
+            veteran_status="",
+            disability_status="",
+            california_resident="",
+            canonical_data=None,
+            token_map=None,
+        )
+
+        canonical = sync_profile_storage(profile)
+
+        self.assertEqual(canonical["personal_info"]["first_name"], "Local")
+        self.assertEqual(canonical["education"][0]["institution"], "UAH")
+        self.assertEqual(canonical["work_experience"][0]["title"], "Frontend Engineer")
+        self.assertIn("personal_info.first_name", profile.token_map)
+        self.assertIn("education[0].institution", profile.token_map)
+        self.assertIn("work_experience[0].title", profile.token_map)
+        self.assertEqual(profile.skills_text, "Vue, Python, SQL")
+
+    def test_apply_profile_updates_to_canonical_preserves_existing_history(self):
+        existing = normalize_canonical_data({
+            "personal_info": {"first_name": "Local", "last_name": "Developer"},
+            "education": [
+                {"institution": "UAH", "degree": "B.S.", "field_of_study": "Computer Science", "end_date": "2025"},
+                {"institution": "UAH", "degree": "M.S.", "field_of_study": "Software Engineering", "end_date": "2027"},
+            ],
+            "work_experience": [
+                {"company": "UAH", "title": "Frontend Engineer"},
+            ],
+            "skills": {"technical": ["Vue"], "languages": [], "tools": [], "soft_skills": []},
+        })
+
+        updated = apply_profile_updates_to_canonical(existing, {
+            "major": "Computer Engineering",
+            "skills_text": "Vue, Python",
+            "employment_history_text": "UAH | Frontend Engineer | Huntsville, AL | 2023 | Present\nOpenAI | Contract Engineer | Remote | 2026 | Present",
+        })
+
+        self.assertEqual(updated["education"][0]["field_of_study"], "Computer Engineering")
+        self.assertEqual(updated["education"][1]["degree"], "M.S.")
+        self.assertIn("Python", updated["skills"]["technical"])
+        self.assertEqual(len(updated["work_experience"]), 3)
+        self.assertEqual(updated["work_experience"][-1]["company"], "OpenAI")
+
+    def test_merge_review_into_profile_defaults_to_existing_conflict_resolution(self):
+        existing = derive_canonical_from_profile_fields({
+            "first_name": "Local",
+            "last_name": "Developer",
+            "email": "old@example.com",
+            "skills_text": "Vue",
+            "job_title": "Frontend Engineer",
+        })
+        incoming = normalize_canonical_data({
+            "personal_info": {"first_name": "Local", "last_name": "Developer", "email": "new@example.com"},
+            "skills": {"technical": ["Vue", "Python"], "languages": [], "tools": [], "soft_skills": []},
+            "work_experience": [{"company": "UAH", "title": "Staff Engineer"}],
+        })
+
+        merged_default, conflicts = merge_review_into_profile(existing, incoming, {})
+        merged_override, _ = merge_review_into_profile(existing, incoming, {"personal_info.email": "incoming"})
+
+        self.assertGreaterEqual(len(conflicts), 1)
+        self.assertEqual(merged_default["personal_info"]["email"], "old@example.com")
+        self.assertEqual(merged_override["personal_info"]["email"], "new@example.com")
+        self.assertIn("skills.technical", flatten_canonical_data(merged_override))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_auth_security.py
+++ b/backend/tests/test_auth_security.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
 import unittest
+from http.cookies import SimpleCookie
 from unittest.mock import patch
 
 from fastapi import HTTPException, Response
 from starlette.requests import Request
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from jose import jwt
 
 from app.api import account as account_api
 from app.api import auth as auth_api
 from app.api import deps as deps_api
+from app.api import routes as routes_api
 from app.core import auth_cookie as auth_cookie_api
+from app.core import auth_session as auth_session_api
 from app.core.rate_limit import reset_rate_limit_state
 from app.core.security import create_access_token, hash_password
 from app.db.base import Base
@@ -25,17 +29,72 @@ from app.schemas.user import (
 )
 
 
-def _build_request(client_host: str = "127.0.0.1") -> Request:
+def _build_request(
+    client_host: str = "127.0.0.1",
+    *,
+    headers: list[tuple[bytes, bytes]] | None = None,
+    scheme: str = "http",
+    path: str = "/test",
+    session: dict | None = None,
+) -> Request:
     scope = {
         "type": "http",
         "method": "POST",
-        "path": "/test",
-        "headers": [],
+        "path": path,
+        "headers": headers or [],
         "client": (client_host, 12345),
         "server": ("testserver", 80),
-        "scheme": "http",
+        "scheme": scheme,
     }
+    if session is not None:
+        scope["session"] = session
     return Request(scope)
+
+
+def _extract_cookie_value(set_cookie_header: str, cookie_name: str) -> str:
+    cookie = SimpleCookie()
+    cookie.load(set_cookie_header)
+    morsel = cookie.get(cookie_name)
+    if morsel is None:
+        raise AssertionError(f"Cookie '{cookie_name}' was not set")
+    return morsel.value
+
+
+def _token_lifetime_seconds(token: str) -> int:
+    claims = jwt.get_unverified_claims(token)
+    return int(claims["exp"]) - int(claims["iat"])
+
+
+class _MockAsyncResponse:
+    def __init__(self, payload: dict, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return dict(self._payload)
+
+
+class _MockGoogleAsyncClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, data=None, **kwargs):
+        return _MockAsyncResponse({"access_token": "google-oauth-access"})
+
+    async def get(self, url, headers=None, **kwargs):
+        return _MockAsyncResponse(
+            {
+                "sub": "google-sub-123",
+                "email": "extension@example.com",
+                "name": "Extension User",
+                "picture": "https://example.com/avatar.png",
+                "email_verified": True,
+            },
+            status_code=200,
+        )
 
 
 class AuthSecurityTests(unittest.TestCase):
@@ -173,6 +232,52 @@ class AuthSecurityTests(unittest.TestCase):
         self.assertIn("HttpOnly", set_cookie)
         self.assertIn("Secure", set_cookie)
 
+    def test_web_login_uses_default_token_lifetime(self):
+        self._create_user(email="default-ttl@example.com", username="default-ttl@example.com")
+        response = Response()
+
+        with patch.object(auth_api.settings, "SECRET_KEY", "ttl-secret"), \
+             patch.object(auth_api.settings, "ACCESS_TOKEN_EXPIRE_MINUTES", 60), \
+             patch.object(auth_api.settings, "EXTENSION_ACCESS_TOKEN_EXPIRE_MINUTES", 1440), \
+             patch.object(auth_cookie_api.settings, "AUTH_COOKIE_NAME", "uah_auth_test"), \
+             patch.object(auth_cookie_api.settings, "SESSION_COOKIE_HTTPS_ONLY", True), \
+             patch.object(auth_cookie_api.settings, "SESSION_COOKIE_SAMESITE", "lax"), \
+             patch.object(auth_cookie_api.settings, "SESSION_COOKIE_PATH", "/"):
+            auth_api.login(
+                payload=UserLogin(email="default-ttl@example.com", password="Password123!"),
+                request=_build_request(),
+                response=response,
+                db=self.db,
+            )
+
+        set_cookie = response.headers.get("set-cookie", "")
+        token = _extract_cookie_value(set_cookie, "uah_auth_test")
+        self.assertIn("Max-Age=3600", set_cookie)
+        self.assertEqual(_token_lifetime_seconds(token), 3600)
+
+    def test_extension_login_uses_extension_token_lifetime(self):
+        self._create_user(email="extension-ttl@example.com", username="extension-ttl@example.com")
+        response = Response()
+
+        with patch.object(auth_api.settings, "SECRET_KEY", "extension-ttl-secret"), \
+             patch.object(auth_api.settings, "ACCESS_TOKEN_EXPIRE_MINUTES", 60), \
+             patch.object(auth_api.settings, "EXTENSION_ACCESS_TOKEN_EXPIRE_MINUTES", 1440), \
+             patch.object(auth_cookie_api.settings, "AUTH_COOKIE_NAME", "uah_auth_test"), \
+             patch.object(auth_cookie_api.settings, "SESSION_COOKIE_HTTPS_ONLY", True), \
+             patch.object(auth_cookie_api.settings, "SESSION_COOKIE_SAMESITE", "lax"), \
+             patch.object(auth_cookie_api.settings, "SESSION_COOKIE_PATH", "/"):
+            auth_api.login(
+                payload=UserLogin(email="extension-ttl@example.com", password="Password123!"),
+                request=_build_request(headers=[(b"x-uah-client", b"extension")]),
+                response=response,
+                db=self.db,
+            )
+
+        set_cookie = response.headers.get("set-cookie", "")
+        token = _extract_cookie_value(set_cookie, "uah_auth_test")
+        self.assertIn("Max-Age=86400", set_cookie)
+        self.assertEqual(_token_lifetime_seconds(token), 86400)
+
     def test_request_token_dependency_accepts_auth_cookie(self):
         token = create_access_token(data={"sub": "123"})
         request = Request(
@@ -206,3 +311,72 @@ class AuthSecurityTests(unittest.TestCase):
             )
 
         self.assertEqual(str(auth_error.exception), "email_not_verified")
+
+    def test_extension_client_token_resolves_with_standard_auth_dependency(self):
+        user = self._create_user(email="dependency@example.com", username="dependency@example.com")
+
+        with patch.object(auth_session_api.settings, "SECRET_KEY", "dependency-secret"), \
+             patch.object(auth_session_api.settings, "EXTENSION_ACCESS_TOKEN_EXPIRE_MINUTES", 1440):
+            token = auth_session_api.create_access_token_for_client(
+                data={"sub": str(user.id)},
+                client="extension",
+            )
+
+        resolved_user = deps_api.get_current_user(db=self.db, token=token)
+        self.assertEqual(resolved_user.id, user.id)
+
+
+class GoogleOAuthExtensionTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(bind=engine, tables=[User.__table__])
+        SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+        self.db = SessionLocal()
+
+    def tearDown(self):
+        self.db.close()
+
+    async def test_google_oauth_callback_extension_uses_extension_token_lifetime(self):
+        session = {
+            "oauth_state": "state-123",
+            "oauth_mode": "login",
+            "oauth_intent": "login",
+            "oauth_next": "/home",
+            "oauth_client": "extension",
+        }
+        request = _build_request(
+            scheme="https",
+            path="/api/auth/google/callback",
+            session=session,
+        )
+
+        with patch.object(routes_api, "GOOGLE_CLIENT_ID", "google-client-id"), \
+             patch.object(routes_api, "GOOGLE_CLIENT_SECRET", "google-client-secret"), \
+             patch.object(routes_api, "GOOGLE_REDIRECT_URI", "https://dev.uahapp.com/api/auth/google/callback"), \
+             patch.object(routes_api.settings, "PUBLIC_APP_URL", "https://dev.uahapp.com"), \
+             patch.object(routes_api.settings, "SECRET_KEY", "google-extension-secret"), \
+             patch.object(routes_api.settings, "ACCESS_TOKEN_EXPIRE_MINUTES", 60), \
+             patch.object(routes_api.settings, "EXTENSION_ACCESS_TOKEN_EXPIRE_MINUTES", 1440), \
+             patch.object(auth_cookie_api.settings, "AUTH_COOKIE_NAME", "uah_auth_test"), \
+             patch.object(auth_cookie_api.settings, "SESSION_COOKIE_HTTPS_ONLY", True), \
+             patch.object(auth_cookie_api.settings, "SESSION_COOKIE_SAMESITE", "lax"), \
+             patch.object(auth_cookie_api.settings, "SESSION_COOKIE_PATH", "/"), \
+             patch.object(routes_api.httpx, "AsyncClient", _MockGoogleAsyncClient):
+            response = await routes_api.google_oauth_callback(
+                request=request,
+                code="google-code",
+                state="state-123",
+                db=self.db,
+            )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.headers.get("location"), "https://dev.uahapp.com/oauth-callback?next=%2Fhome&provider=google")
+        set_cookie = response.headers.get("set-cookie", "")
+        token = _extract_cookie_value(set_cookie, "uah_auth_test")
+        self.assertIn("Max-Age=86400", set_cookie)
+        self.assertEqual(_token_lifetime_seconds(token), 86400)
+        self.assertIsNone(request.session.get("oauth_client"))
+
+        created_user = self.db.query(User).filter(User.email == "extension@example.com").first()
+        self.assertIsNotNone(created_user)
+        self.assertTrue(created_user.email_verified)

--- a/backend/tests/test_parse_queue_isolation.py
+++ b/backend/tests/test_parse_queue_isolation.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 import unittest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from app.services import parse_job_runner, parse_queue
 
@@ -80,6 +80,62 @@ class ParseQueueIsolationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(job.status, "failed")
         self.assertEqual(job.error_code, "RESUME_OWNERSHIP_MISMATCH")
         self.assertGreaterEqual(fake_db.commits, 1)
+
+    async def test_run_parse_job_sets_pending_review_draft_on_success(self):
+        structured = {
+            "personal_info": {"first_name": "Local", "last_name": "Developer", "email": "local@example.com"},
+            "skills": {"technical": ["Vue"]},
+            "_validation": {
+                "portal_ready": True,
+                "has_name": True,
+                "has_email": True,
+                "education_count": 1,
+                "experience_count": 1,
+                "skills_count": 1,
+                "missing_required": [],
+            },
+        }
+        job = SimpleNamespace(
+            id=2,
+            status="queued",
+            resume_id=12,
+            user_id=200,
+            method="local",
+            error_code=None,
+            error_message=None,
+            progress_stage=None,
+            result_summary=None,
+        )
+        resume = SimpleNamespace(
+            id=12,
+            user_id=200,
+            pdf_data=b"pdf",
+            raw_markdown=None,
+            structured_data=None,
+            parse_method=None,
+            portal_ready=False,
+            review_status=None,
+            review_draft=None,
+            review_updated_at=None,
+        )
+        fake_db = _FakeSession(job=job, resume=resume)
+
+        with patch.object(parse_job_runner, "SessionLocal", return_value=fake_db), \
+             patch.object(parse_job_runner, "get_parse_input_text", AsyncMock(return_value={"ok": True, "text": "resume markdown"})), \
+             patch.object(parse_job_runner, "parse_markdown_by_method", AsyncMock(return_value={"parsed": "ignored"})), \
+             patch.object(parse_job_runner, "validate_and_fix", return_value=structured):
+            ok = await parse_job_runner.run_parse_job(2)
+
+        self.assertTrue(ok)
+        self.assertEqual(job.status, "success")
+        self.assertEqual(resume.parse_method, "local")
+        self.assertEqual(resume.raw_markdown, "resume markdown")
+        self.assertTrue(resume.portal_ready)
+        self.assertEqual(resume.review_status, "pending")
+        self.assertEqual(resume.review_draft, structured)
+        self.assertIsNotNone(resume.review_updated_at)
+        self.assertEqual(job.result_summary["portal_ready"], True)
+        self.assertEqual(job.result_summary["skills_count"], 1)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_resume_pipeline_contract.py
+++ b/backend/tests/test_resume_pipeline_contract.py
@@ -79,6 +79,32 @@ class _FakeQueueDb:
         return _FakeQueueQuery(self._rows)
 
 
+class _FakeResumeByIdQuery:
+    def __init__(self, resume):
+        self._resume = resume
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._resume
+
+
+class _FakeResumeByIdDb:
+    def __init__(self, resume):
+        self._resume = resume
+        self.commits = 0
+
+    def query(self, _model):
+        return _FakeResumeByIdQuery(self._resume)
+
+    def commit(self):
+        self.commits += 1
+
+    def refresh(self, _obj):
+        return None
+
+
 class ResumePipelineContractTests(unittest.IsolatedAsyncioTestCase):
     async def test_upload_stores_pdf_without_running_ocr(self):
         fake_db = _FakeUploadDb()
@@ -210,6 +236,34 @@ class ResumePipelineContractTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(payload["pipeline_availability"]["cloud"]["available"], True)
         self.assertEqual(payload["pipeline_availability"]["rules"]["available"], True)
+
+    def test_update_review_draft_allows_persisted_review_draft_without_structured_data(self):
+        resume = SimpleNamespace(
+            id=101,
+            user_id=7,
+            file_name="resume.pdf",
+            structured_data=None,
+            review_draft={"personal_info": {"first_name": "Existing"}},
+            review_status="pending",
+            review_updated_at=None,
+            parse_method="local",
+        )
+        fake_db = _FakeResumeByIdDb(resume)
+        current_user = SimpleNamespace(id=7)
+        payload = resume_api.ResumeReviewDraftUpdate(
+            review_draft={"personal_info": {"first_name": "Updated"}}
+        )
+
+        response = resume_api.update_review_draft(
+            payload=payload,
+            resume_id=101,
+            db=fake_db,
+            current_user=current_user,
+        )
+
+        self.assertEqual(fake_db.commits, 1)
+        self.assertEqual(resume.review_draft["personal_info"]["first_name"], "Updated")
+        self.assertEqual(response.review_draft["personal_info"]["first_name"], "Updated")
 
 
 if __name__ == "__main__":

--- a/env-examples/beta/.env.example
+++ b/env-examples/beta/.env.example
@@ -20,6 +20,8 @@ ENVIRONMENT=beta
 COMPOSE_PROJECT_NAME=uah-beta
 # JWT access token lifetime in minutes.
 ACCESS_TOKEN_EXPIRE_MINUTES=60
+# Browser extension auth lifetime in minutes when X-UAH-Client=extension.
+EXTENSION_ACCESS_TOKEN_EXPIRE_MINUTES=1440
 # If true, ignore local geolocation dataset cache at startup.
 GEOLOCATION_IGNORE_LOCAL_DATASET=false
 

--- a/env-examples/dev/.env.example
+++ b/env-examples/dev/.env.example
@@ -25,6 +25,8 @@ ENVIRONMENT=development
 COMPOSE_PROJECT_NAME=uah-dev
 # JWT access token lifetime in minutes.
 ACCESS_TOKEN_EXPIRE_MINUTES=60
+# Browser extension auth lifetime in minutes when X-UAH-Client=extension.
+EXTENSION_ACCESS_TOKEN_EXPIRE_MINUTES=1440
 # If true, ignore on-disk geolocation dataset and use fallback behavior.
 GEOLOCATION_IGNORE_LOCAL_DATASET=false
 

--- a/env-examples/local/.env.example
+++ b/env-examples/local/.env.example
@@ -19,6 +19,10 @@ VERSION=0.1.0
 ENVIRONMENT=local
 # Compose naming prefix for local resources.
 COMPOSE_PROJECT_NAME=uah-local
+# Default web JWT lifetime in minutes.
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+# Browser extension auth lifetime in minutes when X-UAH-Client=extension.
+EXTENSION_ACCESS_TOKEN_EXPIRE_MINUTES=1440
 
 # --- Local host ports ---
 # Host ports used by docker-compose.local.yml (loopback bindings).
@@ -45,12 +49,14 @@ AUTH_COOKIE_NAME=uah_auth_local
 SESSION_COOKIE_NAME=uah_session_local
 SESSION_COOKIE_SAMESITE=lax
 SESSION_COOKIE_PATH=/
-SESSION_COOKIE_HTTPS_ONLY=false
+# Keep secure cookies enabled for the localhost HTTPS extension harness.
+SESSION_COOKIE_HTTPS_ONLY=true
 
 # --- Local security/seed defaults ---
 # Keep disabled unless you explicitly need startup admin seeding.
 ADMIN_BOOTSTRAP_ENABLED=false
-# Optional deterministic local test account seeding.
+# Optional deterministic local test account seeding. Enable this for the
+# localhost browser-extension harness if you want a ready-made login.
 DEV_AUTH_TEST_ACCOUNT_ENABLED=false
 DEV_AUTH_TEST_USERNAME=devtester
 DEV_AUTH_TEST_PASSWORD=
@@ -63,8 +69,8 @@ DEV_AUTH_TEST_IS_DEVELOPER=true
 DEV_AUTH_TEST_ROTATE_PASSWORD=true
 # If false, password-reset and verification flows stay local/dev behavior.
 EMAILS_ENABLED=false
-# Frontend URL used in generated links.
-PUBLIC_APP_URL=http://localhost:5173
+# Frontend URL used in generated links and OAuth redirects for local HTTPS.
+PUBLIC_APP_URL=https://localhost:5173
 
 # --- Optional external integrations ---
 # Keep empty unless specifically testing each integration path.
@@ -124,6 +130,11 @@ JOB_SYNC_ENABLED_PROVIDERS_JSON=["the_muse","arbeitnow"]
 VITE_LOCAL_MODE=mock
 # Backend origin used when VITE_LOCAL_MODE=backend.
 VITE_LOCAL_BACKEND_ORIGIN=http://localhost:8000
+# Enable HTTPS for local Vite when using the extension harness.
+VITE_DEV_HTTPS=false
+# Mkcert-style cert and key paths for local HTTPS dev.
+VITE_DEV_HTTPS_CERT_FILE=../volumes/certs/local/tls.crt
+VITE_DEV_HTTPS_KEY_FILE=../volumes/certs/local/tls.key
 # Safety flag: keep false to block accidental remote API targets.
 VITE_ALLOW_REMOTE_API=false
 # If true in mock mode, auto-populate auth state with default local user.

--- a/env-examples/prod/.env.example
+++ b/env-examples/prod/.env.example
@@ -42,6 +42,10 @@ SESSION_COOKIE_SAMESITE=lax
 SESSION_COOKIE_PATH=/
 # Production should keep cookies HTTPS-only.
 SESSION_COOKIE_HTTPS_ONLY=true
+# Default web JWT lifetime in minutes.
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+# Browser extension auth lifetime in minutes when X-UAH-Client=extension.
+EXTENSION_ACCESS_TOKEN_EXPIRE_MINUTES=1440
 
 # --- Safety defaults for prod ---
 # Must remain false in production.

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,9 @@
+VITE_LOCAL_MODE=backend
+VITE_LOCAL_BACKEND_ORIGIN=http://localhost:8000
+VITE_ALLOW_REMOTE_API=false
+VITE_DEV_HOST=localhost
+VITE_DEV_PORT=5173
+VITE_DEV_HTTPS=true
+VITE_DEV_HTTPS_CERT_FILE=../volumes/certs/local/tls.crt
+VITE_DEV_HTTPS_KEY_FILE=../volumes/certs/local/tls.key
+VITE_AUTH_NAMESPACE=local

--- a/frontend/node_modules/.vite/deps/_metadata.json
+++ b/frontend/node_modules/.vite/deps/_metadata.json
@@ -1,19 +1,19 @@
 {
-  "hash": "394a26b8",
-  "configHash": "10dc73b6",
+  "hash": "e9620197",
+  "configHash": "d581463d",
   "lockfileHash": "77384327",
-  "browserHash": "62c9b17d",
+  "browserHash": "f2904c1e",
   "optimized": {
     "vue": {
       "src": "../../vue/dist/vue.runtime.esm-bundler.js",
       "file": "vue.js",
-      "fileHash": "33a0ecbe",
+      "fileHash": "555c3ff1",
       "needsInterop": false
     },
     "vue-router": {
       "src": "../../vue-router/dist/vue-router.mjs",
       "file": "vue-router.js",
-      "fileHash": "1702d2fd",
+      "fileHash": "e1738cb9",
       "needsInterop": false
     }
   },

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,41 +1,9 @@
+@import "../../shared/theme/uah-theme.css";
+
 * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-}
-
-:root {
-  --bp-tablet: 768px;
-  --bp-phone: 600px;
-  --bp-small: 480px;
-  --space-1: 8px;
-  --space-2: 12px;
-  --space-3: 16px;
-  --space-4: 24px;
-  --space-5: 32px;
-  --radius-sm: 8px;
-  --radius-md: 12px;
-  --radius-lg: 14px;
-  --color-primary-500: #3b82f6;
-  --color-primary-600: #2563eb;
-  --color-primary-700: #1d4ed8;
-  --color-success-600: #16a34a;
-  --color-danger-600: #dc2626;
-  --color-warning-600: #d97706;
-  --color-text-primary: #1a1a2e;
-  --color-text-secondary: #374151;
-  --color-text-muted: #8a94a6;
-  --color-surface: #ffffff;
-  --color-surface-muted: #f8fafc;
-  --color-surface-hover: #f3f4f6;
-  --border-color: rgba(203, 213, 225, 0.9);
-  --border-color-light: #e5e7eb;
-  --shadow-soft: 0 2px 6px rgba(15, 23, 42, 0.08);
-  --shadow-card: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
-  --transition-fast: 0.15s ease;
-  --app-page-background:
-    radial-gradient(circle at top right, rgba(14, 165, 233, 0.08), transparent 28%),
-    linear-gradient(180deg, #f8fafc 0%, #eef4f8 100%);
 }
 
 body {

--- a/frontend/src/components/ResumeReviewModal.vue
+++ b/frontend/src/components/ResumeReviewModal.vue
@@ -1,0 +1,621 @@
+<template>
+  <div class="review-overlay" @click.self="requestClose">
+    <div class="review-dialog" v-draggable-modal="{ handle: '.review-header' }" @click.stop>
+      <div class="review-header drag-handle">
+        <div>
+          <p class="review-eyebrow">Resume Parse Review</p>
+          <h2>{{ meta.file_name || resumeName || 'Review Parsed Resume' }}</h2>
+          <p class="review-subtitle">
+            {{ parseMethodLabel(meta.parse_method) }}
+            <span v-if="meta.review_updated_at"> · Draft updated {{ formatDate(meta.review_updated_at) }}</span>
+          </p>
+        </div>
+        <button type="button" class="btn-secondary btn-compact" @click="requestClose">Close</button>
+      </div>
+
+      <div v-if="loading" class="review-state"><div class="spinner"></div><p>Loading parsed resume draft…</p></div>
+      <div v-else-if="error" class="review-state review-state--error">
+        <p>{{ error }}</p>
+        <button type="button" class="btn-secondary" @click="loadReviewDraft">Retry</button>
+      </div>
+
+      <template v-else>
+        <div class="review-steps">
+          <button type="button" :class="['review-step', step === 'review' ? 'active' : '']" @click="step = 'review'">1. Review</button>
+          <button type="button" :class="['review-step', step === 'profile' ? 'active' : '']" @click="openProfileStep">2. Choose Profile</button>
+          <button type="button" :class="['review-step', step === 'conflicts' ? 'active' : '', conflicts.length ? '' : 'is-disabled']" :disabled="!conflicts.length">3. Conflicts</button>
+        </div>
+
+        <div v-if="step === 'review'" class="review-body">
+          <section class="review-banner" :class="{ 'is-warning': missingRequired.length || fixesApplied.length || !portalReady }">
+            <div>
+              <h3>Review extracted fields before filling an applicant profile.</h3>
+              <p>Blank values and required parser fields are highlighted so they are easier to catch before the merge.</p>
+            </div>
+            <div class="review-pill-row">
+              <span class="review-pill" :class="portalReady ? 'is-success' : 'is-warning'">{{ portalReady ? 'Portal Ready' : 'Needs Review' }}</span>
+              <span class="review-pill">{{ sectionCount }} sections parsed</span>
+              <span v-if="fixesApplied.length" class="review-pill">{{ fixesApplied.length }} parser fixes</span>
+            </div>
+          </section>
+
+          <section v-if="missingRequired.length" class="review-alert">
+            <h4>Missing required fields</h4>
+            <div class="review-pill-row">
+              <span v-for="path in missingRequired" :key="path" class="review-pill is-warning">{{ prettifyPath(path) }}</span>
+            </div>
+          </section>
+
+          <section v-if="fixesApplied.length" class="review-alert">
+            <h4>Parser fixes applied</h4>
+            <ul class="review-list"><li v-for="item in fixesApplied" :key="item">{{ item }}</li></ul>
+          </section>
+
+          <section class="review-section">
+            <div class="review-section-head"><div><h3>Personal Information</h3><p>Confirm contact details and location before saving.</p></div></div>
+            <div class="review-grid review-grid--two">
+              <label v-for="field in personalFields" :key="field.key" :class="['review-field', field.full ? 'review-field--full' : '']">
+                <span>{{ field.label }}</span>
+                <input v-model="reviewDraft.personal_info[field.key]" :type="field.type || 'text'" :class="fieldClass(`personal_info.${field.key}`, reviewDraft.personal_info[field.key])">
+              </label>
+            </div>
+          </section>
+
+          <section class="review-section">
+            <div class="review-section-head"><div><h3>Summary</h3><p>Keep this reusable for downstream autofill and profile generation.</p></div></div>
+            <label class="review-field"><span>Professional Summary</span><textarea v-model="reviewDraft.summary" rows="5" :class="fieldClass('summary', reviewDraft.summary)"></textarea></label>
+          </section>
+
+          <section class="review-section">
+            <div class="review-section-head"><div><h3>Skills</h3><p>Use comma-separated values so the data remains easy to tokenize later.</p></div></div>
+            <div class="review-grid review-grid--two">
+              <label v-for="field in skillFields" :key="field.key" class="review-field">
+                <span>{{ field.label }}</span>
+                <textarea :value="joinList(reviewDraft.skills[field.key])" rows="3" :class="fieldClass(`skills.${field.key}`, reviewDraft.skills[field.key])" @input="setInlineList(reviewDraft.skills, field.key, $event.target.value)"></textarea>
+              </label>
+            </div>
+          </section>
+
+          <section v-for="section in structuredSections" :key="section.key" class="review-section">
+            <div class="review-section-head">
+              <div><h3>{{ section.title }}</h3><p>{{ section.description }}</p></div>
+              <button type="button" class="btn-secondary btn-compact" @click="addStructuredEntry(section.key)">Add Entry</button>
+            </div>
+
+            <p v-if="!reviewDraft[section.key].length" class="review-empty">{{ section.emptyText }}</p>
+
+            <details v-for="(entry, index) in reviewDraft[section.key]" :key="`${section.key}-${index}`" class="review-entry" open>
+              <summary>
+                <div>
+                  <strong>{{ entryTitle(section.key, entry, index) }}</strong>
+                  <span>{{ entrySubtitle(section.key, entry) }}</span>
+                </div>
+                <button type="button" class="review-inline-btn" @click.stop="removeStructuredEntry(section.key, index)">Remove</button>
+              </summary>
+
+              <div class="review-grid review-grid--two">
+                <template v-for="field in section.fields" :key="`${section.key}-${field.key}`">
+                  <label :class="['review-field', field.full ? 'review-field--full' : '']">
+                    <span>{{ field.label }}</span>
+                    <textarea
+                      v-if="field.kind === 'textarea'"
+                      v-model="entry[field.key]"
+                      rows="3"
+                      :class="fieldClass(`${section.pathStem}.${field.key}`, entry[field.key])"
+                    ></textarea>
+                    <textarea
+                      v-else-if="field.kind === 'inline-list'"
+                      :value="joinList(entry[field.key])"
+                      rows="2"
+                      :class="fieldClass(`${section.pathStem}.${field.key}`, entry[field.key])"
+                      @input="setInlineList(entry, field.key, $event.target.value)"
+                    ></textarea>
+                    <textarea
+                      v-else-if="field.kind === 'line-list'"
+                      :value="joinLines(entry[field.key])"
+                      rows="4"
+                      :class="fieldClass(`${section.pathStem}.${field.key}`, entry[field.key])"
+                      @input="setLineList(entry, field.key, $event.target.value)"
+                    ></textarea>
+                    <select v-else-if="field.kind === 'current-select'" v-model="entry.is_current" @change="syncCurrentRole(entry)">
+                      <option :value="false">No</option>
+                      <option :value="true">Yes</option>
+                    </select>
+                    <input
+                      v-else
+                      v-model="entry[field.key]"
+                      :type="field.type || 'text'"
+                      :class="fieldClass(`${section.pathStem}.${field.key}`, entry[field.key])"
+                    >
+                  </label>
+                </template>
+              </div>
+            </details>
+          </section>
+
+          <section class="review-section">
+            <div class="review-section-head"><div><h3>Additional Sections</h3><p>Optional sections still matter for long-term autofill coverage, so they stay editable here too.</p></div></div>
+            <div class="review-grid review-grid--three">
+              <label v-for="field in extraListSections" :key="field.key" class="review-field">
+                <span>{{ field.label }}</span>
+                <textarea :value="joinLines(reviewDraft[field.key])" rows="4" :class="fieldClass(field.key, reviewDraft[field.key])" @input="setRootLineList(field.key, $event.target.value)"></textarea>
+              </label>
+            </div>
+          </section>
+        </div>
+
+        <div v-else-if="step === 'profile'" class="review-body">
+          <section class="review-section">
+            <div class="review-section-head"><div><h3>Choose where this reviewed data should go</h3><p>Merge into an existing profile or create a new one from this parse.</p></div></div>
+            <div class="review-toggle">
+              <button type="button" :class="['review-toggle-btn', selectedMode === 'existing' ? 'active' : '']" @click="selectedMode = 'existing'">Fill Existing Profile</button>
+              <button type="button" :class="['review-toggle-btn', selectedMode === 'new' ? 'active' : '']" @click="selectedMode = 'new'">Create New Profile</button>
+            </div>
+
+            <template v-if="selectedMode === 'existing'">
+              <label class="review-field review-field--full"><span>Search Profiles</span><input v-model="profileQuery" type="text" placeholder="Search by name, title, city, or state"></label>
+              <div v-if="filteredProfiles.length" class="profile-list">
+                <button v-for="profile in filteredProfiles" :key="profile.id" type="button" :class="['profile-option', Number(selectedProfileId) === Number(profile.id) ? 'is-selected' : '']" @click="selectedProfileId = Number(profile.id)">
+                  <div>
+                    <strong>{{ profile.name }}</strong>
+                    <p>{{ profileSummary(profile) }}</p>
+                    <p>Updated {{ formatDate(profile.updated_at || profile.created_at) }}</p>
+                  </div>
+                  <span v-if="profile.is_active" class="review-pill is-success">Active</span>
+                </button>
+              </div>
+              <p v-else class="review-empty">No profiles matched that search. You can create a new one instead.</p>
+            </template>
+
+            <template v-else>
+              <label class="review-field review-field--full"><span>Profile Name</span><input v-model="newProfileName" type="text" placeholder="Name this new applicant profile"></label>
+              <p class="review-helper">Suggested name: <strong>{{ suggestedProfileName }}</strong></p>
+            </template>
+          </section>
+        </div>
+
+        <div v-else class="review-body">
+          <section class="review-section">
+            <div class="review-section-head"><div><h3>Resolve merge conflicts</h3><p>Existing non-empty values are preserved by default unless you explicitly choose the reviewed parse.</p></div></div>
+            <article v-for="conflict in conflicts" :key="conflict.id" class="conflict-card">
+              <div class="conflict-head"><h4>{{ conflict.label }}</h4><span class="review-pill is-warning">{{ prettifyPath(conflict.path) }}</span></div>
+              <div class="conflict-grid">
+                <label :class="['conflict-option', conflictChoice(conflict.path) === 'existing' ? 'is-selected' : '']">
+                  <input :checked="conflictChoice(conflict.path) === 'existing'" type="radio" :name="`conflict-${conflict.id}`" @change="setConflictChoice(conflict.path, 'existing')">
+                  <span class="conflict-option-title">Keep existing profile value</span>
+                  <code>{{ displayConflictValue(conflict.existing_value) }}</code>
+                </label>
+                <label :class="['conflict-option', conflictChoice(conflict.path) === 'incoming' ? 'is-selected' : '']">
+                  <input :checked="conflictChoice(conflict.path) === 'incoming'" type="radio" :name="`conflict-${conflict.id}`" @change="setConflictChoice(conflict.path, 'incoming')">
+                  <span class="conflict-option-title">Use parsed value</span>
+                  <code>{{ displayConflictValue(conflict.incoming_value) }}</code>
+                </label>
+              </div>
+            </article>
+          </section>
+        </div>
+
+        <div class="review-footer">
+          <p class="review-footer-note">{{ footerNote }}</p>
+          <div class="review-footer-actions">
+            <button v-if="step !== 'review'" type="button" class="btn-secondary" :disabled="busy" @click="goBack">Back</button>
+            <button v-if="step === 'review'" type="button" class="btn-secondary" :disabled="busy" @click="persistDraft({ toastOnSuccess: true })">{{ savingDraft ? 'Saving Draft…' : 'Save Draft' }}</button>
+            <button v-if="step === 'review'" type="button" class="btn-primary" :disabled="busy" @click="openProfileStep">Continue</button>
+            <button v-else-if="step === 'profile'" type="button" class="btn-primary" :disabled="busy || !canApplySelection" @click="submitProfileStep">{{ conflictsLoading ? 'Checking Conflicts…' : applying ? 'Saving Profile…' : selectedMode === 'existing' ? 'Review Merge' : 'Create Profile and Save' }}</button>
+            <button v-else type="button" class="btn-primary" :disabled="busy" @click="applyReview">{{ applying ? 'Applying Review…' : 'Apply to Profile' }}</button>
+          </div>
+        </div>
+      </template>
+    </div>
+
+    <ConfirmModal
+      v-if="closeConfirmVisible"
+      title="Leave Resume Review?"
+      message="Your parsed draft remains saved on this resume, but unsaved edits in this modal will be lost. Close anyway?"
+      cancel-text="Keep Reviewing"
+      confirm-text="Close Review"
+      @cancel="closeConfirmVisible = false"
+      @confirm="confirmClose"
+    />
+  </div>
+</template>
+
+<script>
+import ConfirmModal from './ConfirmModal.vue'
+import { authedFetch } from '../lib/auth.js'
+import { showToast } from '../services/toastService.js'
+
+const PERSONAL_FIELDS = [
+  { key: 'first_name', label: 'First Name' },
+  { key: 'last_name', label: 'Last Name' },
+  { key: 'email', label: 'Email', type: 'email' },
+  { key: 'phone', label: 'Phone' },
+  { key: 'address', label: 'Street Address', full: true },
+  { key: 'city', label: 'City' },
+  { key: 'state', label: 'State' },
+  { key: 'zip', label: 'ZIP' },
+  { key: 'linkedin', label: 'LinkedIn', type: 'url' },
+  { key: 'website', label: 'Website', type: 'url' },
+]
+
+const SKILL_FIELDS = [
+  { key: 'technical', label: 'Technical Skills' },
+  { key: 'languages', label: 'Languages' },
+  { key: 'tools', label: 'Tools' },
+  { key: 'soft_skills', label: 'Soft Skills' },
+]
+
+const STRUCTURED_SECTIONS = [
+  {
+    key: 'education',
+    pathStem: 'education',
+    title: 'Education',
+    description: 'Education stays structured so it can be flattened back into token paths later.',
+    emptyText: 'The parser did not return any education entries.',
+    fields: [
+      { key: 'institution', label: 'Institution' },
+      { key: 'degree', label: 'Degree' },
+      { key: 'field_of_study', label: 'Field of Study' },
+      { key: 'gpa', label: 'GPA' },
+      { key: 'start_date', label: 'Start Date' },
+      { key: 'end_date', label: 'End Date' },
+      { key: 'honors', label: 'Honors', kind: 'inline-list', full: true },
+      { key: 'relevant_coursework', label: 'Relevant Coursework', kind: 'inline-list', full: true },
+    ],
+  },
+  {
+    key: 'work_experience',
+    pathStem: 'work_experience',
+    title: 'Work Experience',
+    description: 'Review titles, dates, and bullets before the merge step.',
+    emptyText: 'The parser did not return any work experience entries.',
+    fields: [
+      { key: 'company', label: 'Company' },
+      { key: 'title', label: 'Title' },
+      { key: 'location', label: 'Location' },
+      { key: 'is_current', label: 'Current Role', kind: 'current-select' },
+      { key: 'start_date', label: 'Start Date' },
+      { key: 'end_date', label: 'End Date' },
+      { key: 'bullets', label: 'Bullets', kind: 'line-list', full: true },
+    ],
+  },
+  {
+    key: 'projects',
+    pathStem: 'projects',
+    title: 'Projects',
+    description: 'Project details are kept structured for later token regeneration.',
+    emptyText: 'No projects were extracted from this parse.',
+    fields: [
+      { key: 'name', label: 'Name' },
+      { key: 'date', label: 'Date' },
+      { key: 'description', label: 'Description', kind: 'textarea', full: true },
+      { key: 'technologies', label: 'Technologies', kind: 'inline-list', full: true },
+    ],
+  },
+  {
+    key: 'certifications',
+    pathStem: 'certifications',
+    title: 'Certifications',
+    description: 'Review certification names and issuers before the merge.',
+    emptyText: 'No certifications were extracted from this parse.',
+    fields: [
+      { key: 'name', label: 'Name' },
+      { key: 'issuer', label: 'Issuer' },
+      { key: 'date', label: 'Date', full: true },
+    ],
+  },
+]
+
+const EXTRA_LIST_SECTIONS = [
+  { key: 'awards', label: 'Awards' },
+  { key: 'activities', label: 'Activities' },
+  { key: 'volunteer', label: 'Volunteer' },
+]
+
+export default {
+  name: 'ResumeReviewModal',
+  components: { ConfirmModal },
+  props: {
+    resumeId: { type: Number, required: true },
+    resumeName: { type: String, default: '' },
+    profiles: { type: Array, default: () => [] },
+    activeProfileId: { type: Number, default: null },
+  },
+  emits: ['close', 'applied'],
+  data() {
+    return {
+      personalFields: PERSONAL_FIELDS,
+      skillFields: SKILL_FIELDS,
+      structuredSections: STRUCTURED_SECTIONS,
+      extraListSections: EXTRA_LIST_SECTIONS,
+      loading: false,
+      error: '',
+      step: 'review',
+      meta: { file_name: '', parse_method: '', review_status: '', review_updated_at: '' },
+      reviewDraft: this.normalizeDraft({}),
+      selectedMode: 'existing',
+      selectedProfileId: null,
+      newProfileName: '',
+      profileQuery: '',
+      conflicts: [],
+      conflictResolutions: {},
+      savingDraft: false,
+      conflictsLoading: false,
+      applying: false,
+      closeConfirmVisible: false,
+      lastSavedSignature: '',
+    }
+  },
+  computed: {
+    busy() { return this.savingDraft || this.conflictsLoading || this.applying },
+    missingRequired() { return Array.isArray(this.reviewDraft?._validation?.missing_required) ? this.reviewDraft._validation.missing_required.filter(Boolean) : [] },
+    fixesApplied() { return Array.isArray(this.reviewDraft?._validation?.fixes_applied) ? this.reviewDraft._validation.fixes_applied.filter(Boolean) : [] },
+    portalReady() { return Boolean(this.reviewDraft?._validation?.portal_ready) },
+    currentSignature() { return JSON.stringify(this.reviewDraft || {}) },
+    dirty() { return this.currentSignature !== this.lastSavedSignature },
+    sectionCount() {
+      return [
+        this.hasObjectContent(this.reviewDraft.personal_info),
+        Boolean(this.cleanText(this.reviewDraft.summary)),
+        this.hasListContent(this.reviewDraft.education),
+        this.hasListContent(this.reviewDraft.work_experience),
+        this.hasSkillsContent(this.reviewDraft.skills),
+        this.hasListContent(this.reviewDraft.projects),
+        this.hasListContent(this.reviewDraft.certifications),
+        this.hasListContent(this.reviewDraft.awards),
+        this.hasListContent(this.reviewDraft.activities),
+        this.hasListContent(this.reviewDraft.volunteer),
+      ].filter(Boolean).length
+    },
+    filteredProfiles() {
+      const query = this.cleanText(this.profileQuery).toLowerCase()
+      const profiles = Array.isArray(this.profiles) ? this.profiles : []
+      if (!query) return profiles
+      return profiles.filter((profile) => [profile.name, profile.first_name, profile.last_name, profile.job_title, profile.city, profile.state].join(' ').toLowerCase().includes(query))
+    },
+    suggestedProfileName() {
+      if (this.cleanText(this.newProfileName)) return this.newProfileName.trim()
+      const name = [this.cleanText(this.reviewDraft.personal_info.first_name), this.cleanText(this.reviewDraft.personal_info.last_name)].filter(Boolean).join(' ')
+      return name || this.resumeName || this.meta.file_name || 'Imported Profile'
+    },
+    canApplySelection() { return this.selectedMode === 'existing' ? Boolean(this.selectedProfileId) : Boolean(this.cleanText(this.suggestedProfileName)) },
+    footerNote() {
+      if (this.step === 'review') return this.dirty ? 'Save the draft or continue to persist your latest edits.' : 'This review draft is already persisted on the resume and can be resumed later.'
+      if (this.step === 'profile') return this.selectedMode === 'existing' ? 'Existing non-empty values stay in place by default whenever there is a conflict.' : 'A new applicant profile will be created from this reviewed parse and made active.'
+      return 'Choose the value that should remain in the applicant profile after the merge.'
+    },
+  },
+  watch: {
+    resumeId: { immediate: true, handler(value) { if (value) this.loadReviewDraft() } },
+    profiles: {
+      immediate: true,
+      handler(nextProfiles) {
+        if (!Array.isArray(nextProfiles) || !nextProfiles.length) {
+          this.selectedMode = 'new'
+          this.selectedProfileId = null
+          return
+        }
+        const fallbackId = Number(this.activeProfileId) || Number(nextProfiles.find((profile) => profile.is_active)?.id) || Number(nextProfiles[0].id)
+        if (!nextProfiles.some((profile) => Number(profile.id) === Number(this.selectedProfileId))) this.selectedProfileId = fallbackId
+      },
+    },
+  },
+  methods: {
+    cleanText(value) { return typeof value === 'string' ? value.trim() : '' },
+    cloneValue(value) { return JSON.parse(JSON.stringify(value || {})) },
+    normalizeText(value) { return typeof value === 'string' ? value : '' },
+    normalizeList(value) { return Array.isArray(value) ? value.map((item) => (typeof item === 'string' ? item.trim() : '')).filter(Boolean) : [] },
+    splitInline(value) { return String(value || '').split(/[\n,;]+/).map((item) => item.trim()).filter(Boolean) },
+    splitLines(value) { return String(value || '').split(/\r?\n+/).map((item) => item.trim()).filter(Boolean) },
+    joinList(value) { return this.normalizeList(value).join(', ') },
+    joinLines(value) { return this.normalizeList(value).join('\n') },
+    normalizeValidation(value) {
+      const validation = value && typeof value === 'object' ? value : {}
+      return { ...validation, missing_required: this.normalizeList(validation.missing_required), fixes_applied: this.normalizeList(validation.fixes_applied) }
+    },
+    normalizeEntry(sectionKey, entry = {}) {
+      if (sectionKey === 'education') return { institution: this.normalizeText(entry.institution), degree: this.normalizeText(entry.degree), field_of_study: this.normalizeText(entry.field_of_study), gpa: this.normalizeText(entry.gpa), start_date: this.normalizeText(entry.start_date), end_date: this.normalizeText(entry.end_date), honors: this.normalizeList(entry.honors), relevant_coursework: this.normalizeList(entry.relevant_coursework) }
+      if (sectionKey === 'work_experience') return { company: this.normalizeText(entry.company), title: this.normalizeText(entry.title), location: this.normalizeText(entry.location), start_date: this.normalizeText(entry.start_date), end_date: this.normalizeText(entry.end_date), is_current: Boolean(entry.is_current || String(entry.end_date || '').toLowerCase() === 'present'), bullets: this.normalizeList(entry.bullets) }
+      if (sectionKey === 'projects') return { name: this.normalizeText(entry.name), description: this.normalizeText(entry.description), date: this.normalizeText(entry.date), technologies: this.normalizeList(entry.technologies) }
+      return typeof entry === 'string' ? { name: entry.trim(), issuer: '', date: '' } : { name: this.normalizeText(entry.name), issuer: this.normalizeText(entry.issuer), date: this.normalizeText(entry.date) }
+    },
+    normalizeDraft(value) {
+      const draft = value && typeof value === 'object' ? value : {}
+      const personal = draft.personal_info && typeof draft.personal_info === 'object' ? draft.personal_info : {}
+      const skills = draft.skills && typeof draft.skills === 'object' ? draft.skills : {}
+      return {
+        personal_info: Object.fromEntries(PERSONAL_FIELDS.map((field) => [field.key, this.normalizeText(personal[field.key])])),
+        summary: this.normalizeText(draft.summary),
+        skills: Object.fromEntries(SKILL_FIELDS.map((field) => [field.key, this.normalizeList(skills[field.key])])),
+        education: Array.isArray(draft.education) ? draft.education.map((entry) => this.normalizeEntry('education', entry)) : [],
+        work_experience: Array.isArray(draft.work_experience) ? draft.work_experience.map((entry) => this.normalizeEntry('work_experience', entry)) : [],
+        projects: Array.isArray(draft.projects) ? draft.projects.map((entry) => this.normalizeEntry('projects', entry)) : [],
+        certifications: Array.isArray(draft.certifications) ? draft.certifications.map((entry) => this.normalizeEntry('certifications', entry)) : [],
+        awards: this.normalizeList(draft.awards),
+        activities: this.normalizeList(draft.activities),
+        volunteer: this.normalizeList(draft.volunteer),
+        _validation: this.normalizeValidation(draft._validation),
+      }
+    },
+    hasObjectContent(value) { return Object.values(value || {}).some((item) => Array.isArray(item) ? item.length > 0 : Boolean(this.cleanText(item))) },
+    hasListContent(value) { return Array.isArray(value) && value.some((item) => typeof item === 'string' ? Boolean(this.cleanText(item)) : this.hasObjectContent(item)) },
+    hasSkillsContent(value) { return Object.values(value || {}).some((items) => Array.isArray(items) && items.length > 0) },
+    setInlineList(target, key, value) { target[key] = this.splitInline(value) },
+    setLineList(target, key, value) { target[key] = this.splitLines(value) },
+    setRootLineList(key, value) { this.reviewDraft[key] = this.splitLines(value) },
+    newStructuredEntry(sectionKey) { return this.normalizeEntry(sectionKey, {}) },
+    addStructuredEntry(sectionKey) { this.reviewDraft[sectionKey].push(this.newStructuredEntry(sectionKey)) },
+    removeStructuredEntry(sectionKey, index) { this.reviewDraft[sectionKey].splice(index, 1) },
+    syncCurrentRole(entry) { if (entry.is_current) entry.end_date = this.cleanText(entry.end_date) || 'Present'; else if (String(entry.end_date || '').toLowerCase() === 'present') entry.end_date = '' },
+    prettifyPath(path) { return String(path || '').replace(/^personal_info\./, '').replace(/_/g, ' ').replace(/\[(\d+)\]/g, (_, n) => ` #${Number(n) + 1}`).replace(/\./g, ' ').replace(/\s+/g, ' ').trim().replace(/\b\w/g, (char) => char.toUpperCase()) },
+    fieldClass(path, value) { return { 'is-attention': this.isBlank(value) || this.pathNeedsReview(path) } },
+    isBlank(value) { return Array.isArray(value) ? value.length === 0 : !this.cleanText(value) },
+    pathNeedsReview(path) { return this.missingRequired.some((item) => item === path || item.startsWith(`${path}.`) || path.startsWith(`${item}.`)) },
+    parseMethodLabel(method) { const normalized = String(method || '').toLowerCase(); return normalized === 'cloud' ? 'Cloud AI Parse' : normalized === 'rules' ? 'Rules-based Parse' : normalized === 'local' ? 'Local AI Parse' : 'Parsed Resume Draft' },
+    formatDate(iso) { try { return iso ? new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : 'recently' } catch { return iso } },
+    entryTitle(sectionKey, entry, index) { if (sectionKey === 'education') return entry.institution || entry.degree || `Education #${index + 1}`; if (sectionKey === 'work_experience') return entry.title || entry.company || `Role #${index + 1}`; if (sectionKey === 'projects') return entry.name || `Project #${index + 1}`; return entry.name || `Certification #${index + 1}` },
+    entrySubtitle(sectionKey, entry) { if (sectionKey === 'education') return [entry.degree, entry.field_of_study].filter(Boolean).join(' · ') || 'Review entry'; if (sectionKey === 'work_experience') return [entry.company, entry.location].filter(Boolean).join(' · ') || 'Review entry'; if (sectionKey === 'projects') return entry.date || 'Review entry'; return [entry.issuer, entry.date].filter(Boolean).join(' · ') || 'Review entry' },
+    profileSummary(profile) { return [[profile.first_name, profile.last_name].filter(Boolean).join(' '), profile.job_title, [profile.city, profile.state].filter(Boolean).join(', ')].filter(Boolean).join(' · ') || 'No profile details yet' },
+    requestClose() { if (this.busy) return; if (this.dirty) { this.closeConfirmVisible = true; return } this.$emit('close') },
+    confirmClose() { this.closeConfirmVisible = false; this.$emit('close') },
+    async loadReviewDraft() {
+      this.loading = true
+      this.error = ''
+      this.step = 'review'
+      this.conflicts = []
+      this.conflictResolutions = {}
+      try {
+        const response = await authedFetch(`/api/resume/${this.resumeId}/review-draft`)
+        const payload = await response.json().catch(() => null)
+        if (!response.ok) throw new Error(payload?.detail || `HTTP ${response.status}`)
+        this.meta = { file_name: payload.file_name || '', parse_method: payload.parse_method || '', review_status: payload.review_status || '', review_updated_at: payload.review_updated_at || '' }
+        this.reviewDraft = this.normalizeDraft(this.cloneValue(payload.review_draft))
+        this.lastSavedSignature = this.currentSignature
+        if (!this.cleanText(this.newProfileName)) this.newProfileName = this.suggestedProfileName
+      } catch (error) {
+        this.error = error?.message || 'Failed to load the review draft.'
+      } finally {
+        this.loading = false
+      }
+    },
+    async persistDraft({ toastOnSuccess = false, quietIfClean = false } = {}) {
+      if (quietIfClean && !this.dirty) return true
+      this.savingDraft = true
+      try {
+        const response = await authedFetch(`/api/resume/${this.resumeId}/review-draft`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ review_draft: this.reviewDraft }),
+        })
+        const payload = await response.json().catch(() => null)
+        if (!response.ok) throw new Error(payload?.detail || `HTTP ${response.status}`)
+        this.meta.review_status = payload.review_status || 'pending'
+        this.meta.review_updated_at = payload.review_updated_at || ''
+        this.reviewDraft = this.normalizeDraft(this.cloneValue(payload.review_draft))
+        this.lastSavedSignature = this.currentSignature
+        if (toastOnSuccess) showToast('Review draft saved.', 'success')
+        return true
+      } catch (error) {
+        showToast(error?.message || 'Failed to save review draft.', 'error')
+        return false
+      } finally {
+        this.savingDraft = false
+      }
+    },
+    async openProfileStep() {
+      if (!(await this.persistDraft({ quietIfClean: true }))) return
+      if (!this.profiles.length) this.selectedMode = 'new'
+      if (!this.cleanText(this.newProfileName)) this.newProfileName = this.suggestedProfileName
+      this.step = 'profile'
+    },
+    goBack() { this.step = this.step === 'conflicts' ? 'profile' : 'review' },
+    async submitProfileStep() {
+      if (!(await this.persistDraft({ quietIfClean: true }))) return
+      if (this.selectedMode === 'new') { await this.applyReview(); return }
+      if (!this.selectedProfileId) { showToast('Choose a profile to continue.', 'error'); return }
+      this.conflictsLoading = true
+      try {
+        const response = await authedFetch(`/api/resume/${this.resumeId}/review-conflicts`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ profile_id: Number(this.selectedProfileId), reviewed_data: this.reviewDraft }),
+        })
+        const payload = await response.json().catch(() => null)
+        if (!response.ok) throw new Error(payload?.detail || `HTTP ${response.status}`)
+        this.conflicts = Array.isArray(payload.conflicts) ? payload.conflicts : []
+        this.conflictResolutions = this.conflicts.reduce((acc, item) => ({ ...acc, [item.path]: 'existing' }), {})
+        if (this.conflicts.length) { this.step = 'conflicts'; return }
+        await this.applyReview()
+      } catch (error) {
+        showToast(error?.message || 'Failed to check merge conflicts.', 'error')
+      } finally {
+        this.conflictsLoading = false
+      }
+    },
+    conflictChoice(path) { return this.conflictResolutions[path] || 'existing' },
+    setConflictChoice(path, value) { this.conflictResolutions = { ...this.conflictResolutions, [path]: value } },
+    displayConflictValue(value) { return Array.isArray(value) ? value.join(', ') : value && typeof value === 'object' ? JSON.stringify(value) : String(value ?? '—') },
+    async applyReview() {
+      this.applying = true
+      try {
+        const payload = { mode: this.selectedMode, reviewed_data: this.reviewDraft }
+        if (this.selectedMode === 'existing') {
+          payload.profile_id = Number(this.selectedProfileId)
+          if (this.conflicts.length) payload.conflict_resolutions = this.conflictResolutions
+        } else {
+          payload.profile_name = this.suggestedProfileName
+        }
+        const response = await authedFetch(`/api/resume/${this.resumeId}/apply-review`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+        const result = await response.json().catch(() => null)
+        if (!response.ok) throw new Error(result?.detail || `HTTP ${response.status}`)
+        this.meta.review_status = result.review_status || 'applied'
+        this.lastSavedSignature = this.currentSignature
+        showToast('Applicant profile updated from reviewed parse.', 'success')
+        this.$emit('applied', result)
+      } catch (error) {
+        showToast(error?.message || 'Failed to apply reviewed parse.', 'error')
+      } finally {
+        this.applying = false
+      }
+    },
+  },
+}
+</script>
+
+<style scoped>
+.review-overlay{position:fixed;inset:0;z-index:9100;display:flex;align-items:center;justify-content:center;padding:20px;background:rgba(15,23,42,.42)}
+.review-dialog{width:min(1160px,100%);max-height:calc(100vh - 40px);display:flex;flex-direction:column;overflow:hidden;border:1px solid var(--border-color);border-radius:18px;background:rgba(255,255,255,.98);box-shadow:0 20px 50px rgba(15,23,42,.18)}
+.review-header,.review-footer,.review-section-head,.conflict-head,.review-banner{display:flex;align-items:flex-start;justify-content:space-between;gap:16px}
+.review-header{padding:22px 24px 18px;border-bottom:1px solid var(--border-color-light);cursor:grab}
+.review-eyebrow{margin:0 0 6px;font-size:.74rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#0f766e}
+.review-header h2,.review-banner h3,.review-alert h4,.review-section h3,.conflict-head h4{margin:0;color:var(--color-text-primary)}
+.review-subtitle,.review-banner p,.review-section-head p,.review-helper,.review-empty,.review-footer-note,.profile-option p,.review-entry summary span{margin:6px 0 0;color:var(--color-text-muted);line-height:1.5}
+.review-steps{display:flex;gap:10px;padding:16px 24px;border-bottom:1px solid var(--border-color-light);background:rgba(248,250,252,.9)}
+.review-step,.review-pill,.review-toggle-btn,.review-inline-btn,.profile-option,.conflict-option{border:1px solid rgba(203,213,225,.85);background:#fff}
+.review-step{border-radius:999px;padding:8px 14px;color:var(--color-text-secondary);font-size:.84rem;font-weight:700}
+.review-step.active,.review-toggle-btn.active{border-color:rgba(37,99,235,.3);background:rgba(37,99,235,.1);color:var(--color-primary-700)}
+.review-step.is-disabled{opacity:.6}
+.review-body{flex:1;overflow:auto;padding:24px;display:flex;flex-direction:column;gap:18px}
+.review-state{min-height:280px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:14px;color:var(--color-text-secondary)}
+.review-state--error{color:var(--color-danger-600)}
+.review-banner,.review-alert,.review-section,.conflict-card{border:1px solid rgba(203,213,225,.85);border-radius:16px;background:rgba(248,250,252,.78);padding:18px}
+.review-banner.is-warning,.conflict-card{border-color:rgba(234,179,8,.3);background:rgba(255,251,235,.88)}
+.review-pill-row,.profile-list{display:flex;flex-wrap:wrap;gap:8px}
+.review-pill{display:inline-flex;align-items:center;border-radius:999px;padding:5px 10px;font-size:.76rem;font-weight:700;color:var(--color-text-secondary)}
+.review-pill.is-success{border-color:rgba(34,197,94,.32);background:rgba(34,197,94,.12);color:#15803d}
+.review-pill.is-warning{border-color:rgba(234,179,8,.32);background:rgba(234,179,8,.13);color:#92400e}
+.review-list{margin:10px 0 0 18px;color:var(--color-text-secondary)}
+.review-grid{display:grid;gap:14px}
+.review-grid--two{grid-template-columns:repeat(2,minmax(0,1fr))}
+.review-grid--three{grid-template-columns:repeat(3,minmax(0,1fr))}
+.review-field{display:flex;flex-direction:column;gap:7px}
+.review-field--full{grid-column:1/-1}
+.review-field span{font-size:.82rem;font-weight:700;color:var(--color-text-secondary)}
+.review-field input,.review-field select,.review-field textarea{width:100%;border:1px solid rgba(203,213,225,.95);border-radius:10px;background:rgba(255,255,255,.96);padding:10px 12px;color:var(--color-text-primary)}
+.review-field textarea{resize:vertical}
+.review-field input:focus,.review-field select:focus,.review-field textarea:focus{outline:none;border-color:var(--color-primary-600);box-shadow:0 0 0 3px rgba(37,99,235,.14)}
+.review-field .is-attention{border-color:rgba(234,179,8,.7);background:rgba(255,251,235,.92)}
+.review-entry{border:1px solid rgba(203,213,225,.85);border-radius:14px;background:rgba(255,255,255,.92);overflow:hidden}
+.review-entry summary{list-style:none;display:flex;align-items:center;justify-content:space-between;gap:14px;padding:14px 16px;cursor:pointer;border-bottom:1px solid rgba(226,232,240,.86)}
+.review-entry summary::-webkit-details-marker{display:none}
+.review-entry summary strong,.profile-option strong{display:block;color:var(--color-text-primary)}
+.review-entry>.review-grid{padding:16px}
+.review-inline-btn{border-radius:999px;padding:6px 10px;color:var(--color-danger-600);font-size:.78rem;font-weight:700;background:rgba(254,242,242,.85)}
+.review-toggle{display:inline-flex;gap:8px;margin-bottom:16px;padding:6px;border:1px solid rgba(203,213,225,.85);border-radius:14px;background:rgba(248,250,252,.9)}
+.review-toggle-btn{border-radius:10px;padding:10px 14px;color:var(--color-text-secondary);font-weight:700}
+.profile-list{flex-direction:column}
+.profile-option{display:flex;align-items:flex-start;justify-content:space-between;gap:14px;padding:14px 16px;border-radius:14px;text-align:left}
+.profile-option.is-selected,.conflict-option.is-selected{border-color:rgba(37,99,235,.42);background:rgba(239,246,255,.92);box-shadow:0 0 0 3px rgba(37,99,235,.08)}
+.conflict-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+.conflict-option{display:flex;flex-direction:column;gap:8px;min-width:0;padding:14px;border-radius:14px;cursor:pointer}
+.conflict-option-title{font-weight:700;color:var(--color-text-primary)}
+.conflict-option code{display:block;white-space:pre-wrap;word-break:break-word;padding:10px;border-radius:10px;background:rgba(248,250,252,.92);color:#0f172a;font-size:.82rem}
+.review-footer{padding:16px 24px 20px;border-top:1px solid var(--border-color-light);background:rgba(255,255,255,.98)}
+.review-footer-actions{display:flex;align-items:center;gap:10px;flex-shrink:0}
+@media (max-width:900px){.review-overlay{padding:12px}.review-dialog{max-height:calc(100vh - 24px)}.review-grid--two,.review-grid--three,.conflict-grid{grid-template-columns:1fr}.review-header,.review-footer,.review-section-head,.conflict-head,.review-banner{flex-direction:column;align-items:stretch}.review-footer-actions{width:100%;justify-content:flex-end}}
+@media (max-width:640px){.review-header,.review-steps,.review-body,.review-footer{padding-left:16px;padding-right:16px}.review-steps{overflow:auto}.review-footer-actions{flex-direction:column-reverse;align-items:stretch}.review-footer-actions .btn-primary,.review-footer-actions .btn-secondary{width:100%}}
+</style>

--- a/frontend/src/lib/localMockApi.js
+++ b/frontend/src/lib/localMockApi.js
@@ -598,26 +598,31 @@ function createResumeStructuredData(user) {
 
 function createResume(id, user, overrides = {}) {
   const createdAt = nowIso()
-  return {
+  return syncMockResumeRecord({
     id,
     file_name: `Resume_${id}.pdf`,
     created_at: createdAt,
+    updated_at: createdAt,
     parse_method: 'local',
     portal_ready: true,
     has_pdf: true,
     structured_data: createResumeStructuredData(user),
+    review_status: '',
+    review_draft: null,
+    review_updated_at: null,
     ...overrides,
-  }
+  })
 }
 
 function createProfile(user, id = 1, overrides = {}) {
   const createdAt = nowIso()
-  return {
+  return syncMockProfileStorage({
     id,
     name: 'Default',
     is_active: true,
     is_default: true,
     created_at: createdAt,
+    updated_at: createdAt,
     first_name: user.first_name || '',
     last_name: user.last_name || '',
     email: user.email || '',
@@ -649,7 +654,312 @@ function createProfile(user, id = 1, overrides = {}) {
     disability_status: '',
     california_resident: '',
     ...overrides,
+  })
+}
+
+function cleanProfileString(value) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function cleanProfileList(value) {
+  return Array.isArray(value)
+    ? value.map((item) => cleanProfileString(item)).filter(Boolean)
+    : []
+}
+
+function splitProfileList(value) {
+  return String(value || '')
+    .split(/[\n,;]+/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function splitProfileLines(value) {
+  return String(value || '')
+    .split(/\r?\n+/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function normalizeCanonicalData(value = {}) {
+  const draft = value && typeof value === 'object' ? value : {}
+  const personal = draft.personal_info && typeof draft.personal_info === 'object' ? draft.personal_info : {}
+  const skills = draft.skills && typeof draft.skills === 'object' ? draft.skills : {}
+  const normalizeEntryList = (entries, mapper) => Array.isArray(entries) ? entries.map((entry) => mapper(entry)).filter((entry) => Object.values(entry).some((item) => Array.isArray(item) ? item.length : Boolean(cleanProfileString(item)))) : []
+
+  return {
+    personal_info: {
+      first_name: cleanProfileString(personal.first_name),
+      last_name: cleanProfileString(personal.last_name),
+      email: cleanProfileString(personal.email),
+      phone: cleanProfileString(personal.phone),
+      address: cleanProfileString(personal.address),
+      city: cleanProfileString(personal.city),
+      state: cleanProfileString(personal.state),
+      zip: cleanProfileString(personal.zip),
+      linkedin: cleanProfileString(personal.linkedin),
+      website: cleanProfileString(personal.website),
+    },
+    summary: cleanProfileString(draft.summary),
+    skills: {
+      technical: cleanProfileList(skills.technical),
+      languages: cleanProfileList(skills.languages),
+      tools: cleanProfileList(skills.tools),
+      soft_skills: cleanProfileList(skills.soft_skills),
+    },
+    education: normalizeEntryList(draft.education, (entry = {}) => ({
+      institution: cleanProfileString(entry.institution),
+      degree: cleanProfileString(entry.degree),
+      field_of_study: cleanProfileString(entry.field_of_study),
+      gpa: cleanProfileString(entry.gpa),
+      start_date: cleanProfileString(entry.start_date),
+      end_date: cleanProfileString(entry.end_date),
+      honors: cleanProfileList(entry.honors),
+      relevant_coursework: cleanProfileList(entry.relevant_coursework),
+    })),
+    work_experience: normalizeEntryList(draft.work_experience, (entry = {}) => ({
+      company: cleanProfileString(entry.company),
+      title: cleanProfileString(entry.title),
+      location: cleanProfileString(entry.location),
+      start_date: cleanProfileString(entry.start_date),
+      end_date: cleanProfileString(entry.end_date),
+      is_current: Boolean(entry.is_current || String(entry.end_date || '').toLowerCase() === 'present'),
+      bullets: cleanProfileList(entry.bullets),
+    })),
+    projects: normalizeEntryList(draft.projects, (entry = {}) => ({
+      name: cleanProfileString(entry.name),
+      description: cleanProfileString(entry.description),
+      date: cleanProfileString(entry.date),
+      technologies: cleanProfileList(entry.technologies),
+    })),
+    certifications: normalizeEntryList(draft.certifications, (entry = {}) => ({
+      name: cleanProfileString(typeof entry === 'string' ? entry : entry.name),
+      issuer: cleanProfileString(entry?.issuer),
+      date: cleanProfileString(entry?.date),
+    })),
+    awards: cleanProfileList(draft.awards),
+    activities: cleanProfileList(draft.activities),
+    volunteer: cleanProfileList(draft.volunteer),
   }
+}
+
+function deriveCanonicalFromProfile(profile = {}) {
+  const education = []
+  if (cleanProfileString(profile.university) || cleanProfileString(profile.degree) || cleanProfileString(profile.major)) {
+    education.push({
+      institution: cleanProfileString(profile.university),
+      degree: cleanProfileString(profile.degree),
+      field_of_study: cleanProfileString(profile.major),
+      gpa: cleanProfileString(profile.gpa),
+      end_date: cleanProfileString(profile.grad_year),
+    })
+  }
+  splitProfileLines(profile.education_history_text).forEach((line) => {
+    const parts = line.split('|').map((item) => item.trim())
+    education.push({
+      institution: cleanProfileString(parts[0]),
+      degree: cleanProfileString(parts[1]),
+      field_of_study: cleanProfileString(parts[2]),
+      start_date: cleanProfileString(parts[3]),
+      end_date: cleanProfileString(parts[4]),
+      gpa: cleanProfileString(parts[5]),
+    })
+  })
+
+  const workExperience = []
+  if (cleanProfileString(profile.job_title)) {
+    workExperience.push({ title: cleanProfileString(profile.job_title) })
+  }
+  splitProfileLines(profile.employment_history_text).forEach((line) => {
+    const parts = line.split('|').map((item) => item.trim())
+    workExperience.push({
+      company: cleanProfileString(parts[0]),
+      title: cleanProfileString(parts[1]),
+      location: cleanProfileString(parts[2]),
+      start_date: cleanProfileString(parts[3]),
+      end_date: cleanProfileString(parts[4]),
+      is_current: String(parts[4] || '').toLowerCase() === 'present',
+    })
+  })
+
+  return normalizeCanonicalData({
+    personal_info: {
+      first_name: profile.first_name,
+      last_name: profile.last_name,
+      email: profile.email,
+      phone: profile.phone,
+      address: profile.street_address,
+      city: profile.city,
+      state: profile.state,
+      zip: profile.zip,
+      linkedin: profile.linkedin,
+      website: profile.portfolio,
+    },
+    summary: profile.summary,
+    skills: { technical: splitProfileList(profile.skills_text) },
+    education,
+    work_experience: workExperience,
+    certifications: splitProfileLines(profile.certifications_text).map((name) => ({ name })),
+    awards: [],
+    activities: [],
+    volunteer: [],
+  })
+}
+
+function flattenCanonicalData(canonical) {
+  const normalized = normalizeCanonicalData(canonical)
+  const tokens = {}
+  Object.entries(normalized.personal_info || {}).forEach(([key, value]) => {
+    if (cleanProfileString(value)) tokens[`personal_info.${key}`] = value
+  })
+  if (cleanProfileString(normalized.summary)) tokens.summary = normalized.summary
+  ;['education', 'work_experience', 'projects', 'certifications'].forEach((sectionKey) => {
+    ;(normalized[sectionKey] || []).forEach((entry, index) => {
+      Object.entries(entry || {}).forEach(([key, value]) => {
+        if (Array.isArray(value) && value.length) {
+          tokens[`${sectionKey}[${index}].${key}`] = value.join(key === 'bullets' ? '\n' : ', ')
+        } else if (!Array.isArray(value) && cleanProfileString(String(value || ''))) {
+          tokens[`${sectionKey}[${index}].${key}`] = value
+        }
+      })
+    })
+  })
+  Object.entries(normalized.skills || {}).forEach(([key, value]) => {
+    if (Array.isArray(value) && value.length) tokens[`skills.${key}`] = value.join(', ')
+  })
+  ;['awards', 'activities', 'volunteer'].forEach((key) => {
+    if (normalized[key]?.length) tokens[key] = normalized[key].join('\n')
+  })
+  return tokens
+}
+
+function deriveProfileFieldsFromCanonical(canonical, existing = {}) {
+  const normalized = normalizeCanonicalData(canonical)
+  const primaryEducation = normalized.education[0] || {}
+  const extraEducation = normalized.education.slice(1)
+  const primaryWork = normalized.work_experience[0] || {}
+  const extraWork = normalized.work_experience.slice(primaryWork.title ? 1 : 0)
+  const allSkills = [
+    ...(normalized.skills.technical || []),
+    ...(normalized.skills.languages || []),
+    ...(normalized.skills.tools || []),
+    ...(normalized.skills.soft_skills || []),
+  ].filter(Boolean)
+
+  return {
+    first_name: cleanProfileString(normalized.personal_info.first_name),
+    last_name: cleanProfileString(normalized.personal_info.last_name),
+    email: cleanProfileString(normalized.personal_info.email),
+    phone: cleanProfileString(normalized.personal_info.phone),
+    linkedin: cleanProfileString(normalized.personal_info.linkedin),
+    portfolio: cleanProfileString(normalized.personal_info.website),
+    street_address: cleanProfileString(normalized.personal_info.address),
+    city: cleanProfileString(normalized.personal_info.city),
+    state: cleanProfileString(normalized.personal_info.state),
+    zip: cleanProfileString(normalized.personal_info.zip),
+    summary: cleanProfileString(normalized.summary),
+    degree: cleanProfileString(primaryEducation.degree),
+    major: cleanProfileString(primaryEducation.field_of_study),
+    university: cleanProfileString(primaryEducation.institution),
+    grad_year: cleanProfileString(primaryEducation.end_date),
+    gpa: cleanProfileString(primaryEducation.gpa),
+    job_title: cleanProfileString(primaryWork.title) || cleanProfileString(existing.job_title),
+    years_experience: cleanProfileString(existing.years_experience),
+    skills_text: allSkills.join(', '),
+    certifications_text: normalized.certifications.map((item) => cleanProfileString(item.name)).filter(Boolean).join('\n'),
+    professional_links_text: cleanProfileString(existing.professional_links_text),
+    education_history_text: extraEducation.map((item) => [item.institution, item.degree, item.field_of_study, item.start_date, item.end_date, item.gpa].map((part) => cleanProfileString(part)).join(' | ')).filter(Boolean).join('\n'),
+    employment_history_text: extraWork.map((item) => [item.company, item.title, item.location, item.start_date, item.end_date || (item.is_current ? 'Present' : '')].map((part) => cleanProfileString(part)).join(' | ')).filter(Boolean).join('\n'),
+  }
+}
+
+function syncMockProfileStorage(profile = {}) {
+  const canonical = profile.canonical_data ? normalizeCanonicalData(profile.canonical_data) : deriveCanonicalFromProfile(profile)
+  return {
+    ...profile,
+    ...deriveProfileFieldsFromCanonical(canonical, profile),
+    canonical_data: canonical,
+    token_map: flattenCanonicalData(canonical),
+    updated_at: profile.updated_at || profile.created_at || nowIso(),
+  }
+}
+
+function syncMockResumeRecord(resume = {}) {
+  return {
+    ...resume,
+    review_status: cleanProfileString(resume.review_status) || '',
+    review_draft: resume.review_draft && typeof resume.review_draft === 'object' ? resume.review_draft : null,
+    review_updated_at: resume.review_updated_at || null,
+    has_review_draft: Boolean(resume.review_draft && typeof resume.review_draft === 'object'),
+  }
+}
+
+function generateMockReviewConflicts(existingCanonical, incomingCanonical) {
+  const existingTokens = flattenCanonicalData(existingCanonical)
+  const incomingTokens = flattenCanonicalData(incomingCanonical)
+  return Object.entries(incomingTokens).reduce((accumulator, [path, incomingValue]) => {
+    const existingValue = existingTokens[path]
+    if (!existingValue || !incomingValue || existingValue === incomingValue) return accumulator
+    accumulator.push({
+      id: path,
+      path,
+      label: path.replace(/^personal_info\./, '').replace(/_/g, ' ').replace(/\[(\d+)\]/g, (_, number) => ` #${Number(number) + 1}`).replace(/\./g, ' ').replace(/\b\w/g, (char) => char.toUpperCase()),
+      existing_value: existingValue,
+      incoming_value: incomingValue,
+      resolution: 'existing',
+    })
+    return accumulator
+  }, []).sort((left, right) => left.label.localeCompare(right.label))
+}
+
+function mergeMockReviewIntoProfile(existingCanonical, incomingCanonical, conflictResolutions = {}) {
+  const existing = normalizeCanonicalData(existingCanonical)
+  const incoming = normalizeCanonicalData(incomingCanonical)
+  const existingTokens = flattenCanonicalData(existing)
+  const incomingTokens = flattenCanonicalData(incoming)
+  const conflicts = generateMockReviewConflicts(existing, incoming)
+  const conflictPaths = new Set(conflicts.map((item) => item.path))
+  const mergedTokens = { ...existingTokens }
+
+  Object.entries(incomingTokens).forEach(([path, value]) => {
+    if (!mergedTokens[path]) {
+      mergedTokens[path] = value
+      return
+    }
+    if (conflictPaths.has(path) && conflictResolutions[path] !== 'incoming') return
+    mergedTokens[path] = value
+  })
+
+  const merged = normalizeCanonicalData({
+    personal_info: {
+      first_name: mergedTokens['personal_info.first_name'],
+      last_name: mergedTokens['personal_info.last_name'],
+      email: mergedTokens['personal_info.email'],
+      phone: mergedTokens['personal_info.phone'],
+      address: mergedTokens['personal_info.address'],
+      city: mergedTokens['personal_info.city'],
+      state: mergedTokens['personal_info.state'],
+      zip: mergedTokens['personal_info.zip'],
+      linkedin: mergedTokens['personal_info.linkedin'],
+      website: mergedTokens['personal_info.website'],
+    },
+    summary: mergedTokens.summary,
+    skills: {
+      technical: [...(existing.skills.technical || []), ...(incoming.skills.technical || [])],
+      languages: [...(existing.skills.languages || []), ...(incoming.skills.languages || [])],
+      tools: [...(existing.skills.tools || []), ...(incoming.skills.tools || [])],
+      soft_skills: [...(existing.skills.soft_skills || []), ...(incoming.skills.soft_skills || [])],
+    },
+    education: [...existing.education, ...incoming.education],
+    work_experience: [...existing.work_experience, ...incoming.work_experience],
+    projects: [...existing.projects, ...incoming.projects],
+    certifications: [...existing.certifications, ...incoming.certifications],
+    awards: [...existing.awards, ...incoming.awards],
+    activities: [...existing.activities, ...incoming.activities],
+    volunteer: [...existing.volunteer, ...incoming.volunteer],
+  })
+
+  return { merged, conflicts }
 }
 
 function createDefaultState() {
@@ -688,8 +998,8 @@ function ensureArray(value, fallback = []) {
 function ensureStateShape(state) {
   const safe = state && typeof state === 'object' ? state : createDefaultState()
   safe.user = safe.user && typeof safe.user === 'object' ? { ...createDefaultUser(), ...safe.user } : createDefaultUser()
-  safe.resumes = ensureArray(safe.resumes, [])
-  safe.profiles = ensureArray(safe.profiles, [])
+  safe.resumes = ensureArray(safe.resumes, []).map((resume) => syncMockResumeRecord(resume))
+  safe.profiles = ensureArray(safe.profiles, []).map((profile) => syncMockProfileStorage(profile))
   safe.parseJobs = safe.parseJobs && typeof safe.parseJobs === 'object' ? safe.parseJobs : {}
   safe.nextIds = safe.nextIds && typeof safe.nextIds === 'object' ? safe.nextIds : { resume: 1, profile: 1, parseJob: 1 }
   safe.nextIds.resume = Number(safe.nextIds.resume || safe.resumes.length + 1)
@@ -1208,7 +1518,11 @@ function finalizeResumeParse(state, job) {
     _validation: validation,
   }
 
-  state.resumes[resumeIndex] = updated
+  updated.review_status = 'pending'
+  updated.review_draft = updated.structured_data
+  updated.review_updated_at = nowIso()
+  updated.updated_at = nowIso()
+  state.resumes[resumeIndex] = syncMockResumeRecord(updated)
 }
 
 function advanceParseJobState(state, job) {
@@ -2357,6 +2671,8 @@ async function handleMockApiRequest(request, requestUrl, state) {
   }
 
   if ((pathname === '/api/resume/' || pathname === '/api/resume') && method === 'GET') {
+    state.resumes = state.resumes.map((resume) => syncMockResumeRecord(resume))
+    saveState(state)
     return toJsonResponse(asJson(state.resumes))
   }
 
@@ -2379,12 +2695,16 @@ async function handleMockApiRequest(request, requestUrl, state) {
       file_name: fileName,
       parse_method: null,
       portal_ready: false,
+      structured_data: null,
+      review_status: '',
+      review_draft: null,
+      review_updated_at: null,
     })
 
     state.resumes.unshift(uploaded)
     saveState(state)
 
-    return toJsonResponse(uploaded, 201)
+    return toJsonResponse(asJson(uploaded), 201)
   }
 
   const resumeParseMatch = pathname.match(/^\/api\/resume\/(\d+)\/parse-async$/)
@@ -2437,6 +2757,7 @@ async function handleMockApiRequest(request, requestUrl, state) {
 
     const payload = {
       job_id: job.job_id,
+      resume_id: job.resume_id,
       status: job.status,
       progress_stage: job.progress_stage,
       attempt: job.attempt,
@@ -2498,7 +2819,138 @@ async function handleMockApiRequest(request, requestUrl, state) {
       return toJsonResponse({ detail: 'Resume not found' }, 404)
     }
 
-    return toJsonResponse(asJson(resume))
+    return toJsonResponse(asJson(syncMockResumeRecord(resume)))
+  }
+
+  const reviewDraftMatch = pathname.match(/^\/api\/resume\/(\d+)\/review-draft$/)
+  if (reviewDraftMatch && method === 'GET') {
+    const resumeId = Number(reviewDraftMatch[1])
+    const resume = state.resumes.find((item) => Number(item.id) === resumeId)
+    if (!resume) {
+      return toJsonResponse({ detail: 'Resume not found' }, 404)
+    }
+    const reviewDraft = resume.review_draft || resume.structured_data
+    if (!reviewDraft) {
+      return toJsonResponse({ detail: 'Resume has not been parsed yet' }, 400)
+    }
+    return toJsonResponse({
+      resume_id: resume.id,
+      file_name: resume.file_name,
+      parse_method: resume.parse_method,
+      review_status: resume.review_status || 'pending',
+      review_updated_at: resume.review_updated_at,
+      review_draft: reviewDraft,
+    })
+  }
+
+  if (reviewDraftMatch && method === 'PUT') {
+    const resumeId = Number(reviewDraftMatch[1])
+    const resumeIndex = state.resumes.findIndex((item) => Number(item.id) === resumeId)
+    if (resumeIndex < 0) {
+      return toJsonResponse({ detail: 'Resume not found' }, 404)
+    }
+    const body = await parseJsonBody(request)
+    state.resumes[resumeIndex] = syncMockResumeRecord({
+      ...state.resumes[resumeIndex],
+      review_status: 'pending',
+      review_draft: body.review_draft || state.resumes[resumeIndex].review_draft || state.resumes[resumeIndex].structured_data,
+      review_updated_at: nowIso(),
+    })
+    saveState(state)
+    return toJsonResponse({
+      resume_id: state.resumes[resumeIndex].id,
+      file_name: state.resumes[resumeIndex].file_name,
+      parse_method: state.resumes[resumeIndex].parse_method,
+      review_status: state.resumes[resumeIndex].review_status,
+      review_updated_at: state.resumes[resumeIndex].review_updated_at,
+      review_draft: state.resumes[resumeIndex].review_draft,
+    })
+  }
+
+  const reviewConflictsMatch = pathname.match(/^\/api\/resume\/(\d+)\/review-conflicts$/)
+  if (reviewConflictsMatch && method === 'POST') {
+    const resumeId = Number(reviewConflictsMatch[1])
+    const resume = state.resumes.find((item) => Number(item.id) === resumeId)
+    if (!resume) {
+      return toJsonResponse({ detail: 'Resume not found' }, 404)
+    }
+    const body = await parseJsonBody(request)
+    const profile = state.profiles.find((item) => Number(item.id) === Number(body.profile_id))
+    if (!profile) {
+      return toJsonResponse({ detail: 'Profile not found' }, 404)
+    }
+    const incoming = normalizeCanonicalData(body.reviewed_data || resume.review_draft || resume.structured_data)
+    const existing = normalizeCanonicalData(profile.canonical_data || {})
+    const conflicts = generateMockReviewConflicts(existing, incoming)
+    return toJsonResponse({ profile_id: profile.id, conflict_count: conflicts.length, conflicts })
+  }
+
+  const applyReviewMatch = pathname.match(/^\/api\/resume\/(\d+)\/apply-review$/)
+  if (applyReviewMatch && method === 'POST') {
+    const resumeId = Number(applyReviewMatch[1])
+    const resumeIndex = state.resumes.findIndex((item) => Number(item.id) === resumeId)
+    if (resumeIndex < 0) {
+      return toJsonResponse({ detail: 'Resume not found' }, 404)
+    }
+    const body = await parseJsonBody(request)
+    const incoming = normalizeCanonicalData(body.reviewed_data)
+    let profile = null
+    let conflicts = []
+
+    if (body.mode === 'existing') {
+      const profileIndex = state.profiles.findIndex((item) => Number(item.id) === Number(body.profile_id))
+      if (profileIndex < 0) {
+        return toJsonResponse({ detail: 'Profile not found' }, 404)
+      }
+      const merge = mergeMockReviewIntoProfile(state.profiles[profileIndex].canonical_data || {}, incoming, body.conflict_resolutions || {})
+      conflicts = merge.conflicts
+      profile = syncMockProfileStorage({
+        ...state.profiles[profileIndex],
+        canonical_data: merge.merged,
+        is_active: true,
+        updated_at: nowIso(),
+      })
+      state.profiles = state.profiles.map((item, index) => index === profileIndex ? profile : { ...item, is_active: false })
+    } else if (body.mode === 'new') {
+      const id = state.nextIds.profile
+      state.nextIds.profile += 1
+      state.profiles = state.profiles.map((item) => ({ ...item, is_active: false }))
+      profile = syncMockProfileStorage(createProfile(state.user, id, {
+        name: cleanProfileString(body.profile_name) || cleanProfileString(incoming.personal_info.first_name) || `Profile ${id}`,
+        is_default: false,
+        is_active: true,
+        canonical_data: incoming,
+        updated_at: nowIso(),
+      }))
+      state.profiles.push(profile)
+    } else {
+      return toJsonResponse({ detail: "Mode must be 'existing' or 'new'" }, 400)
+    }
+
+    if (profile?.is_active) {
+      state.user = {
+        ...state.user,
+        first_name: profile.first_name || state.user.first_name,
+        last_name: profile.last_name || state.user.last_name,
+        email: profile.email || state.user.email,
+      }
+    }
+
+    state.resumes[resumeIndex] = syncMockResumeRecord({
+      ...state.resumes[resumeIndex],
+      review_status: 'applied',
+      review_draft: body.reviewed_data,
+      review_updated_at: nowIso(),
+      updated_at: nowIso(),
+    })
+    saveState(state)
+    return toJsonResponse({
+      resume_id: state.resumes[resumeIndex].id,
+      profile_id: profile.id,
+      review_status: state.resumes[resumeIndex].review_status,
+      conflict_count: conflicts.length,
+      profile: asJson(profile),
+    })
   }
 
   if (resumeByIdMatch && method === 'DELETE') {
@@ -2509,6 +2961,8 @@ async function handleMockApiRequest(request, requestUrl, state) {
   }
 
   if ((pathname === '/api/applicant-profile/' || pathname === '/api/applicant-profile') && method === 'GET') {
+    state.profiles = state.profiles.map((profile) => syncMockProfileStorage(profile))
+    saveState(state)
     return toJsonResponse(asJson(state.profiles))
   }
 
@@ -2534,9 +2988,9 @@ async function handleMockApiRequest(request, requestUrl, state) {
       state.profiles = state.profiles.map((profile) => ({ ...profile, is_active: false }))
     }
 
-    state.profiles.push(created)
+    state.profiles.push(syncMockProfileStorage(created))
     saveState(state)
-    return toJsonResponse(created, 201)
+    return toJsonResponse(asJson(state.profiles[state.profiles.length - 1]), 201)
   }
 
   const profileByIdMatch = pathname.match(/^\/api\/applicant-profile\/(\d+)$/)
@@ -2548,7 +3002,10 @@ async function handleMockApiRequest(request, requestUrl, state) {
       return toJsonResponse({ detail: 'Profile not found' }, 404)
     }
 
-    return toJsonResponse(asJson(profile))
+    const synced = syncMockProfileStorage(profile)
+    state.profiles = state.profiles.map((item) => Number(item.id) === profileId ? synced : item)
+    saveState(state)
+    return toJsonResponse(asJson(synced))
   }
 
   if (profileByIdMatch && method === 'PUT') {
@@ -2565,11 +3022,12 @@ async function handleMockApiRequest(request, requestUrl, state) {
     } catch (error) {
       return toJsonResponse({ detail: error?.message || 'Please enter valid contact details' }, 400)
     }
-    state.profiles[profileIndex] = {
+    state.profiles[profileIndex] = syncMockProfileStorage({
       ...state.profiles[profileIndex],
       ...body,
       id: profileId,
-    }
+      updated_at: nowIso(),
+    })
 
     if (state.profiles[profileIndex].is_active) {
       state.user = {
@@ -2629,6 +3087,8 @@ async function handleMockApiRequest(request, requestUrl, state) {
       email: activeProfile.email || state.user.email,
     }
 
+    activeProfile = syncMockProfileStorage(activeProfile)
+    state.profiles = state.profiles.map((profile) => Number(profile.id) === profileId ? activeProfile : profile)
     saveState(state)
     return toJsonResponse(asJson(activeProfile))
   }

--- a/frontend/src/views/Resumes.vue
+++ b/frontend/src/views/Resumes.vue
@@ -211,6 +211,7 @@
                             <span v-if="r.parse_method" :class="['badge', 'parse-method-badge', parseMethodToneClass(r.parse_method)]">{{ parseMethodTagLabel(r.parse_method) }}</span>
                         </div>
                         <div class="resume-actions">
+                            <button v-if="canReviewResume(r)" title="Review parsed data before profile fill" class="review-btn" @click="openReviewModal(r)">Review</button>
                             <button title="View parsed data" @click="viewResume(r.id)">View</button>
                             <button
                                 title="Delete resume"
@@ -1000,6 +1001,16 @@
             </div>
         </div>
 
+        <ResumeReviewModal
+            v-if="showReviewModal && reviewResumeId"
+            :resume-id="reviewResumeId"
+            :resume-name="reviewResumeName"
+            :profiles="profiles"
+            :active-profile-id="activeProfileId"
+            @close="closeReviewModal"
+            @applied="handleReviewApplied"
+        />
+
         <ConfirmModal
             v-if="jobInfoConfirmVisible"
             title="Leave Mandatory Disclosures?"
@@ -1049,6 +1060,7 @@
                             <span v-if="r.parse_method" :class="['badge', 'parse-method-badge', parseMethodToneClass(r.parse_method)]">{{ parseMethodTagLabel(r.parse_method) }}</span>
                         </div>
                         <div class="resume-actions">
+                            <button v-if="canReviewResume(r)" title="Review parsed data before profile fill" class="review-btn" @click="openReviewModal(r)">Review</button>
                             <button title="View parsed data" @click="viewResume(r.id)">View</button>
                             <button
                                 title="Delete resume"
@@ -1075,6 +1087,7 @@
 <script>
 import Card from '../components/Card.vue'
 import ConfirmModal from '../components/ConfirmModal.vue'
+import ResumeReviewModal from '../components/ResumeReviewModal.vue'
 import { authedFetch, getCurrentUser, setCurrentUser } from '../lib/auth.js'
 import { publishCurrentPageDiagnostics, clearCurrentPageDiagnostics } from '../lib/debugDiagnostics'
 import { assertValidEmail, buildMailtoHref, buildPhoneHref, inferPhoneCountry, normalizePhone } from '../lib/validation.js'
@@ -1087,6 +1100,7 @@ export default {
     components: {
         Card,
         ConfirmModal,
+        ResumeReviewModal,
     },
 
     data() {
@@ -1121,6 +1135,7 @@ export default {
             parseQueuePosition: null,
             parseQueueTotal: null,
             parseErrorCode: null,
+            parseResumeId: null,
 
             // Queue panel
             queueScope: 'user',
@@ -1139,6 +1154,9 @@ export default {
             pdfObjectUrl: '',
             pdfLoading: false,
             pdfLoadError: null,
+            showReviewModal: false,
+            reviewResumeId: null,
+            reviewResumeName: '',
 
             // Parse details popup
             showPipelineDetails: false,
@@ -1721,8 +1739,10 @@ export default {
                 uploading: this.uploading,
                 uploadError: this.uploadError,
                 showViewModal: this.showViewModal,
+                showReviewModal: this.showReviewModal,
                 viewLoading: this.viewLoading,
                 viewingResumeId: this.viewingResume?.id || null,
+                reviewResumeId: this.reviewResumeId || null,
                 saveStatus: this.saveStatus,
                 jobInfoError: this.jobInfoError,
                 jobInfoSuccess: this.jobInfoSuccess,
@@ -1751,14 +1771,47 @@ export default {
         },
 
         badgeClass(r) {
+            if (r?.review_status === 'pending' || (r?.has_review_draft && !r?.review_status)) return 'review-pending'
             if (r.portal_ready) return 'portal-ready'
             if (r.parse_method) return 'needs-fields'
             return 'not-parsed'
         },
         badgeText(r) {
+            if (r?.review_status === 'pending' || (r?.has_review_draft && !r?.review_status)) return 'Review Pending'
             if (r.portal_ready) return 'Portal Ready'
             if (r.parse_method) return 'Needs Fields'
             return 'Not Parsed'
+        },
+        canReviewResume(r) {
+            return Boolean(r?.review_status === 'pending' || (r?.has_review_draft && !r?.review_status))
+        },
+
+        openReviewModal(resume) {
+            const resumeId = typeof resume === 'object' ? resume?.id : resume
+            if (!resumeId) return
+            const resumeName = typeof resume === 'object' ? resume?.file_name || '' : ''
+            this.showLibraryModal = false
+            this.closeViewModal()
+            this.reviewResumeId = Number(resumeId)
+            this.reviewResumeName = resumeName
+            this.showReviewModal = true
+            this.publishDebugState('review-open')
+        },
+        closeReviewModal() {
+            this.showReviewModal = false
+            this.reviewResumeId = null
+            this.reviewResumeName = ''
+            this.publishDebugState('review-close')
+        },
+        async handleReviewApplied(result) {
+            const profileId = Number(result?.profile_id || 0) || null
+            await this.loadResumes()
+            await this.refreshProfileList()
+            if (profileId) {
+                await this.loadProfileData(profileId)
+            }
+            this.closeReviewModal()
+            this.publishDebugState('review-applied')
         },
 
         handleDelete(id) {
@@ -1883,6 +1936,7 @@ export default {
             this.parseQueuePosition = null
             this.parseQueueTotal = null
             this.parseErrorCode = null
+            this.parseResumeId = null
             if (this._pollTimer) clearTimeout(this._pollTimer)
         },
         triggerFileInput() {
@@ -1953,6 +2007,7 @@ export default {
 
                 // 3. Switch to parsing progress stage
                 this.parseJobId = parseData.job_id
+                this.parseResumeId = resumeId
                 this.parseStatus = 'queued'
                 this.parseStageLabel = 'Queued…'
                 this.parseError = null
@@ -1990,12 +2045,15 @@ export default {
                 this.parseErrorCode = job.error_code || null
 
                 if (job.status === 'success') {
-                    const summary = job.result_summary || {}
-                    const readiness = summary.portal_ready ? 'Portal-ready' : 'Needs additional fields'
-                    showToast(`Parse complete. ${readiness}.`, 'success')
+                    const completedResumeId = this.parseResumeId
+                    showToast('Parse complete. Review the extracted data before filling a profile.', 'success')
                     this.resetUploadFlow()
                     await this.loadResumes()
                     await this.loadQueueStatus()
+                    if (completedResumeId) {
+                        const completedResume = this.resumes.find((resume) => Number(resume.id) === Number(completedResumeId))
+                        this.openReviewModal(completedResume || completedResumeId)
+                    }
                     this.publishDebugState('parse-success')
                     return
                 }
@@ -2006,6 +2064,7 @@ export default {
                     this.uploadStep = 'confirm'
                     this.parseJobId = null
                     this.parseJobMethod = null
+                    this.parseResumeId = null
                     this.publishDebugState('parse-failed')
                     return
                 }
@@ -2014,6 +2073,7 @@ export default {
                     this.uploadStep = 'confirm'
                     this.parseJobId = null
                     this.parseJobMethod = null
+                    this.parseResumeId = null
                     this.publishDebugState('parse-cancelled')
                     return
                 }
@@ -2038,6 +2098,7 @@ export default {
             this.uploadStep = 'confirm'
             this.parseJobId = null
             this.parseJobMethod = null
+            this.parseResumeId = null
             showToast('Parse cancelled.', 'success')
             this.publishDebugState('parse-cancelled-by-user')
         },

--- a/frontend/src/views/css/Resumes.css
+++ b/frontend/src/views/css/Resumes.css
@@ -682,6 +682,18 @@
   color: #1a1a2e;
 }
 
+.resume-actions button.review-btn {
+  border-color: rgba(37, 99, 235, 0.26);
+  color: #1d4ed8;
+  background: rgba(239, 246, 255, 0.92);
+}
+
+.resume-actions button.review-btn:hover {
+  background: rgba(219, 234, 254, 0.95);
+  border-color: rgba(37, 99, 235, 0.42);
+  color: #1d4ed8;
+}
+
 .resume-actions button.delete-btn:hover {
   background: rgba(239, 68, 68, 0.08);
   border-color: rgba(239, 68, 68, 0.4);
@@ -713,6 +725,12 @@
   background: rgba(34, 197, 94, 0.12);
   color: #15803d;
   border: 1px solid rgba(34, 197, 94, 0.3);
+}
+
+.badge.review-pending {
+  background: rgba(37, 99, 235, 0.1);
+  color: #1d4ed8;
+  border: 1px solid rgba(37, 99, 235, 0.3);
 }
 
 .badge.needs-fields {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath, URL } from 'node:url'
 
 import { defineConfig, loadEnv } from 'vite'
@@ -49,12 +50,38 @@ function buildApiProxy(target) {
   }
 }
 
+function resolveHttpsConfig(env) {
+  const httpsEnabled = parseBoolean(env.VITE_DEV_HTTPS, false)
+  if (!httpsEnabled) return false
+
+  const certFile = String(env.VITE_DEV_HTTPS_CERT_FILE || '').trim()
+  const keyFile = String(env.VITE_DEV_HTTPS_KEY_FILE || '').trim()
+
+  if (!certFile || !keyFile) {
+    throw new Error(
+      '[local-https] Set both VITE_DEV_HTTPS_CERT_FILE and VITE_DEV_HTTPS_KEY_FILE when VITE_DEV_HTTPS=true.'
+    )
+  }
+  if (!existsSync(certFile)) {
+    throw new Error(`[local-https] HTTPS cert file was not found: ${certFile}`)
+  }
+  if (!existsSync(keyFile)) {
+    throw new Error(`[local-https] HTTPS key file was not found: ${keyFile}`)
+  }
+
+  return {
+    cert: readFileSync(certFile),
+    key: readFileSync(keyFile),
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const localMode = resolveLocalMode(mode, env)
   const backendOrigin = String(env.VITE_LOCAL_BACKEND_ORIGIN || 'http://localhost:8000').trim()
   const allowRemoteApi = parseBoolean(env.VITE_ALLOW_REMOTE_API, false)
+  const https = resolveHttpsConfig(env)
 
   if (localMode === 'backend' && !allowRemoteApi && !isLoopbackOrigin(backendOrigin)) {
     throw new Error(
@@ -73,9 +100,10 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
-      host: env.VITE_DEV_HOST || '127.0.0.1',
+      host: env.VITE_DEV_HOST || 'localhost',
       port: Number(env.VITE_DEV_PORT || 5173),
       strictPort: false,
+      https,
       proxy: localMode === 'backend' ? buildApiProxy(backendOrigin) : undefined,
     },
   }

--- a/scripts/local/lifecycle/local-extension-test.ps1
+++ b/scripts/local/lifecycle/local-extension-test.ps1
@@ -1,0 +1,417 @@
+[CmdletBinding()]
+param(
+    [switch]$SkipBuild,
+    [switch]$SkipFrontend,
+    [switch]$BackendOnly
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "== $Message ==" -ForegroundColor Cyan
+}
+
+function Fail {
+    param([string]$Message)
+    Write-Error $Message
+    exit 1
+}
+
+function Assert-CommandExists {
+    param(
+        [string]$CommandName,
+        [string]$InstallHint
+    )
+
+    if (-not (Get-Command $CommandName -ErrorAction SilentlyContinue)) {
+        Fail "$CommandName is required. $InstallHint"
+    }
+}
+
+function Invoke-NativeCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [string[]]$Arguments = @(),
+
+        [string]$FailureMessage = "Native command failed."
+    )
+
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        Fail "$FailureMessage`nCommand: $FilePath $($Arguments -join ' ')`nExit code: $LASTEXITCODE"
+    }
+}
+
+function Get-RepoRoot {
+    param([string]$StartPath)
+
+    $current = Split-Path -Parent $StartPath
+    while ($current) {
+        if (Test-Path -LiteralPath (Join-Path $current 'docker-compose.local.yml')) {
+            return $current
+        }
+
+        $parent = Split-Path -Parent $current
+        if ($parent -eq $current) {
+            break
+        }
+        $current = $parent
+    }
+
+    Fail "Could not locate the repo root from $StartPath. Expected to find docker-compose.local.yml in an ancestor directory."
+}
+
+function Assert-PathExists {
+    param(
+        [string]$Path,
+        [string]$Hint
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        Fail "Required path missing: $Path`n$Hint"
+    }
+}
+
+function Ensure-FileFromExample {
+    param(
+        [string]$TargetPath,
+        [string]$ExamplePath,
+        [string]$Label
+    )
+
+    if (Test-Path -LiteralPath $TargetPath) {
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $ExamplePath)) {
+        Fail "Missing $Label and its example template was not found: $ExamplePath"
+    }
+
+    Copy-Item -LiteralPath $ExamplePath -Destination $TargetPath
+    Write-Host "Created $Label from example: $TargetPath" -ForegroundColor Yellow
+}
+
+function Get-DotEnvValue {
+    param(
+        [string]$EnvFilePath,
+        [string]$Key
+    )
+
+    if (-not (Test-Path -LiteralPath $EnvFilePath)) {
+        return ''
+    }
+
+    $prefix = "$Key="
+    foreach ($line in Get-Content -LiteralPath $EnvFilePath) {
+        $trimmed = $line.Trim()
+        if (-not $trimmed -or $trimmed.StartsWith('#')) {
+            continue
+        }
+        if (-not $trimmed.StartsWith($prefix)) {
+            continue
+        }
+
+        $value = $trimmed.Substring($prefix.Length).Trim()
+        if (
+            ($value.StartsWith('"') -and $value.EndsWith('"')) -or
+            ($value.StartsWith("'") -and $value.EndsWith("'"))
+        ) {
+            $value = $value.Substring(1, $value.Length - 2)
+        }
+        return $value
+    }
+
+    return ''
+}
+
+function Wait-ForHttpOk {
+    param(
+        [string]$Url,
+        [int]$Attempts = 60,
+        [int]$DelaySeconds = 2,
+        [string]$SslHelp = ""
+    )
+
+    for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+        try {
+            $response = Invoke-WebRequest -Uri $Url -Method Get -TimeoutSec 5 -UseBasicParsing
+            if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 400) {
+                return
+            }
+        } catch {
+            $message = $_.Exception.Message
+            if ($SslHelp -and ($message -match 'SSL|TLS|certificate|secure channel|trust relationship')) {
+                Fail "$SslHelp`nLatest error: $message"
+            }
+            if ($attempt -eq $Attempts) {
+                Fail "Timed out waiting for $Url`nLatest error: $message"
+            }
+        }
+
+        Start-Sleep -Seconds $DelaySeconds
+    }
+}
+
+function Get-ProcessExecutable {
+    $current = Get-Process -Id $PID
+    if ($current.Path) {
+        return $current.Path
+    }
+
+    $pwsh = (Get-Command pwsh -ErrorAction SilentlyContinue)
+    if ($pwsh) {
+        return $pwsh.Source
+    }
+
+    $powershell = (Get-Command powershell -ErrorAction SilentlyContinue)
+    if ($powershell) {
+        return $powershell.Source
+    }
+
+    Fail "Could not locate a PowerShell executable to launch the frontend dev server."
+}
+
+function Get-NpmExecutable {
+    if ($IsWindows) {
+        $npmCmd = Get-Command npm.cmd -ErrorAction SilentlyContinue
+        if ($npmCmd) {
+            return $npmCmd.Source
+        }
+    }
+
+    $npm = Get-Command npm -ErrorAction SilentlyContinue
+    if ($npm) {
+        return $npm.Source
+    }
+
+    Fail "Could not locate npm on PATH."
+}
+
+function Get-InstallHint {
+    param([string]$ToolName)
+
+    switch ($ToolName) {
+        'mkcert' {
+            if ($IsMacOS) {
+                return "Install it with `brew install mkcert` and then run `mkcert -install`."
+            }
+            if ($IsWindows) {
+                return "Install it with `choco install mkcert -y` and then run `mkcert -install`."
+            }
+            return "Install it with your package manager, then run `mkcert -install`."
+        }
+        'docker' {
+            if ($IsMacOS) {
+                return "Install Docker Desktop for Mac and ensure `docker` is on PATH."
+            }
+            if ($IsWindows) {
+                return "Install Docker Desktop and ensure `docker` is on PATH."
+            }
+            return "Install Docker and ensure `docker` is on PATH."
+        }
+        'npm' {
+            if ($IsMacOS) {
+                return "Install Node.js, for example with `brew install node`, and ensure `npm` is on PATH."
+            }
+            if ($IsWindows) {
+                return "Install Node.js and ensure `npm` is on PATH."
+            }
+            return "Install Node.js and ensure `npm` is on PATH."
+        }
+        default {
+            return "Install $ToolName and ensure it is on PATH."
+        }
+    }
+}
+
+function Test-FrontendDependencies {
+    param([string]$FrontendDir)
+
+    if (-not (Test-Path -LiteralPath (Join-Path $FrontendDir 'node_modules'))) {
+        Fail "frontend/node_modules is missing. Run `npm install` inside `frontend/` before using this script."
+    }
+}
+
+function Test-ExtensionDependencies {
+    param(
+        [string]$ExtensionDir,
+        [string]$FrontendDir
+    )
+
+    $extensionNodeModules = Test-Path -LiteralPath (Join-Path $ExtensionDir 'node_modules')
+    $frontendNodeModules = Test-Path -LiteralPath (Join-Path $FrontendDir 'node_modules')
+
+    if (-not $extensionNodeModules -and -not $frontendNodeModules) {
+        Fail "Neither uah-browser-extension/node_modules nor frontend/node_modules exists. Run `npm install` in one of those directories before building the extension."
+    }
+}
+
+function Start-FrontendWindow {
+    param(
+        [string]$FrontendDir,
+        [string]$PowerShellExe
+    )
+
+    if ($IsWindows) {
+        $command = "Set-Location -LiteralPath '$FrontendDir'; npm run dev:backend"
+        Start-Process -FilePath $PowerShellExe -WorkingDirectory $FrontendDir -ArgumentList '-NoExit', '-Command', $command | Out-Null
+        return
+    }
+
+    if ($IsMacOS -and (Get-Command osascript -ErrorAction SilentlyContinue)) {
+        $escapedPath = $FrontendDir.Replace('\', '\\').Replace('"', '\"')
+        $terminalCommand = "cd `"$escapedPath`"; npm run dev:backend"
+        & osascript -e 'tell application "Terminal" to activate' -e "tell application `"Terminal`" to do script `"$terminalCommand`"" | Out-Null
+        return
+    }
+
+    Fail "Automatic frontend launch in a new terminal window is only supported on Windows and macOS Terminal right now. Start `npm run dev:backend` manually in $FrontendDir or rerun with -SkipFrontend."
+}
+
+if ($BackendOnly) {
+    $SkipFrontend = $true
+    $SkipBuild = $true
+}
+
+$repoRoot = Get-RepoRoot -StartPath $PSCommandPath
+$frontendDir = Join-Path $repoRoot 'frontend'
+$extensionDir = Join-Path $repoRoot 'uah-browser-extension'
+$localComposePath = Join-Path $repoRoot 'docker-compose.local.yml'
+$rootEnvPath = Join-Path $repoRoot '.env'
+$rootEnvExamplePath = Join-Path $repoRoot 'env-examples\local\.env.example'
+$frontendEnvLocalPath = Join-Path $frontendDir '.env.local'
+$frontendEnvLocalExamplePath = Join-Path $frontendDir '.env.local.example'
+$extensionEnvLocalPath = Join-Path $extensionDir '.env.local'
+$extensionEnvLocalExamplePath = Join-Path $extensionDir '.env.local.example'
+$localCertDir = Join-Path $repoRoot 'volumes\certs\local'
+$localCertPath = Join-Path $localCertDir 'tls.crt'
+$localKeyPath = Join-Path $localCertDir 'tls.key'
+$extensionDistPath = Join-Path $extensionDir 'dist'
+$npmExecutable = Get-NpmExecutable
+
+Write-Step "Checking prerequisites"
+Assert-CommandExists -CommandName 'docker' -InstallHint (Get-InstallHint -ToolName 'docker')
+Assert-CommandExists -CommandName 'npm' -InstallHint (Get-InstallHint -ToolName 'npm')
+Assert-CommandExists -CommandName 'mkcert' -InstallHint (Get-InstallHint -ToolName 'mkcert')
+
+Assert-PathExists -Path $localComposePath -Hint 'The local compose file is required to start backend-local.'
+Ensure-FileFromExample -TargetPath $frontendEnvLocalPath -ExamplePath $frontendEnvLocalExamplePath -Label 'frontend/.env.local'
+Ensure-FileFromExample -TargetPath $extensionEnvLocalPath -ExamplePath $extensionEnvLocalExamplePath -Label 'uah-browser-extension/.env.local'
+Assert-PathExists -Path $rootEnvPath -Hint 'Create repo-root .env from env-examples/local/.env.example.'
+Assert-PathExists -Path $rootEnvExamplePath -Hint 'The local root env example is missing from env-examples/local/.env.example.'
+Assert-PathExists -Path $localCertPath -Hint 'Generate mkcert certs at volumes/certs/local/tls.crt and tls.key.'
+Assert-PathExists -Path $localKeyPath -Hint 'Generate mkcert certs at volumes/certs/local/tls.crt and tls.key.'
+
+Write-Step "Checking dependency directories"
+Test-FrontendDependencies -FrontendDir $frontendDir
+if (-not $SkipBuild) {
+    Test-ExtensionDependencies -ExtensionDir $extensionDir -FrontendDir $frontendDir
+}
+
+Write-Step "Starting local backend"
+Push-Location $repoRoot
+try {
+    Invoke-NativeCommand `
+        -FilePath 'docker' `
+        -Arguments @('compose', '-f', $localComposePath, '--profile', 'backend', 'up', '-d', 'db-local', 'backend-local') `
+        -FailureMessage 'Failed to start the local backend with docker compose.'
+} finally {
+    Pop-Location
+}
+
+Write-Host "Waiting for backend-local to answer on http://localhost:8000/openapi.json ..."
+Wait-ForHttpOk -Url 'http://localhost:8000/openapi.json' -Attempts 60 -DelaySeconds 2
+Write-Host "Backend is ready." -ForegroundColor Green
+
+if (-not $SkipFrontend) {
+    Write-Step "Starting HTTPS frontend"
+    $frontendAlreadyRunning = $false
+    try {
+        Wait-ForHttpOk -Url 'https://localhost:5173/' -Attempts 1 -DelaySeconds 1 -SslHelp ''
+        $frontendAlreadyRunning = $true
+    } catch {
+        $frontendAlreadyRunning = $false
+    }
+
+    if ($frontendAlreadyRunning) {
+        Write-Host "Frontend already appears to be running on https://localhost:5173." -ForegroundColor Yellow
+    } else {
+        $powerShellExe = Get-ProcessExecutable
+        Start-FrontendWindow -FrontendDir $frontendDir -PowerShellExe $powerShellExe
+    }
+
+    Write-Host "Waiting for HTTPS frontend on https://localhost:5173 ..."
+    Wait-ForHttpOk `
+        -Url 'https://localhost:5173/' `
+        -Attempts 60 `
+        -DelaySeconds 2 `
+        -SslHelp 'The HTTPS frontend could not be reached because the localhost certificate is not trusted. Open https://localhost:5173 in Chrome, trust the mkcert certificate if prompted, then rerun this script.'
+
+    Write-Host "Frontend is ready." -ForegroundColor Green
+} else {
+    Write-Step "Skipping frontend startup"
+}
+
+if (-not $SkipBuild) {
+    Write-Step "Building the browser extension"
+    if (Test-Path -LiteralPath $extensionDistPath) {
+        Remove-Item -LiteralPath $extensionDistPath -Recurse -Force
+    }
+
+    Push-Location $extensionDir
+    try {
+        Invoke-NativeCommand `
+            -FilePath $npmExecutable `
+            -Arguments @('run', 'build') `
+            -FailureMessage 'Browser extension build failed.'
+    } finally {
+        Pop-Location
+    }
+
+    if (-not (Test-Path -LiteralPath $extensionDistPath)) {
+        Fail "Extension build finished without producing $extensionDistPath"
+    }
+
+    Write-Host "Extension build is ready at $extensionDistPath" -ForegroundColor Green
+} else {
+    Write-Step "Skipping extension build"
+}
+
+Write-Step "Next test steps"
+Write-Host "1. Open Chrome and go to chrome://extensions"
+Write-Host "2. Turn on Developer mode"
+if (-not $SkipBuild) {
+    Write-Host "3. Click Load unpacked and choose: $extensionDistPath"
+} else {
+    Write-Host "3. Load the existing unpacked extension from: $extensionDistPath"
+}
+Write-Host "4. Open the extension popup and sign in with email/password"
+Write-Host "5. Verify popup close/reopen keeps the session"
+Write-Host "6. Verify Profiles loads and detail copy buttons work"
+Write-Host "7. Verify Resumes loads and detail copy buttons work"
+Write-Host "8. Verify Open UAH opens https://localhost:5173"
+Write-Host "9. Verify logout clears extension state"
+Write-Host ""
+Write-Host "Local harness note: Google OAuth is intentionally disabled on localhost." -ForegroundColor Yellow
+Write-Host "Seeded login env file: $rootEnvPath" -ForegroundColor Yellow
+Write-Host "Extension local config env file: $extensionEnvLocalPath" -ForegroundColor Yellow
+
+$devAuthEnabled = (Get-DotEnvValue -EnvFilePath $rootEnvPath -Key 'DEV_AUTH_TEST_ACCOUNT_ENABLED').ToLowerInvariant()
+if ($devAuthEnabled -in @('true', '1', 'yes', 'on')) {
+    $devAuthEmail = Get-DotEnvValue -EnvFilePath $rootEnvPath -Key 'DEV_AUTH_TEST_EMAIL'
+    if (-not $devAuthEmail) {
+        $devAuthEmail = Get-DotEnvValue -EnvFilePath $rootEnvPath -Key 'DEV_AUTH_TEST_USERNAME'
+    }
+    $devAuthPassword = Get-DotEnvValue -EnvFilePath $rootEnvPath -Key 'DEV_AUTH_TEST_PASSWORD'
+
+    Write-Host "Seeded local login:" -ForegroundColor Yellow
+    Write-Host "  Email/username: $devAuthEmail" -ForegroundColor Yellow
+    Write-Host "  Password: $devAuthPassword" -ForegroundColor Yellow
+} else {
+    Write-Host "If you enable DEV_AUTH_TEST_ACCOUNT_ENABLED in $rootEnvPath, the script will print that seeded account for login." -ForegroundColor Yellow
+}

--- a/shared/theme/uah-theme.css
+++ b/shared/theme/uah-theme.css
@@ -1,0 +1,33 @@
+:root {
+  --bp-tablet: 768px;
+  --bp-phone: 600px;
+  --bp-small: 480px;
+  --space-1: 8px;
+  --space-2: 12px;
+  --space-3: 16px;
+  --space-4: 24px;
+  --space-5: 32px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 14px;
+  --color-primary-500: #3b82f6;
+  --color-primary-600: #2563eb;
+  --color-primary-700: #1d4ed8;
+  --color-success-600: #16a34a;
+  --color-danger-600: #dc2626;
+  --color-warning-600: #d97706;
+  --color-text-primary: #1a1a2e;
+  --color-text-secondary: #374151;
+  --color-text-muted: #8a94a6;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f8fafc;
+  --color-surface-hover: #f3f4f6;
+  --border-color: rgba(203, 213, 225, 0.9);
+  --border-color-light: #e5e7eb;
+  --shadow-soft: 0 2px 6px rgba(15, 23, 42, 0.08);
+  --shadow-card: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+  --transition-fast: 0.15s ease;
+  --app-page-background:
+    radial-gradient(circle at top right, rgba(14, 165, 233, 0.08), transparent 28%),
+    linear-gradient(180deg, #f8fafc 0%, #eef4f8 100%);
+}

--- a/test.txt
+++ b/test.txt
@@ -29,3 +29,19 @@ Dedup hash collisions are back — but this time they're on UPDATE statements, n
 Unexpected EOF on client connection with an open transaction at 12:44:05 — a backend worker dropped its connection mid-transaction. Postgres cleaned it up fine but it's a sign of instability somewhere, possibly a Celery worker getting killed or timing out during a long operation.
 Checkpoints are taking a long time — the one at 12:16 took 269 seconds to write 48% of shared buffers. That's a lot of write pressure, likely from the sync churning through 27k jobs. Should settle down once the initial backfill activity calms.
 Nothing is on fire, but flag the dedup UPDATE collision to the agent — it's the same root bug in a different code path.
+
+
+
+still need to fix country display. why dont we also just check to see if the city refered to exists in that country or something idk, context clues in listings could also be utilized perhaps
+
+allow multi select of countrys for filters
+
+reporting jobs that are potentially stale (community notes kinda)
+
+nother pass on validating job listings are still active on the secondary links on sites.
+
+nother pass on making sure we simply expunge returned job listings that dont fit our max age of job and or link valididity params
+
+on review readyness make sure csv typing works, make the form values more clear
+
+improve the resume profile parsing options and stuff to fit better. 

--- a/test.txt
+++ b/test.txt
@@ -45,3 +45,5 @@ nother pass on making sure we simply expunge returned job listings that dont fit
 on review readyness make sure csv typing works, make the form values more clear
 
 improve the resume profile parsing options and stuff to fit better. 
+
+direct key based ssh

--- a/uah-browser-extension/.env.local.example
+++ b/uah-browser-extension/.env.local.example
@@ -1,0 +1,5 @@
+VITE_EXTENSION_APP_ORIGIN=https://localhost:5173
+VITE_EXTENSION_API_ORIGIN=https://localhost:5173
+VITE_EXTENSION_AUTH_NAMESPACE=local
+# Optional explicit override. If omitted, the extension derives `uah_auth_<namespace>`.
+# VITE_EXTENSION_AUTH_COOKIE_NAME=uah_auth_local

--- a/uah-browser-extension/README.md
+++ b/uah-browser-extension/README.md
@@ -69,6 +69,12 @@ This repo also supports a fallback where the extension reuses `frontend/node_mod
 
 This is the supported local integration path for the extension.
 
+Quick helper:
+
+```powershell
+pwsh -File .\scripts\local\lifecycle\local-extension-test.ps1
+```
+
 1. Generate trusted localhost certs with `mkcert`:
 
 ```bash
@@ -109,6 +115,7 @@ npm run build
 11. Sign in with email/password using either your normal local account or the seeded test account.
 
 The local harness keeps the extension HTTPS-only and routes all app and API traffic through the same `https://localhost:5173` origin.
+The helper script validates the required local env files, starts backend-local, launches the HTTPS frontend in a new PowerShell window, builds the extension, and prints the manual smoke-test checklist.
 
 ## Load Unpacked In Chrome
 

--- a/uah-browser-extension/README.md
+++ b/uah-browser-extension/README.md
@@ -1,0 +1,139 @@
+# UAH Browser Extension
+
+Vue 3 + Vite browser extension that gives UAH users quick access to their saved applicant profiles and parsed resume data without leaving the current job board tab.
+
+## What It Does
+
+- Signs in against the existing UAH backend. There is no separate extension auth system.
+- Supports email/password login and Google sign-in through the existing UAH OAuth endpoints.
+- Shows compact read-only views for:
+  - applicant profiles
+  - parsed resumes
+  - account and connected sign-in status
+- Lets users copy individual fields like email, phone, summary, skills, and quick resume snapshots.
+- Opens the full UAH app for anything that belongs in the full product experience.
+
+## Legacy Reference Folders
+
+The repo still contains `uah-test-extension/` and `uah-apply-overlay-prototype/` as rough historical references. They are legacy prototypes and are not part of the supported build path for this extension.
+
+## Storage Model
+
+- `chrome.storage.local`
+  - Stores only extension auth metadata: the JWT, its expiry, and basic auth bookkeeping so the extension can survive browser restarts.
+- `chrome.storage.session`
+  - Stores non-sensitive view caches such as the current user snapshot, profile and resume summaries, and detail responses for the current browser session. These session caches are cleared on logout and whenever auth expires.
+- The extension does not use `localStorage` or `sessionStorage`.
+
+## Auth Flow
+
+### Email / Password
+
+1. The popup sends the credentials to the background service worker.
+2. The background posts to `/api/auth/login` with `X-UAH-Client: extension`.
+3. The backend returns the normal token payload and also sets the same HttpOnly auth cookie it uses for the web app.
+4. The extension stores the JWT and expiry metadata in `chrome.storage.local`.
+5. Each popup open validates the stored expiry first, then calls `/api/auth/me`; any `401` clears auth and returns to the sign-in screen.
+
+### Google OAuth
+
+1. The popup asks the background worker to start Google sign-in.
+2. The background opens `/api/auth/google?intent=login&client=extension` in a new tab.
+3. The backend completes the normal OAuth flow and redirects back to the configured UAH app origin.
+4. The background watches that auth tab, then reads the env-scoped UAH auth cookie from the configured API origin with `chrome.cookies`.
+5. The cookie JWT becomes the extension bearer token stored in `chrome.storage.local`.
+
+## Configuration
+
+Copy `.env.example` to `.env` inside `uah-browser-extension/` and set:
+
+- `VITE_EXTENSION_APP_ORIGIN`
+- `VITE_EXTENSION_API_ORIGIN`
+- `VITE_EXTENSION_AUTH_COOKIE_NAME` or `VITE_EXTENSION_AUTH_NAMESPACE`
+
+Both origins must be HTTPS-only. The build intentionally fails for non-HTTPS values.
+
+For the reusable localhost harness, copy `.env.local.example` to `.env.local` instead. That local config points the extension at `https://localhost:5173`.
+
+## Local Build
+
+```bash
+cd uah-browser-extension
+npm install
+npm run build
+```
+
+This repo also supports a fallback where the extension reuses `frontend/node_modules` for Vite if that toolchain is already installed.
+
+## Local HTTPS Test Harness
+
+This is the supported local integration path for the extension.
+
+1. Generate trusted localhost certs with `mkcert`:
+
+```bash
+mkdir -p volumes/certs/local
+mkcert -install
+mkcert -cert-file volumes/certs/local/tls.crt -key-file volumes/certs/local/tls.key localhost 127.0.0.1 ::1
+```
+
+2. Create the root local `.env` from `env-examples/local/.env.example`.
+3. If you want a seeded login, set:
+   - `DEV_AUTH_TEST_ACCOUNT_ENABLED=true`
+   - `DEV_AUTH_TEST_PASSWORD=<your local password>`
+4. Create `frontend/.env.local` from `frontend/.env.local.example`.
+5. Start the local backend:
+
+```bash
+docker compose -f docker-compose.local.yml --profile backend up -d db-local backend-local
+```
+
+6. Start the HTTPS frontend:
+
+```bash
+cd frontend
+npm install
+npm run dev:backend
+```
+
+7. Open `https://localhost:5173` once in the browser and confirm the cert is trusted.
+8. Create `uah-browser-extension/.env.local` from `uah-browser-extension/.env.local.example`.
+9. Build the extension:
+
+```bash
+cd uah-browser-extension
+npm run build
+```
+
+10. Load `uah-browser-extension/dist` unpacked in Chrome.
+11. Sign in with email/password using either your normal local account or the seeded test account.
+
+The local harness keeps the extension HTTPS-only and routes all app and API traffic through the same `https://localhost:5173` origin.
+
+## Load Unpacked In Chrome
+
+1. Build the extension with `npm run build`.
+2. Open `chrome://extensions`.
+3. Enable `Developer mode`.
+4. Click `Load unpacked`.
+5. Select `uah-browser-extension/dist`.
+
+## Load Temporarily In Firefox
+
+1. Build the extension with `npm run build`.
+2. Open `about:debugging`.
+3. Choose `This Firefox`.
+4. Click `Load Temporary Add-on...`.
+5. Select the generated `uah-browser-extension/dist/manifest.json`.
+
+## Firefox Note
+
+The code isolates browser APIs behind a small wrapper to keep Firefox compatibility feasible later, but this version is Chrome-first and has only been planned and wired for MV3 behavior.
+
+## Known Limitations
+
+- The popup is intentionally read-only for profiles and resume data.
+- Resume upload/parse flows stay in the full app.
+- The old overlay autofill prototype is not part of this extension build.
+- Google sign-in depends on the configured UAH auth cookie name and the browser permitting the extension to read it through the `cookies` permission on the configured API origin.
+- Google sign-in is intentionally disabled when the extension is pointed at the localhost HTTPS harness; use email/password there and verify OAuth against dev or beta.

--- a/uah-browser-extension/SECURITY.md
+++ b/uah-browser-extension/SECURITY.md
@@ -1,0 +1,79 @@
+# UAH Browser Extension Security Model
+
+## Scope
+
+This extension is a compact companion to the UAH web app. It reads existing UAH account data and opens the full app for any broader workflow.
+
+## Network Boundaries
+
+- The extension build requires a configured HTTPS UAH app origin and HTTPS UAH API origin.
+- `manifest.json` grants host permissions only for the configured API origin.
+- No wildcard origins are used.
+- All backend requests are sent with `X-UAH-Client: extension`.
+- The localhost test harness still uses HTTPS; there is no HTTP-only extension bypass.
+
+## Permissions
+
+- `storage`
+  - Required to persist extension auth metadata across browser restarts and hold session-scoped caches.
+- `cookies`
+  - Required to read and clear the existing UAH auth cookie on the configured API origin for Google sign-in bridging and explicit logout cleanup.
+- `tabs`
+  - Required to open the full UAH app and watch the Google OAuth tab until it lands back on the configured UAH origin.
+
+No content scripts, `activeTab`, `scripting`, or broad site permissions are used in v1.
+
+## Stored Data
+
+### `chrome.storage.local`
+
+Stored:
+
+- extension JWT
+- token expiry timestamp
+- token issued-at timestamp
+- client marker (`extension`)
+
+Not stored:
+
+- passwords
+- Google OAuth codes
+- full applicant profile payloads
+- full resume payloads
+
+Reason:
+
+- This is the minimum persistent state needed to keep the user signed in between browser restarts.
+
+### `chrome.storage.session`
+
+Stored:
+
+- current user snapshot
+- connected-account status payload
+- profile list and profile detail responses
+- resume list and resume detail responses
+
+Reason:
+
+- This is non-sensitive display data that helps the popup stay responsive during the current browser session without persisting those payloads long-term.
+- All session cache entries are cleared on logout and on auth expiry so stale profile or resume data does not linger between signed-in states.
+
+## Logging
+
+- Tokens and cookie values must never be written to `console.log`.
+- Errors are surfaced to the UI using generic user-safe messages.
+- The background worker avoids serializing raw auth headers or cookies into thrown errors.
+
+## Session Expiry
+
+- The extension checks the stored JWT expiry before using it.
+- It then confirms the session against `/api/auth/me`.
+- Any `401` clears local auth state and returns the popup to the sign-in flow.
+- Google OAuth is disabled in the localhost harness so local testing stays on the email/password path.
+
+## CSP
+
+- The extension uses Manifest V3 with a strict `extension_pages` CSP.
+- No inline scripts are used.
+- No `eval` usage is allowed.

--- a/uah-browser-extension/manifest.config.mjs
+++ b/uah-browser-extension/manifest.config.mjs
@@ -1,0 +1,83 @@
+import { URL } from 'node:url'
+
+function normalizeNamespace(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]/g, '_')
+}
+
+function requireHttpsOrigin(rawValue, envName) {
+  const value = String(rawValue || '').trim()
+  if (!value) {
+    throw new Error(`${envName} is required`)
+  }
+
+  let parsed
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new Error(`${envName} must be a valid HTTPS origin`)
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`${envName} must use HTTPS`)
+  }
+  if (parsed.pathname !== '/' || parsed.search || parsed.hash) {
+    throw new Error(`${envName} must be an origin only, without a path, query, or hash`)
+  }
+
+  return parsed.origin
+}
+
+export function resolveExtensionBuildConfig(rawEnv) {
+  const appOrigin = requireHttpsOrigin(rawEnv.VITE_EXTENSION_APP_ORIGIN, 'VITE_EXTENSION_APP_ORIGIN')
+  const apiOrigin = requireHttpsOrigin(rawEnv.VITE_EXTENSION_API_ORIGIN, 'VITE_EXTENSION_API_ORIGIN')
+  const namespace = normalizeNamespace(rawEnv.VITE_EXTENSION_AUTH_NAMESPACE)
+  const authCookieName = String(rawEnv.VITE_EXTENSION_AUTH_COOKIE_NAME || '').trim()
+    || (namespace ? `uah_auth_${namespace}` : '')
+
+  if (!authCookieName) {
+    throw new Error(
+      'Set VITE_EXTENSION_AUTH_COOKIE_NAME or VITE_EXTENSION_AUTH_NAMESPACE so the extension knows which auth cookie to read.'
+    )
+  }
+
+  return {
+    appOrigin,
+    apiOrigin,
+    apiHostPermission: `${apiOrigin}/*`,
+    authCookieName,
+  }
+}
+
+export function buildManifest(rawEnv) {
+  const config = resolveExtensionBuildConfig(rawEnv)
+
+  return {
+    manifest_version: 3,
+    name: 'UAH Browser Extension',
+    version: '0.1.0',
+    description: 'Quick access to UAH applicant profiles and resume data from your browser toolbar.',
+    action: {
+      default_title: 'UAH',
+      default_popup: 'popup.html',
+    },
+    background: {
+      service_worker: 'background.js',
+      type: 'module',
+    },
+    // `storage`: persists extension auth metadata across browser restarts and
+    // keeps non-sensitive per-session caches in chrome.storage.session.
+    // `cookies`: reads and clears the backend auth cookie for Google sign-in
+    // bridge support and explicit logout cleanup.
+    // `tabs`: opens UAH pages in a new tab and watches the Google OAuth tab
+    // until it lands back on the configured UAH app origin.
+    permissions: ['storage', 'cookies', 'tabs'],
+    // Restrict all backend access to the configured UAH HTTPS origin only.
+    host_permissions: [config.apiHostPermission],
+    content_security_policy: {
+      extension_pages: "script-src 'self'; object-src 'self';",
+    },
+  }
+}

--- a/uah-browser-extension/package.json
+++ b/uah-browser-extension/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "uah-browser-extension",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node ./scripts/run-vite.mjs",
+    "build": "node ./scripts/run-vite.mjs build",
+    "preview": "node ./scripts/run-vite.mjs preview"
+  },
+  "dependencies": {
+    "vue": "^3.5.28"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.4",
+    "vite": "^7.3.2"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/uah-browser-extension/popup.html
+++ b/uah-browser-extension/popup.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UAH Browser Extension</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/uah-browser-extension/scripts/run-vite.mjs
+++ b/uah-browser-extension/scripts/run-vite.mjs
@@ -1,0 +1,25 @@
+import { existsSync } from 'node:fs'
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const localVite = fileURLToPath(new URL('../node_modules/vite/bin/vite.js', import.meta.url))
+const frontendVite = fileURLToPath(new URL('../../frontend/node_modules/vite/bin/vite.js', import.meta.url))
+
+const viteBin = existsSync(localVite) ? localVite : frontendVite
+
+if (!existsSync(viteBin)) {
+  console.error(
+    'Unable to locate Vite. Run `npm install` inside `uah-browser-extension/` or ensure `frontend/node_modules` exists.'
+  )
+  process.exit(1)
+}
+
+const child = spawn(process.execPath, [viteBin, ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  cwd: fileURLToPath(new URL('../', import.meta.url)),
+  env: process.env,
+})
+
+child.on('exit', (code) => {
+  process.exit(code ?? 0)
+})

--- a/uah-browser-extension/src/App.vue
+++ b/uah-browser-extension/src/App.vue
@@ -1,0 +1,706 @@
+<template>
+  <div class="popup-shell">
+    <header class="hero-card">
+      <div>
+        <p class="eyebrow">UAH Browser Companion</p>
+        <h1>Quick Applicant Access</h1>
+        <p class="hero-copy">
+          Reference your profiles and resume details while browsing job boards, then jump back into the full UAH app when you need more.
+        </p>
+      </div>
+      <button class="btn-secondary btn-compact" @click="openFullApp('/home')">Open UAH</button>
+    </header>
+
+    <section v-if="booting" class="state-card">
+      <h2>Checking your session</h2>
+      <p>Confirming whether your saved UAH extension session is still valid.</p>
+    </section>
+
+    <section v-else-if="!authenticated" class="auth-card">
+      <div class="panel-heading">
+        <div>
+          <p class="panel-kicker">Account</p>
+          <h2>Sign in to UAH</h2>
+        </div>
+      </div>
+
+      <p class="auth-copy">
+        The extension uses your existing UAH backend account and stores only extension auth metadata locally.
+      </p>
+
+      <form class="auth-form" @submit.prevent="handleLogin">
+        <label class="field-group">
+          <span>Email</span>
+          <input
+            v-model.trim="email"
+            type="email"
+            autocomplete="username"
+            placeholder="you@example.com"
+            :disabled="authBusy"
+          />
+        </label>
+
+        <label class="field-group">
+          <span>Password</span>
+          <input
+            v-model="password"
+            type="password"
+            autocomplete="current-password"
+            placeholder="Password"
+            :disabled="authBusy"
+          />
+        </label>
+
+        <button class="btn-primary" type="submit" :disabled="authBusy">
+          {{ authBusy ? 'Signing in…' : 'Sign in' }}
+        </button>
+      </form>
+
+      <template v-if="!localHarnessMode">
+        <div class="auth-divider"><span>or</span></div>
+
+        <button class="btn-secondary" :disabled="authBusy" @click="handleGoogleLogin">
+          {{ googleBusy ? 'Completing Google sign-in…' : 'Continue with Google' }}
+        </button>
+      </template>
+      <div v-else class="inline-banner">
+        Local extension testing uses email/password only. Google OAuth stays disabled in the localhost harness.
+      </div>
+
+      <div v-if="authError" class="inline-banner inline-banner--error">
+        {{ authError }}
+      </div>
+
+      <div class="footer-actions">
+        <button class="text-link" @click="openFullApp('/login')">Open full sign-in page</button>
+        <button class="text-link" @click="openFullApp('/register')">Create an account</button>
+      </div>
+    </section>
+
+    <template v-else>
+      <section class="account-strip">
+        <div>
+          <p class="account-name">{{ displayUserName(currentUser) }}</p>
+          <p class="account-email">{{ currentUser?.email }}</p>
+        </div>
+        <div class="account-meta">
+          <span class="status-pill status-pill--success">Signed in</span>
+          <span class="status-note">Expires {{ formatDateTime(expiresAt) }}</span>
+        </div>
+      </section>
+
+      <nav class="tab-row" aria-label="Extension sections">
+        <button
+          v-for="tab in tabs"
+          :key="tab.key"
+          :class="['tab-button', { active: activeTab === tab.key }]"
+          @click="activeTab = tab.key"
+        >
+          {{ tab.label }}
+        </button>
+      </nav>
+
+      <div v-if="feedbackMessage" class="inline-banner inline-banner--success">
+        {{ feedbackMessage }}
+      </div>
+
+      <section v-if="activeTab === 'profiles'" class="panel-stack">
+        <div class="panel-card">
+          <div class="panel-heading">
+            <div>
+              <p class="panel-kicker">Profiles</p>
+              <h2>Your applicant profiles</h2>
+            </div>
+            <button class="text-link" @click="refreshProfiles">Refresh</button>
+          </div>
+
+          <div v-if="profilesLoading" class="state-card state-card--nested">
+            <p>Loading your UAH profiles…</p>
+          </div>
+          <div v-else-if="profilesError" class="inline-banner inline-banner--error">{{ profilesError }}</div>
+          <div v-else-if="!profiles.length" class="empty-card">
+            <p>No applicant profiles are available yet.</p>
+            <button class="text-link" @click="openFullApp('/resumes')">Create one in the full app</button>
+          </div>
+          <div v-else class="selection-list">
+            <button
+              v-for="profile in profiles"
+              :key="profile.id"
+              :class="['selection-item', { active: selectedProfile?.id === profile.id }]"
+              @click="selectProfile(profile.id)"
+            >
+              <div>
+                <p class="selection-title">{{ profile.name || 'Untitled profile' }}</p>
+                <p class="selection-subtitle">
+                  {{ [profile.first_name, profile.last_name].filter(Boolean).join(' ') || 'No saved name yet' }}
+                </p>
+              </div>
+              <span v-if="profile.is_active" class="status-pill">Active</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="panel-card">
+          <div class="panel-heading">
+            <div>
+              <p class="panel-kicker">Profile details</p>
+              <h2>{{ selectedProfile?.name || 'Profile' }}</h2>
+            </div>
+            <button class="text-link" @click="openFullApp('/resumes')">Open full editor</button>
+          </div>
+
+          <div v-if="profileDetailLoading" class="state-card state-card--nested">
+            <p>Loading this profile…</p>
+          </div>
+          <div v-else-if="profileDetailError" class="inline-banner inline-banner--error">{{ profileDetailError }}</div>
+          <div v-else-if="selectedProfile" class="detail-stack">
+            <div class="detail-grid">
+              <div v-for="field in profileFields" :key="field.label" class="detail-row">
+                <div>
+                  <p class="detail-label">{{ field.label }}</p>
+                  <p class="detail-value">{{ field.value }}</p>
+                </div>
+                <button class="copy-button" :disabled="!field.canCopy" @click="copyText(field.copyValue, field.label)">
+                  Copy
+                </button>
+              </div>
+            </div>
+
+            <div v-for="block in profileBlocks" :key="block.label" class="copy-card">
+              <div class="copy-card-header">
+                <div>
+                  <p class="detail-label">{{ block.label }}</p>
+                </div>
+                <button class="copy-button" :disabled="!block.copyValue" @click="copyText(block.copyValue, block.label)">
+                  Copy
+                </button>
+              </div>
+              <p class="copy-card-body">{{ block.value }}</p>
+            </div>
+          </div>
+          <div v-else class="empty-card">
+            <p>Select a profile to view its quick-reference details.</p>
+          </div>
+        </div>
+      </section>
+
+      <section v-else-if="activeTab === 'resumes'" class="panel-stack">
+        <div class="panel-card">
+          <div class="panel-heading">
+            <div>
+              <p class="panel-kicker">Resumes</p>
+              <h2>Your parsed resume library</h2>
+            </div>
+            <button class="text-link" @click="refreshResumes">Refresh</button>
+          </div>
+
+          <div v-if="resumesLoading" class="state-card state-card--nested">
+            <p>Loading your resumes…</p>
+          </div>
+          <div v-else-if="resumesError" class="inline-banner inline-banner--error">{{ resumesError }}</div>
+          <div v-else-if="!resumes.length" class="empty-card">
+            <p>No resumes are saved yet.</p>
+            <button class="text-link" @click="openFullApp('/resumes')">Upload one in the full app</button>
+          </div>
+          <div v-else class="selection-list">
+            <button
+              v-for="resume in resumes"
+              :key="resume.id"
+              :class="['selection-item', { active: selectedResume?.id === resume.id }]"
+              @click="selectResume(resume.id)"
+            >
+              <div>
+                <p class="selection-title">{{ resume.file_name }}</p>
+                <p class="selection-subtitle">Added {{ formatDateTime(resume.created_at) }}</p>
+              </div>
+              <span :class="['status-pill', resume.portal_ready ? 'status-pill--success' : 'status-pill--warning']">
+                {{ resume.portal_ready ? 'Ready' : 'Needs fields' }}
+              </span>
+            </button>
+          </div>
+        </div>
+
+        <div class="panel-card">
+          <div class="panel-heading">
+            <div>
+              <p class="panel-kicker">Resume details</p>
+              <h2>{{ selectedResume?.file_name || 'Resume' }}</h2>
+            </div>
+            <button class="text-link" @click="openFullApp('/resumes')">Open resume workspace</button>
+          </div>
+
+          <div v-if="resumeDetailLoading" class="state-card state-card--nested">
+            <p>Loading this resume…</p>
+          </div>
+          <div v-else-if="resumeDetailError" class="inline-banner inline-banner--error">{{ resumeDetailError }}</div>
+          <div v-else-if="selectedResume" class="detail-stack">
+            <div class="detail-grid">
+              <div v-for="field in resumeFields" :key="field.label" class="detail-row">
+                <div>
+                  <p class="detail-label">{{ field.label }}</p>
+                  <p class="detail-value">{{ field.value }}</p>
+                </div>
+                <button class="copy-button" :disabled="!field.canCopy" @click="copyText(field.copyValue, field.label)">
+                  Copy
+                </button>
+              </div>
+            </div>
+
+            <div v-for="block in resumeBlocks" :key="block.label" class="copy-card">
+              <div class="copy-card-header">
+                <div>
+                  <p class="detail-label">{{ block.label }}</p>
+                </div>
+                <button class="copy-button" :disabled="!block.copyValue" @click="copyText(block.copyValue, block.label)">
+                  Copy
+                </button>
+              </div>
+              <p class="copy-card-body">{{ block.value }}</p>
+            </div>
+          </div>
+          <div v-else class="empty-card">
+            <p>Select a resume to view its parsed summary.</p>
+          </div>
+        </div>
+      </section>
+
+      <section v-else class="panel-stack">
+        <div class="panel-card">
+          <div class="panel-heading">
+            <div>
+              <p class="panel-kicker">Account</p>
+              <h2>Session and connected sign-in methods</h2>
+            </div>
+            <button class="text-link" @click="refreshAccount">Refresh</button>
+          </div>
+
+          <div class="detail-grid">
+            <div class="detail-row">
+              <div>
+                <p class="detail-label">Signed in as</p>
+                <p class="detail-value">{{ displayUserName(currentUser) }}</p>
+              </div>
+              <button class="copy-button" @click="copyText(currentUser?.email, 'account email')">Copy</button>
+            </div>
+            <div class="detail-row">
+              <div>
+                <p class="detail-label">Email</p>
+                <p class="detail-value">{{ currentUser?.email }}</p>
+              </div>
+              <button class="copy-button" @click="copyText(currentUser?.email, 'account email')">Copy</button>
+            </div>
+            <div class="detail-row">
+              <div>
+                <p class="detail-label">Extension session</p>
+                <p class="detail-value">Expires {{ formatDateTime(expiresAt) }}</p>
+              </div>
+              <button class="copy-button" disabled>Managed</button>
+            </div>
+          </div>
+
+          <div v-if="accountLoading" class="state-card state-card--nested">
+            <p>Refreshing account status…</p>
+          </div>
+          <div v-else-if="accountError" class="inline-banner inline-banner--error">{{ accountError }}</div>
+          <div v-else-if="connectedAccounts?.providers?.length" class="selection-list selection-list--static">
+            <div
+              v-for="provider in connectedAccounts.providers"
+              :key="provider.provider"
+              class="selection-item selection-item--static"
+            >
+              <div>
+                <p class="selection-title">{{ provider.label }}</p>
+                <p class="selection-subtitle">
+                  {{
+                    provider.connected
+                      ? provider.account_email || 'Connected'
+                      : provider.coming_soon
+                        ? 'Coming soon'
+                        : 'Not connected'
+                  }}
+                </p>
+              </div>
+              <span :class="['status-pill', provider.connected ? 'status-pill--success' : 'status-pill--warning']">
+                {{ provider.connected ? 'Connected' : 'Not connected' }}
+              </span>
+            </div>
+          </div>
+
+          <div class="footer-actions">
+            <button class="text-link" @click="openFullApp('/settings')">Open settings</button>
+            <button class="text-link" @click="openFullApp('/home')">Open dashboard</button>
+            <button class="text-link text-link--danger" @click="handleLogout">Sign out</button>
+          </div>
+        </div>
+      </section>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue'
+
+import { requestBackground } from '@/lib/messages'
+import { runtimeConfig } from '@/lib/runtimeConfig'
+import {
+  buildProfileLinks,
+  buildProfileLocation,
+  buildResumeLocation,
+  buildResumeName,
+  displayUserName,
+  displayValue,
+  flattenResumeSkills,
+  formatDateTime,
+  summarizeEducation,
+  summarizeWork,
+} from '@/lib/formatters'
+
+const tabs = [
+  { key: 'profiles', label: 'Profiles' },
+  { key: 'resumes', label: 'Resumes' },
+  { key: 'account', label: 'Account' },
+]
+const localHarnessMode = runtimeConfig.isLocalHarness
+
+const booting = ref(true)
+const authenticated = ref(false)
+const currentUser = ref(null)
+const expiresAt = ref(null)
+const activeTab = ref('profiles')
+const feedbackMessage = ref('')
+
+const email = ref('')
+const password = ref('')
+const authBusy = ref(false)
+const googleBusy = ref(false)
+const authError = ref('')
+
+const profiles = ref([])
+const profilesLoading = ref(false)
+const profilesError = ref('')
+const selectedProfile = ref(null)
+const profileDetailLoading = ref(false)
+const profileDetailError = ref('')
+
+const resumes = ref([])
+const resumesLoading = ref(false)
+const resumesError = ref('')
+const selectedResume = ref(null)
+const resumeDetailLoading = ref(false)
+const resumeDetailError = ref('')
+
+const connectedAccounts = ref(null)
+const accountLoading = ref(false)
+const accountError = ref('')
+
+function setFeedback(message = '') {
+  feedbackMessage.value = message
+  if (!message) return
+  window.clearTimeout(setFeedback.timer)
+  setFeedback.timer = window.setTimeout(() => {
+    feedbackMessage.value = ''
+  }, 2200)
+}
+
+async function copyText(value, label) {
+  const normalized = String(value || '').trim()
+  if (!normalized) return
+  await navigator.clipboard.writeText(normalized)
+  setFeedback(`Copied ${label}.`)
+}
+
+async function openFullApp(pathname) {
+  await requestBackground('openFullApp', { pathname })
+}
+
+function applyAuthFailure(error) {
+  if (error?.code !== 'AUTH_REQUIRED' && error?.status !== 401) {
+    return false
+  }
+
+  authenticated.value = false
+  currentUser.value = null
+  expiresAt.value = null
+  profiles.value = []
+  resumes.value = []
+  selectedProfile.value = null
+  selectedResume.value = null
+  connectedAccounts.value = null
+  authError.value = String(error?.message || error)
+  return true
+}
+
+async function bootstrap() {
+  booting.value = true
+  authError.value = ''
+
+  try {
+    const session = await requestBackground('bootstrap')
+    authenticated.value = Boolean(session.authenticated)
+    currentUser.value = session.user || null
+    expiresAt.value = session.expiresAt || null
+
+    if (!session.authenticated) {
+      profiles.value = []
+      selectedProfile.value = null
+      resumes.value = []
+      selectedResume.value = null
+      connectedAccounts.value = null
+    }
+  } catch (error) {
+    authenticated.value = false
+    currentUser.value = null
+    expiresAt.value = null
+    authError.value = String(error?.message || error)
+  } finally {
+    booting.value = false
+  }
+}
+
+async function handleLogin() {
+  authBusy.value = true
+  authError.value = ''
+
+  try {
+    const session = await requestBackground('login', {
+      email: email.value,
+      password: password.value,
+    })
+    authenticated.value = true
+    currentUser.value = session.user
+    expiresAt.value = session.expiresAt
+    password.value = ''
+    activeTab.value = 'profiles'
+    await loadProfiles()
+  } catch (error) {
+    authError.value = String(error?.message || error)
+  } finally {
+    authBusy.value = false
+  }
+}
+
+async function handleGoogleLogin() {
+  authBusy.value = true
+  googleBusy.value = true
+  authError.value = ''
+
+  try {
+    const session = await requestBackground('loginWithGoogle')
+    authenticated.value = true
+    currentUser.value = session.user
+    expiresAt.value = session.expiresAt
+    activeTab.value = 'profiles'
+    await loadProfiles()
+  } catch (error) {
+    authError.value = String(error?.message || error)
+  } finally {
+    authBusy.value = false
+    googleBusy.value = false
+  }
+}
+
+async function handleLogout() {
+  await requestBackground('logout')
+  authenticated.value = false
+  currentUser.value = null
+  expiresAt.value = null
+  selectedProfile.value = null
+  selectedResume.value = null
+  profiles.value = []
+  resumes.value = []
+  connectedAccounts.value = null
+  email.value = ''
+  password.value = ''
+}
+
+async function loadProfiles(force = false) {
+  profilesLoading.value = true
+  profilesError.value = ''
+
+  try {
+    const list = await requestBackground('getProfiles', { force })
+    profiles.value = Array.isArray(list) ? list : []
+
+    const defaultProfile = profiles.value.find((profile) => profile.is_active) || profiles.value[0] || null
+    if (defaultProfile) {
+      await selectProfile(defaultProfile.id)
+    } else {
+      selectedProfile.value = null
+    }
+  } catch (error) {
+    if (applyAuthFailure(error)) return
+    profilesError.value = String(error?.message || error)
+  } finally {
+    profilesLoading.value = false
+  }
+}
+
+async function selectProfile(profileId, force = false) {
+  if (!profileId) return
+  profileDetailLoading.value = true
+  profileDetailError.value = ''
+
+  try {
+    selectedProfile.value = await requestBackground('getProfile', { profileId, force })
+  } catch (error) {
+    if (applyAuthFailure(error)) return
+    profileDetailError.value = String(error?.message || error)
+  } finally {
+    profileDetailLoading.value = false
+  }
+}
+
+async function refreshProfiles() {
+  await loadProfiles(true)
+}
+
+async function loadResumes(force = false) {
+  resumesLoading.value = true
+  resumesError.value = ''
+
+  try {
+    const list = await requestBackground('getResumes', { force })
+    resumes.value = Array.isArray(list) ? list : []
+    const defaultResume = resumes.value[0] || null
+    if (defaultResume) {
+      await selectResume(defaultResume.id)
+    } else {
+      selectedResume.value = null
+    }
+  } catch (error) {
+    if (applyAuthFailure(error)) return
+    resumesError.value = String(error?.message || error)
+  } finally {
+    resumesLoading.value = false
+  }
+}
+
+async function selectResume(resumeId, force = false) {
+  if (!resumeId) return
+  resumeDetailLoading.value = true
+  resumeDetailError.value = ''
+
+  try {
+    selectedResume.value = await requestBackground('getResume', { resumeId, force })
+  } catch (error) {
+    if (applyAuthFailure(error)) return
+    resumeDetailError.value = String(error?.message || error)
+  } finally {
+    resumeDetailLoading.value = false
+  }
+}
+
+async function refreshResumes() {
+  await loadResumes(true)
+}
+
+async function loadAccount(force = false) {
+  accountLoading.value = true
+  accountError.value = ''
+
+  try {
+    connectedAccounts.value = await requestBackground('getConnectedAccounts', { force })
+  } catch (error) {
+    if (applyAuthFailure(error)) return
+    accountError.value = String(error?.message || error)
+  } finally {
+    accountLoading.value = false
+  }
+}
+
+async function refreshAccount() {
+  await loadAccount(true)
+}
+
+watch(activeTab, async (tab) => {
+  if (!authenticated.value) return
+  if (tab === 'profiles' && !profiles.value.length && !profilesLoading.value) {
+    await loadProfiles()
+  }
+  if (tab === 'resumes' && !resumes.value.length && !resumesLoading.value) {
+    await loadResumes()
+  }
+  if (tab === 'account' && !connectedAccounts.value && !accountLoading.value) {
+    await loadAccount()
+  }
+})
+
+const profileFields = computed(() => {
+  const profile = selectedProfile.value || {}
+  const fullName = [profile.first_name, profile.last_name].filter(Boolean).join(' ')
+  const location = buildProfileLocation(profile)
+
+  return [
+    { label: 'Name', value: displayValue(fullName), copyValue: fullName, canCopy: Boolean(fullName) },
+    { label: 'Email', value: displayValue(profile.email), copyValue: profile.email, canCopy: Boolean(profile.email) },
+    { label: 'Phone', value: displayValue(profile.phone), copyValue: profile.phone, canCopy: Boolean(profile.phone) },
+    { label: 'Location', value: displayValue(location), copyValue: location, canCopy: Boolean(location) },
+    { label: 'Target role', value: displayValue(profile.job_title), copyValue: profile.job_title, canCopy: Boolean(profile.job_title) },
+    { label: 'Work auth', value: displayValue(profile.work_auth), copyValue: profile.work_auth, canCopy: Boolean(profile.work_auth) },
+  ]
+})
+
+const profileBlocks = computed(() => {
+  const profile = selectedProfile.value || {}
+  const links = buildProfileLinks(profile)
+  return [
+    { label: 'Summary', value: displayValue(profile.summary), copyValue: profile.summary },
+    { label: 'Skills', value: displayValue(profile.skills_text), copyValue: profile.skills_text },
+    { label: 'Professional links', value: displayValue(links), copyValue: links },
+  ]
+})
+
+const resumeFields = computed(() => {
+  const structured = selectedResume.value?.structured_data || {}
+  const personalInfo = structured.personal_info || {}
+  const combinedSkills = flattenResumeSkills(structured.skills || {})
+  const resumeName = buildResumeName(personalInfo)
+  const location = buildResumeLocation(personalInfo)
+
+  return [
+    { label: 'Name', value: displayValue(resumeName), copyValue: resumeName, canCopy: Boolean(resumeName) },
+    { label: 'Email', value: displayValue(personalInfo.email), copyValue: personalInfo.email, canCopy: Boolean(personalInfo.email) },
+    { label: 'Phone', value: displayValue(personalInfo.phone), copyValue: personalInfo.phone, canCopy: Boolean(personalInfo.phone) },
+    { label: 'Location', value: displayValue(location), copyValue: location, canCopy: Boolean(location) },
+    {
+      label: 'Portal readiness',
+      value: selectedResume.value?.portal_ready ? 'Ready for portal checks' : 'Needs additional required fields',
+      copyValue: '',
+      canCopy: false,
+    },
+    {
+      label: 'Parse method',
+      value: displayValue(selectedResume.value?.parse_method, 'Unknown'),
+      copyValue: selectedResume.value?.parse_method || '',
+      canCopy: Boolean(selectedResume.value?.parse_method),
+    },
+    {
+      label: 'Skills count',
+      value: combinedSkills.length ? `${combinedSkills.length} extracted skill${combinedSkills.length === 1 ? '' : 's'}` : 'No skills extracted yet',
+      copyValue: combinedSkills.join(', '),
+      canCopy: combinedSkills.length > 0,
+    },
+  ]
+})
+
+const resumeBlocks = computed(() => {
+  const structured = selectedResume.value?.structured_data || {}
+  const combinedSkills = flattenResumeSkills(structured.skills || {})
+  const educationSnapshot = summarizeEducation(structured.education || []).join('\n')
+  const workSnapshot = summarizeWork(structured.work_experience || []).join('\n')
+
+  return [
+    { label: 'Summary', value: displayValue(structured.summary), copyValue: structured.summary },
+    { label: 'Skills', value: displayValue(combinedSkills.join(', ')), copyValue: combinedSkills.join(', ') },
+    { label: 'Education snapshot', value: displayValue(educationSnapshot), copyValue: educationSnapshot },
+    { label: 'Work snapshot', value: displayValue(workSnapshot), copyValue: workSnapshot },
+  ]
+})
+
+onMounted(async () => {
+  await bootstrap()
+  if (authenticated.value) {
+    await loadProfiles()
+  }
+})
+</script>

--- a/uah-browser-extension/src/background/index.js
+++ b/uah-browser-extension/src/background/index.js
@@ -1,0 +1,435 @@
+import {
+  addRuntimeMessageListener,
+  addTabsRemovedListener,
+  addTabsUpdatedListener,
+  cookiesGet,
+  cookiesRemove,
+  storageGet,
+  storageRemove,
+  storageSet,
+  tabsCreate,
+  tabsRemove,
+  removeTabsRemovedListener,
+  removeTabsUpdatedListener,
+} from '@/lib/extensionApi'
+import { runtimeConfig } from '@/lib/runtimeConfig'
+
+const LOCAL_AUTH_KEY = 'uah.extension.auth'
+const SESSION_CACHE_PREFIX = 'uah.extension.cache.'
+
+// Persist only the extension's auth token and its expiry across browser restarts.
+// Everything else is cached in chrome.storage.session because it is non-sensitive
+// display data that does not need long-term persistence.
+const SESSION_CACHE_KEYS = {
+  currentUser: `${SESSION_CACHE_PREFIX}current-user`,
+  connectedAccounts: `${SESSION_CACHE_PREFIX}connected-accounts`,
+  profiles: `${SESSION_CACHE_PREFIX}profiles`,
+  resumes: `${SESSION_CACHE_PREFIX}resumes`,
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function decodeJwtClaims(token) {
+  try {
+    const payload = token.split('.')[1]
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4 || 4)) % 4), '=')
+    return JSON.parse(atob(padded))
+  } catch {
+    return null
+  }
+}
+
+function parseErrorMessage(payload, status) {
+  if (typeof payload === 'string' && payload.trim()) {
+    return payload.trim()
+  }
+  if (isObject(payload)) {
+    if (typeof payload.detail === 'string' && payload.detail.trim()) return payload.detail.trim()
+    if (isObject(payload.detail) && typeof payload.detail.message === 'string' && payload.detail.message.trim()) {
+      return payload.detail.message.trim()
+    }
+    if (typeof payload.message === 'string' && payload.message.trim()) return payload.message.trim()
+  }
+  return `HTTP ${status}`
+}
+
+function buildError(message, code, status = 500) {
+  const error = new Error(message)
+  error.code = code
+  error.status = status
+  return error
+}
+
+async function readLocalAuthState() {
+  const result = await storageGet('local', LOCAL_AUTH_KEY)
+  return result?.[LOCAL_AUTH_KEY] || null
+}
+
+async function writeLocalAuthState(value) {
+  await storageSet('local', { [LOCAL_AUTH_KEY]: value })
+}
+
+async function readSessionCache(key) {
+  const result = await storageGet('session', key)
+  return result?.[key]
+}
+
+async function writeSessionCache(key, value) {
+  await storageSet('session', { [key]: value })
+}
+
+async function removeSessionCache(keys = Object.values(SESSION_CACHE_KEYS)) {
+  const removals = new Set(Array.isArray(keys) ? keys : [keys])
+  const sessionSnapshot = await storageGet('session', null)
+
+  for (const cacheKey of Object.keys(sessionSnapshot || {})) {
+    if (cacheKey.startsWith(SESSION_CACHE_PREFIX)) {
+      removals.add(cacheKey)
+    }
+  }
+
+  await storageRemove('session', [...removals])
+}
+
+async function clearAuthState() {
+  await storageRemove('local', LOCAL_AUTH_KEY)
+  await removeSessionCache()
+}
+
+async function persistToken(token) {
+  const claims = decodeJwtClaims(token)
+  if (!claims?.exp) {
+    throw buildError('Received an invalid auth token from the backend.', 'INVALID_TOKEN', 401)
+  }
+
+  const authState = {
+    accessToken: token,
+    expiresAt: Number(claims.exp) * 1000,
+    issuedAt: claims.iat ? Number(claims.iat) * 1000 : Date.now(),
+    client: 'extension',
+  }
+
+  await writeLocalAuthState(authState)
+  return authState
+}
+
+function isExpired(authState) {
+  return !authState?.expiresAt || Date.now() >= Number(authState.expiresAt)
+}
+
+function buildApiUrl(pathname) {
+  return new URL(pathname, runtimeConfig.apiOrigin).toString()
+}
+
+async function fetchJson(pathname, options = {}) {
+  const {
+    method = 'GET',
+    body,
+    requireAuth = true,
+  } = options
+
+  const headers = new Headers(options.headers || {})
+  headers.set('Accept', 'application/json')
+  headers.set('X-UAH-Client', 'extension')
+
+  if (body !== undefined && !(body instanceof FormData)) {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  if (requireAuth) {
+    const authState = await readLocalAuthState()
+    if (!authState?.accessToken || isExpired(authState)) {
+      await clearAuthState()
+      throw buildError('Your UAH session has expired. Please sign in again.', 'AUTH_REQUIRED', 401)
+    }
+    headers.set('Authorization', `Bearer ${authState.accessToken}`)
+  }
+
+  const response = await fetch(buildApiUrl(pathname), {
+    method,
+    headers,
+    credentials: 'include',
+    body: body === undefined ? undefined : (body instanceof FormData ? body : JSON.stringify(body)),
+  })
+
+  const responseText = await response.text()
+  let payload = null
+
+  if (responseText) {
+    try {
+      payload = JSON.parse(responseText)
+    } catch {
+      payload = responseText
+    }
+  }
+
+  if (response.status === 401) {
+    await clearAuthState()
+    throw buildError('Your UAH session has expired. Please sign in again.', 'AUTH_REQUIRED', 401)
+  }
+
+  if (!response.ok) {
+    throw buildError(parseErrorMessage(payload, response.status), 'API_ERROR', response.status)
+  }
+
+  return payload
+}
+
+async function bootstrapSession() {
+  const authState = await readLocalAuthState()
+  if (!authState?.accessToken) {
+    return { authenticated: false, user: null, expiresAt: null }
+  }
+
+  if (isExpired(authState)) {
+    await clearAuthState()
+    return { authenticated: false, user: null, expiresAt: null, reason: 'expired' }
+  }
+
+  const user = await fetchJson('/api/auth/me')
+  await writeSessionCache(SESSION_CACHE_KEYS.currentUser, user)
+
+  return {
+    authenticated: true,
+    user,
+    expiresAt: authState.expiresAt,
+  }
+}
+
+async function loadCachedOrFetch(cacheKey, pathname, options = {}) {
+  if (!options.force) {
+    const cached = await readSessionCache(cacheKey)
+    if (cached) return cached
+  }
+
+  const payload = await fetchJson(pathname, options)
+  await writeSessionCache(cacheKey, payload)
+  return payload
+}
+
+async function loginWithPassword(payload) {
+  const data = await fetchJson('/api/auth/login', {
+    method: 'POST',
+    requireAuth: false,
+    body: {
+      email: payload.email,
+      password: payload.password,
+    },
+  })
+
+  const authState = await persistToken(data.access_token)
+  await removeSessionCache()
+  await writeSessionCache(SESSION_CACHE_KEYS.currentUser, data.user)
+
+  return {
+    user: data.user,
+    expiresAt: authState.expiresAt,
+  }
+}
+
+async function readAuthCookieToken() {
+  const cookie = await cookiesGet({
+    url: runtimeConfig.apiOrigin,
+    name: runtimeConfig.authCookieName,
+  }).catch(() => null)
+  if (cookie?.value) {
+    return cookie.value
+  }
+
+  return ''
+}
+
+async function removeAuthCookie() {
+  await cookiesRemove({
+    url: runtimeConfig.apiOrigin,
+    name: runtimeConfig.authCookieName,
+  }).catch(() => null)
+}
+
+async function finishGoogleLogin() {
+  const token = await readAuthCookieToken()
+  if (!token) {
+    throw buildError(
+      'Google sign-in completed, but the extension could not read the UAH auth cookie.',
+      'COOKIE_NOT_FOUND',
+      401,
+    )
+  }
+
+  const authState = await persistToken(token)
+  const user = await fetchJson('/api/auth/me')
+  await writeSessionCache(SESSION_CACHE_KEYS.currentUser, user)
+
+  return {
+    user,
+    expiresAt: authState.expiresAt,
+  }
+}
+
+async function loginWithGoogle() {
+  if (runtimeConfig.isLocalHarness) {
+    throw buildError(
+      'Google sign-in is disabled for the local extension harness. Use email and password against your local backend instead.',
+      'GOOGLE_AUTH_UNAVAILABLE',
+      400,
+    )
+  }
+
+  const authUrl = new URL('/api/auth/google', runtimeConfig.apiOrigin)
+  authUrl.searchParams.set('intent', 'login')
+  authUrl.searchParams.set('client', 'extension')
+
+  const authTab = await tabsCreate({ url: authUrl.toString(), active: true })
+  const tabId = authTab?.id
+
+  if (typeof tabId !== 'number') {
+    throw buildError('Could not open a Google sign-in tab.', 'TAB_CREATE_FAILED')
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+
+    const cleanup = () => {
+      clearTimeout(timeoutId)
+      removeTabsUpdatedListener(onUpdated)
+      removeTabsRemovedListener(onRemoved)
+    }
+
+    const finish = async (callback) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      try {
+        await callback()
+      } catch (error) {
+        reject(error)
+      }
+    }
+
+    const timeoutId = setTimeout(() => {
+      finish(async () => {
+        throw buildError('Google sign-in timed out. Please try again.', 'GOOGLE_AUTH_TIMEOUT')
+      })
+    }, 180000)
+
+    const onRemoved = (removedTabId) => {
+      if (removedTabId !== tabId) return
+      finish(async () => {
+        throw buildError('Google sign-in was cancelled before UAH completed the login flow.', 'GOOGLE_AUTH_CANCELLED')
+      })
+    }
+
+    const onUpdated = (updatedTabId, changeInfo, tab) => {
+      if (updatedTabId !== tabId) return
+      const currentUrl = changeInfo.url || tab?.url || ''
+      if (!currentUrl.startsWith(runtimeConfig.appOrigin)) return
+
+      finish(async () => {
+        const parsedUrl = new URL(currentUrl)
+        if (parsedUrl.searchParams.get('oauth') === 'error') {
+          const reason = parsedUrl.searchParams.get('reason')
+          throw buildError(
+            `Google sign-in failed${reason ? ` (${reason.replaceAll('_', ' ')})` : ''}.`,
+            'GOOGLE_AUTH_FAILED',
+          )
+        }
+
+        const result = await finishGoogleLogin()
+        await tabsRemove(tabId).catch(() => null)
+        resolve(result)
+      })
+    }
+
+    addTabsUpdatedListener(onUpdated)
+    addTabsRemovedListener(onRemoved)
+  })
+}
+
+async function logout() {
+  await fetchJson('/api/auth/logout', {
+    method: 'POST',
+    requireAuth: false,
+  }).catch(() => null)
+
+  await removeAuthCookie()
+  await clearAuthState()
+  return { authenticated: false }
+}
+
+async function openFullApp(pathname) {
+  const destination = new URL(pathname.startsWith('/') ? pathname : `/${pathname}`, runtimeConfig.appOrigin).toString()
+  await tabsCreate({ url: destination, active: true })
+  return { opened: true }
+}
+
+function serializeError(error) {
+  return {
+    ok: false,
+    code: error?.code || 'UNEXPECTED_ERROR',
+    status: error?.status || 500,
+    message: String(error?.message || error || 'Unexpected extension error.'),
+  }
+}
+
+addRuntimeMessageListener(async (message) => {
+  try {
+    switch (message?.type) {
+      case 'bootstrap':
+        return { ok: true, data: await bootstrapSession() }
+      case 'login':
+        return { ok: true, data: await loginWithPassword(message.payload || {}) }
+      case 'loginWithGoogle':
+        return { ok: true, data: await loginWithGoogle() }
+      case 'logout':
+        return { ok: true, data: await logout() }
+      case 'getConnectedAccounts':
+        return {
+          ok: true,
+          data: await loadCachedOrFetch(SESSION_CACHE_KEYS.connectedAccounts, '/api/auth/connected-accounts', {
+            force: Boolean(message?.payload?.force),
+          }),
+        }
+      case 'getProfiles':
+        return {
+          ok: true,
+          data: await loadCachedOrFetch(SESSION_CACHE_KEYS.profiles, '/api/applicant-profile/', {
+            force: Boolean(message?.payload?.force),
+          }),
+        }
+      case 'getProfile':
+        return {
+          ok: true,
+          data: await loadCachedOrFetch(
+            `${SESSION_CACHE_KEYS.profiles}:detail:${message?.payload?.profileId}`,
+            `/api/applicant-profile/${message?.payload?.profileId}`,
+            { force: Boolean(message?.payload?.force) },
+          ),
+        }
+      case 'getResumes':
+        return {
+          ok: true,
+          data: await loadCachedOrFetch(SESSION_CACHE_KEYS.resumes, '/api/resume/', {
+            force: Boolean(message?.payload?.force),
+          }),
+        }
+      case 'getResume':
+        return {
+          ok: true,
+          data: await loadCachedOrFetch(
+            `${SESSION_CACHE_KEYS.resumes}:detail:${message?.payload?.resumeId}`,
+            `/api/resume/${message?.payload?.resumeId}`,
+            { force: Boolean(message?.payload?.force) },
+          ),
+        }
+      case 'openFullApp':
+        return { ok: true, data: await openFullApp(message?.payload?.pathname || '/home') }
+      default:
+        return serializeError(buildError('Unknown extension message.', 'UNKNOWN_MESSAGE', 400))
+    }
+  } catch (error) {
+    return serializeError(error)
+  }
+})

--- a/uah-browser-extension/src/lib/extensionApi.js
+++ b/uah-browser-extension/src/lib/extensionApi.js
@@ -1,0 +1,119 @@
+const browserApi = globalThis.browser
+const chromeApi = globalThis.chrome
+
+function runtimeErrorMessage() {
+  return chromeApi?.runtime?.lastError?.message || ''
+}
+
+function callCallbackApi(target, methodName, ...args) {
+  return new Promise((resolve, reject) => {
+    const method = target?.[methodName]
+    if (typeof method !== 'function') {
+      reject(new Error(`Extension API method '${methodName}' is unavailable.`))
+      return
+    }
+
+    try {
+      method.call(target, ...args, (result) => {
+        const message = runtimeErrorMessage()
+        if (message) {
+          reject(new Error(message))
+          return
+        }
+        resolve(result)
+      })
+    } catch (error) {
+      reject(error)
+    }
+  })
+}
+
+function wrapPromiseApi(target, methodName, ...args) {
+  const method = target?.[methodName]
+  if (typeof method !== 'function') {
+    return Promise.reject(new Error(`Extension API method '${methodName}' is unavailable.`))
+  }
+  return Promise.resolve(method.call(target, ...args))
+}
+
+function extensionCall(targetFactory, methodName, ...args) {
+  if (browserApi) {
+    return wrapPromiseApi(targetFactory(browserApi), methodName, ...args)
+  }
+  if (chromeApi) {
+    return callCallbackApi(targetFactory(chromeApi), methodName, ...args)
+  }
+  return Promise.reject(new Error('Browser extension APIs are unavailable in this context.'))
+}
+
+export function sendRuntimeMessage(message) {
+  return extensionCall((api) => api.runtime, 'sendMessage', message)
+}
+
+export function addRuntimeMessageListener(handler) {
+  const runtime = browserApi?.runtime || chromeApi?.runtime
+  if (!runtime?.onMessage?.addListener) {
+    throw new Error('runtime.onMessage is unavailable.')
+  }
+
+  runtime.onMessage.addListener((message, sender, sendResponse) => {
+    Promise.resolve(handler(message, sender))
+      .then((response) => sendResponse(response))
+      .catch((error) => sendResponse({ ok: false, code: 'UNHANDLED_ERROR', message: String(error?.message || error) }))
+    return true
+  })
+}
+
+export function storageGet(areaName, keys) {
+  return extensionCall((api) => api.storage[areaName], 'get', keys)
+}
+
+export function storageSet(areaName, value) {
+  return extensionCall((api) => api.storage[areaName], 'set', value)
+}
+
+export function storageRemove(areaName, keys) {
+  return extensionCall((api) => api.storage[areaName], 'remove', keys)
+}
+
+export function cookiesGet(details) {
+  return extensionCall((api) => api.cookies, 'get', details)
+}
+
+export function cookiesRemove(details) {
+  return extensionCall((api) => api.cookies, 'remove', details)
+}
+
+export function tabsCreate(details) {
+  return extensionCall((api) => api.tabs, 'create', details)
+}
+
+export function tabsRemove(tabId) {
+  return extensionCall((api) => api.tabs, 'remove', tabId)
+}
+
+export function addTabsUpdatedListener(listener) {
+  const tabs = browserApi?.tabs || chromeApi?.tabs
+  if (!tabs?.onUpdated?.addListener) {
+    throw new Error('tabs.onUpdated is unavailable.')
+  }
+  tabs.onUpdated.addListener(listener)
+}
+
+export function removeTabsUpdatedListener(listener) {
+  const tabs = browserApi?.tabs || chromeApi?.tabs
+  tabs?.onUpdated?.removeListener?.(listener)
+}
+
+export function addTabsRemovedListener(listener) {
+  const tabs = browserApi?.tabs || chromeApi?.tabs
+  if (!tabs?.onRemoved?.addListener) {
+    throw new Error('tabs.onRemoved is unavailable.')
+  }
+  tabs.onRemoved.addListener(listener)
+}
+
+export function removeTabsRemovedListener(listener) {
+  const tabs = browserApi?.tabs || chromeApi?.tabs
+  tabs?.onRemoved?.removeListener?.(listener)
+}

--- a/uah-browser-extension/src/lib/formatters.js
+++ b/uah-browser-extension/src/lib/formatters.js
@@ -1,0 +1,80 @@
+export function displayValue(value, fallback = 'Not set') {
+  const normalized = String(value ?? '').trim()
+  return normalized || fallback
+}
+
+export function displayUserName(user) {
+  const fullName = [user?.first_name, user?.last_name].filter(Boolean).join(' ').trim()
+  return fullName || user?.email || 'UAH user'
+}
+
+export function formatDateTime(value) {
+  if (!value) return 'Unknown'
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Unknown'
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date)
+}
+
+export function buildProfileLocation(profile) {
+  return [profile?.city, profile?.state, profile?.zip].filter(Boolean).join(', ')
+}
+
+export function buildProfileLinks(profile) {
+  return [profile?.linkedin, profile?.portfolio, profile?.professional_links_text].filter(Boolean).join('\n')
+}
+
+export function buildResumeName(personalInfo) {
+  return [personalInfo?.first_name, personalInfo?.last_name].filter(Boolean).join(' ').trim()
+}
+
+export function buildResumeLocation(personalInfo) {
+  return [personalInfo?.city, personalInfo?.state, personalInfo?.zip, personalInfo?.country].filter(Boolean).join(', ')
+}
+
+export function flattenResumeSkills(skills) {
+  const seen = new Set()
+  const flattened = []
+
+  for (const value of Object.values(skills || {})) {
+    if (!Array.isArray(value)) continue
+    for (const skill of value) {
+      const normalized = String(skill || '').trim()
+      const key = normalized.toLowerCase()
+      if (!normalized || seen.has(key)) continue
+      seen.add(key)
+      flattened.push(normalized)
+    }
+  }
+
+  return flattened
+}
+
+export function summarizeEducation(education = []) {
+  return education
+    .slice(0, 2)
+    .map((entry) => {
+      const lineOne = [entry?.degree, entry?.field_of_study].filter(Boolean).join(' in ').trim()
+      const lineTwo = [entry?.institution, entry?.end_date || entry?.graduation_date].filter(Boolean).join(' · ').trim()
+      return [lineOne, lineTwo].filter(Boolean).join(' — ')
+    })
+    .filter(Boolean)
+}
+
+export function summarizeWork(workExperience = []) {
+  return workExperience
+    .slice(0, 2)
+    .map((entry) => {
+      const lineOne = [entry?.title, entry?.company].filter(Boolean).join(' @ ').trim()
+      const lineTwo = [entry?.location, entry?.start_date, entry?.end_date || (entry?.is_current ? 'Present' : '')]
+        .filter(Boolean)
+        .join(' · ')
+        .trim()
+      return [lineOne, lineTwo].filter(Boolean).join(' — ')
+    })
+    .filter(Boolean)
+}

--- a/uah-browser-extension/src/lib/messages.js
+++ b/uah-browser-extension/src/lib/messages.js
@@ -1,0 +1,12 @@
+import { sendRuntimeMessage } from './extensionApi'
+
+export async function requestBackground(type, payload = {}) {
+  const response = await sendRuntimeMessage({ type, payload })
+  if (!response?.ok) {
+    const error = new Error(response?.message || 'Extension request failed.')
+    error.code = response?.code || 'EXTENSION_REQUEST_FAILED'
+    error.status = response?.status || null
+    throw error
+  }
+  return response.data
+}

--- a/uah-browser-extension/src/lib/runtimeConfig.js
+++ b/uah-browser-extension/src/lib/runtimeConfig.js
@@ -1,0 +1,54 @@
+function normalizeNamespace(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]/g, '_')
+}
+
+function requireHttpsOrigin(rawValue, name) {
+  const value = String(rawValue || '').trim()
+  if (!value) {
+    throw new Error(`${name} is required`)
+  }
+
+  let parsed
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new Error(`${name} must be a valid HTTPS origin`)
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`${name} must use HTTPS`)
+  }
+  if (parsed.pathname !== '/' || parsed.search || parsed.hash) {
+    throw new Error(`${name} must be an origin only`)
+  }
+
+  return parsed.origin
+}
+
+function isLocalHarnessOrigin(origin) {
+  try {
+    return new URL(origin).hostname.toLowerCase() === 'localhost'
+  } catch {
+    return false
+  }
+}
+
+const appOrigin = requireHttpsOrigin(import.meta.env.VITE_EXTENSION_APP_ORIGIN, 'VITE_EXTENSION_APP_ORIGIN')
+const apiOrigin = requireHttpsOrigin(import.meta.env.VITE_EXTENSION_API_ORIGIN, 'VITE_EXTENSION_API_ORIGIN')
+const namespace = normalizeNamespace(import.meta.env.VITE_EXTENSION_AUTH_NAMESPACE)
+const authCookieName = String(import.meta.env.VITE_EXTENSION_AUTH_COOKIE_NAME || '').trim()
+  || (namespace ? `uah_auth_${namespace}` : '')
+
+if (!authCookieName) {
+  throw new Error('Set VITE_EXTENSION_AUTH_COOKIE_NAME or VITE_EXTENSION_AUTH_NAMESPACE before building the extension.')
+}
+
+export const runtimeConfig = {
+  appOrigin,
+  apiOrigin,
+  authCookieName,
+  isLocalHarness: isLocalHarnessOrigin(appOrigin) && isLocalHarnessOrigin(apiOrigin),
+}

--- a/uah-browser-extension/src/main.js
+++ b/uah-browser-extension/src/main.js
@@ -1,0 +1,6 @@
+import { createApp } from 'vue'
+
+import App from './App.vue'
+import './styles/popup.css'
+
+createApp(App).mount('#app')

--- a/uah-browser-extension/src/styles/popup.css
+++ b/uah-browser-extension/src/styles/popup.css
@@ -1,0 +1,429 @@
+@import "../../../shared/theme/uah-theme.css";
+
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  color-scheme: light;
+}
+
+html,
+body,
+#app {
+  width: 380px;
+  min-width: 380px;
+  min-height: 560px;
+  margin: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--app-page-background);
+  color: var(--color-text-primary);
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  border: 0;
+  background: none;
+  cursor: pointer;
+}
+
+.popup-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 100%;
+  padding: 14px;
+}
+
+.hero-card,
+.auth-card,
+.panel-card,
+.account-strip,
+.state-card,
+.inline-banner {
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(203, 213, 225, 0.8);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+}
+
+.hero-card,
+.auth-card,
+.panel-card,
+.state-card {
+  padding: 14px;
+}
+
+.hero-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.eyebrow,
+.panel-kicker {
+  margin: 0 0 4px;
+  color: var(--color-primary-700);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-card h1,
+.panel-card h2,
+.auth-card h2,
+.state-card h2 {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.2;
+}
+
+.hero-copy,
+.auth-copy,
+.selection-subtitle,
+.detail-value,
+.copy-card-body,
+.state-card p,
+.status-note,
+.account-email {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.45;
+}
+
+.hero-copy {
+  margin-top: 6px;
+  max-width: 250px;
+  font-size: 0.84rem;
+}
+
+.account-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+}
+
+.account-name {
+  margin: 0;
+  font-weight: 700;
+}
+
+.account-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.tab-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.tab-button {
+  padding: 10px 12px;
+  border: 1px solid var(--border-color-light);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.78);
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.tab-button.active {
+  border-color: color-mix(in srgb, var(--color-primary-600) 44%, white);
+  background: color-mix(in srgb, var(--color-primary-600) 12%, white);
+  color: var(--color-primary-700);
+}
+
+.panel-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.selection-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.selection-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid rgba(203, 213, 225, 0.88);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  text-align: left;
+  transition: transform var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.selection-item:hover {
+  border-color: color-mix(in srgb, var(--color-primary-600) 36%, white);
+  transform: translateY(-1px);
+}
+
+.selection-item.active,
+.selection-item--static {
+  border-color: color-mix(in srgb, var(--color-primary-600) 44%, white);
+  background: color-mix(in srgb, var(--color-primary-600) 8%, white);
+}
+
+.selection-list--static .selection-item {
+  cursor: default;
+}
+
+.selection-title {
+  margin: 0 0 4px;
+  color: var(--color-text-primary);
+  font-weight: 700;
+}
+
+.detail-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.detail-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.detail-row,
+.copy-card {
+  border: 1px solid rgba(203, 213, 225, 0.86);
+  border-radius: var(--radius-sm);
+  background: rgba(248, 250, 252, 0.88);
+}
+
+.detail-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+}
+
+.detail-label {
+  margin: 0 0 4px;
+  color: var(--color-text-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.copy-card {
+  padding: 10px 12px;
+}
+
+.copy-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.copy-card-body {
+  white-space: pre-wrap;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.12);
+  color: var(--color-primary-700);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.status-pill--success {
+  background: rgba(22, 163, 74, 0.12);
+  color: var(--color-success-600);
+}
+
+.status-pill--warning {
+  background: rgba(217, 119, 6, 0.12);
+  color: var(--color-warning-600);
+}
+
+.copy-button,
+.text-link,
+.btn-primary,
+.btn-secondary {
+  border-radius: var(--radius-sm);
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.btn-primary,
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid transparent;
+  font-weight: 600;
+}
+
+.btn-primary {
+  background: var(--color-primary-600);
+  border-color: var(--color-primary-600);
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--color-primary-700);
+  border-color: var(--color-primary-700);
+}
+
+.btn-secondary {
+  background: var(--color-surface);
+  border-color: var(--border-color);
+  color: var(--color-text-secondary);
+}
+
+.btn-compact {
+  min-height: 32px;
+  padding: 0 10px;
+}
+
+.copy-button,
+.text-link {
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid rgba(203, 213, 225, 0.9);
+  background: white;
+  color: var(--color-primary-700);
+  font-weight: 600;
+}
+
+.copy-button:disabled,
+.btn-primary:disabled,
+.btn-secondary:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.text-link--danger {
+  color: var(--color-danger-600);
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--color-text-secondary);
+  font-size: 0.84rem;
+  font-weight: 600;
+}
+
+.field-group input {
+  width: 100%;
+  min-height: 38px;
+  padding: 0 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.field-group input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--color-primary-600) 55%, white);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+
+.auth-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 12px 0;
+  color: var(--color-text-muted);
+  font-size: 0.82rem;
+}
+
+.auth-divider::before,
+.auth-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: rgba(203, 213, 225, 0.92);
+}
+
+.footer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.state-card,
+.empty-card {
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  background: rgba(248, 250, 252, 0.88);
+  border: 1px dashed rgba(148, 163, 184, 0.7);
+}
+
+.state-card--nested {
+  padding: 12px;
+}
+
+.empty-card p {
+  margin: 0 0 8px;
+  color: var(--color-text-secondary);
+}
+
+.inline-banner {
+  padding: 10px 12px;
+  color: var(--color-text-secondary);
+}
+
+.inline-banner--error {
+  border-color: rgba(220, 38, 38, 0.2);
+  background: rgba(254, 242, 242, 0.95);
+  color: var(--color-danger-600);
+}
+
+.inline-banner--success {
+  border-color: rgba(22, 163, 74, 0.2);
+  background: rgba(240, 253, 244, 0.96);
+  color: var(--color-success-600);
+}

--- a/uah-browser-extension/vite.config.mjs
+++ b/uah-browser-extension/vite.config.mjs
@@ -1,0 +1,64 @@
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { buildManifest, resolveExtensionBuildConfig } from './manifest.config.mjs'
+
+function resolveToolModule(relativePath) {
+  const candidates = [
+    new URL(`./node_modules/${relativePath}`, import.meta.url),
+    new URL(`../frontend/node_modules/${relativePath}`, import.meta.url),
+  ]
+
+  for (const candidate of candidates) {
+    if (existsSync(fileURLToPath(candidate))) {
+      return candidate
+    }
+  }
+
+  throw new Error(`Unable to resolve tool module '${relativePath}'. Install extension deps or ensure frontend/node_modules exists.`)
+}
+
+const { defineConfig, loadEnv } = await import(resolveToolModule('vite/dist/node/index.js').href)
+const { default: vue } = await import(resolveToolModule('@vitejs/plugin-vue/dist/index.mjs').href)
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  resolveExtensionBuildConfig(env)
+
+  return {
+    plugins: [
+      vue(),
+      {
+        name: 'uah-extension-manifest',
+        generateBundle() {
+          this.emitFile({
+            type: 'asset',
+            fileName: 'manifest.json',
+            source: JSON.stringify(buildManifest(env), null, 2),
+          })
+        },
+      },
+    ],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+        vue: fileURLToPath(resolveToolModule('vue/dist/vue.esm-bundler.js')),
+      },
+    },
+    build: {
+      outDir: 'dist',
+      emptyOutDir: true,
+      rollupOptions: {
+        input: {
+          popup: fileURLToPath(new URL('./popup.html', import.meta.url)),
+          background: fileURLToPath(new URL('./src/background/index.js', import.meta.url)),
+        },
+        output: {
+          entryFileNames: (chunk) => (chunk.name === 'background' ? 'background.js' : 'assets/[name].js'),
+          chunkFileNames: 'assets/[name]-[hash].js',
+          assetFileNames: 'assets/[name]-[hash][extname]',
+        },
+      },
+    },
+  }
+})


### PR DESCRIPTION
Introduce canonical applicant profile handling and a resume review workflow. Adds a new applicant_profile_canonical service to normalize/merge canonical data, generate token maps, and build profiles from reviewed resumes. Resume model and schemas updated (review_status, review_draft, review_updated_at, has_review_draft) and new resume API endpoints for getting/updating review drafts, previewing conflicts, and applying reviews (merge into existing or create new profile).

Enable profile canonical fields on ApplicantProfile (canonical_data, token_map) and add logic to keep profiles in sync during list/get/create/update/activate operations. Add DB dev-schema fixups on startup for resumes and applicant_profiles to add new JSON/column types when schema lags.

Add client-aware auth session helpers (auth_session) to create access tokens with client-specific expirations (extension vs web), wire them into auth flows and Google OAuth, and propagate max_age to cookies via an updated set_auth_cookie signature. Add config for EXTENSION_ACCESS_TOKEN_EXPIRE_MINUTES.

Also: update README with a local HTTPS harness for testing the browser extension, expose frontend/env examples in .gitignore, add browser-extension scaffold and related frontend files, and include tests for applicant profile canonical logic and queue isolation changes.
