### PR TITLE
Rewrite README/docs; backend compatibility fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,68 +1,73 @@
-# Contributing to UAH
+# Contributing To UAH
 
-Thanks for being part of the project. This guide covers how we work together so things stay organized as the codebase grows.
+This guide covers the day-to-day contribution rules for the repository. For the detailed branch and PR flow, use [docs/WORKFLOW.MD](docs/WORKFLOW.MD).
 
 ## Before You Start
 
-- Check the [issues board](https://github.com/GUI2-G6/UAH/issues) for open work
-- Comment on an issue before starting — this signals to the team that you're working on it and prevents duplicate effort
-- If something you want to work on doesn't have an issue yet, create one first and assign yourself
+- Check the [issues board](https://github.com/GUI2-G6/UAH/issues) for existing work.
+- Comment on the issue before starting so ownership is visible.
+- If there is no issue yet, create one first.
 
 ## Branch Naming
 
-All work happens on branches off `dev`. Use this format:
+All work should branch from `dev`.
 
 | Type | Format | Example |
-|---|---|---|
-| New feature | `feature/short-description` | `feature/gmail-oauth-scope` |
-| Bug fix | `fix/short-description` | `fix/pdf-viewer-auth` |
-| Chore/infra | `chore/short-description` | `chore/update-dependencies` |
-| Documentation | `docs/short-description` | `docs/beta-setup-guide` |
+| --- | --- | --- |
+| Feature | `feature/short-description` | `feature/gmail-oauth-status` |
+| Bug fix | `fix/short-description` | `fix/status-page-auth-state` |
+| Chore / infra | `chore/short-description` | `chore/update-env-sync-check` |
+| Docs | `docs/short-description` | `docs/rewrite-backend-guide` |
 
-Keep branch names lowercase and hyphenated. No spaces, no uppercase.
+Keep names lowercase and hyphenated.
 
-## Making Changes
+## What To Update With Your Change
 
-1. Branch off `dev` — never branch off `prod` or `beta`
-2. Make your changes in focused, logical commits
-3. Write commit messages that describe what changed and why, not just "fix stuff"
-4. Test your changes locally before opening a PR
+If your change affects any of these surfaces, update the matching docs in the same PR:
 
-## Migrations and Backfills
+- backend behavior or required env vars
+- frontend route or auth/runtime behavior
+- browser extension build/runtime/autofill behavior
+- operator-facing lifecycle or deployment behavior
 
-- If a migration adds a computed or derived column to `jobs`, ship an automated backfill path for existing rows in the same change
-- Prefer the existing Celery maintenance-task pattern over one-off manual scripts so older rows converge automatically after deploy
-- Do not drop and recreate a populated column just to backfill it unless the migration explicitly requires destructive replacement
+Use [docs/README.md](docs/README.md) to find the current source-of-truth doc before you open the PR.
+
+## Migrations And Backfills
+
+- If a migration adds a derived field to `jobs`, ship an automated backfill path in the same change.
+- Prefer the existing Celery maintenance-task pattern over one-off manual scripts.
+- Do not destroy and recreate populated columns just to backfill them unless the migration explicitly requires destructive replacement.
 
 ## Pull Requests
 
-- For the full branch and PR workflow, see [WORKFLOW.md](WORKFLOW.md).
-- All changes to `dev` must come through a pull request — no direct pushes
-- Title your PR clearly: what does it do?
-- Reference the issue it closes using `Closes #XX` in the PR description
-- Use the PR template — fill it out completely
-- At least one team member should review before merging
-- Do not merge your own PR without a review unless it is a critical hotfix and you have confirmed with @TrentBrownUML
+- All changes to `dev` should go through a pull request.
+- Use a clear PR title that describes the outcome.
+- Link the issue with `Closes #XX` when appropriate.
+- Fill out the PR template completely.
+- If a change alters setup, behavior, or operator workflow, mention which docs you updated.
 
 ## Commit Style
 
-Use clear, present-tense commit messages:
-- `Add Gmail OAuth scope endpoint`
-- `Fix PDF viewer auth header not being passed`
-- `Update CORS origins for beta environment`
+Prefer clear, present-tense messages:
 
-Not:
+- `Add Gmail integration status endpoint`
+- `Fix saved jobs pagination for authenticated users`
+- `Rewrite beta setup docs for cloudflared tunnel flow`
+
+Avoid vague messages like:
+
 - `stuff`
 - `fixed it`
 - `wip`
 
-## Environment and Secrets
+## Environment And Secrets
 
-- Never commit `.env` files — they are gitignored, keep it that way
-- If you add a new environment variable, add it to `env-examples/dev/.env.example` with a description and a safe placeholder value
-- Runtime `.env` must live at the repository root when running the app/compose (do not run from files inside `env-examples/`)
-- If you accidentally commit a secret, notify @TrentBrownUML immediately
+- Never commit `.env` files.
+- If you add a new env var, update the relevant `env-examples/*/.env.example` files.
+- Runtime `.env` always belongs at the repository root for repo-managed workflows.
+- If you suspect a secret was committed, notify the maintainers immediately.
 
 ## Questions
 
-Reach out on Discord or comment on the relevant GitHub issue. @TrentBrownUML handles PM and infra questions.
+- Product / infra / workflow questions: comment on the issue or reach out to the project lead.
+- For uncertainty about documentation placement, start with [docs/README.md](docs/README.md) instead of creating a new ad hoc doc.

--- a/README.md
+++ b/README.md
@@ -1,118 +1,41 @@
-# UAH — Unified Application Hub
+# UAH
 
-> **License Notice**
-> This project is licensed under AGPL-3.0 with Commons Clause. Commercial use, resale, or monetized hosting without explicit written permission from the UAH team is prohibited. We actively monitor derivative works.
+Unified Application Hub is a full-stack job-search and application-assistance project with three main surfaces:
 
-> **DEV Environment Documentation**
-> All commands assume you are SSH'd into the server at  `/srv/uah/environments/dev` on proxmox
+- a FastAPI backend
+- a Vue 3 frontend
+- a browser extension for in-tab profile and autofill workflows
 
----
+This README is the repo entrypoint. For subsystem-specific details, use the docs map in [docs/README.md](docs/README.md).
 
-## Connecting to the Server
+## Source Of Truth
 
-The app runs on an Ubuntu 24.04 VM behind a Proxmox host. To access it:
+| Need | Doc |
+| --- | --- |
+| Documentation map | [docs/README.md](docs/README.md) |
+| Architecture overview | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
+| Backend local development | [docs/backend/README.md](docs/backend/README.md) |
+| Frontend local development | [docs/frontend/README.md](docs/frontend/README.md) |
+| Browser extension build/runtime | [uah-browser-extension/README.md](uah-browser-extension/README.md) |
+| Environment template rules | [docs/env-examples/README.md](docs/env-examples/README.md) |
+| Server env checklist | [docs/SERVER_ENV_CHECKLIST.md](docs/SERVER_ENV_CHECKLIST.md) |
+| Contribution policy | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Branch and PR workflow | [docs/WORKFLOW.MD](docs/WORKFLOW.MD) |
+| Security policy | [SECURITY.md](SECURITY.md) |
+| Historical snapshots | [docs/archive/README.md](docs/archive/README.md) |
 
-### 1. SSH into the VM
+## Current Stack
 
-```bash
-ssh uahdeploy@192.168.1.230
-```
+| Layer | Primary tech | Notes |
+| --- | --- | --- |
+| Backend | FastAPI, SQLAlchemy, Alembic, Celery, Redis | Auth, jobs, resumes, profiles, integrations, diagnostics |
+| Frontend | Vue 3, Vue Router, Vite | Mock-first local dev plus backend passthrough mode |
+| Extension | Vue 3, Vite, MV3 service worker | Reuses backend auth and injects manual autofill tools |
+| Infra | Docker Compose, Nginx, Postgres, Cloudflare tunnel for beta | Dev and beta are separate environment shapes |
 
-You'll be prompted for the `uahdeploy` user's password. After login you'll land in the home directory (`/home/uahdeploy`).
+## Quick Start
 
-### 2. Navigate to the project
-
-```bash
-cd /srv/uah
-```
-
-The `/srv/uah` directory is the root of the deployment and contains:
-
-```
-/srv/uah/
-├── environments/
-│   ├── dev/          # Dev environment (docker-compose, app code, volumes)
-│   └── prod/         # Production environment
-├── infrastructure/   # VPN, tunnel, and network configs
-└── shared/           # Shared resources
-```
-
-To get to the dev environment specifically:
-
-```bash
-cd /srv/uah/environments/dev
-```
-
-From here you can run `docker compose` commands, view logs, sync code, etc.
-
-### 3. Verify services are running
-
-```bash
-docker ps
-```
-
-You should see containers for the frontend, backend, database, and VPN.
-
----
-
-## Architecture
-
-```
-                    VPN Clients
-                        │
-                   ┌────▼────┐
-                   │ WireGuard│  (10.8.0.1)
-                   │ wg-easy  │
-                   └────┬────┘
-                        │ network_mode: container
-                   ┌────▼────────┐
-                   │  Frontend   │  Nginx :80
-                   │  (Vue 3)    │
-                   └────┬────────┘
-                        │ proxy_pass /api/
-                   ┌────▼────────┐
-                   │  Backend    │  Uvicorn :8000
-                   │  (FastAPI)  │
-                   └────┬────────┘
-                        │ service name "db"
-                   ┌────▼────────┐
-                   │  Database   │  Postgres :5432
-                   │  (Postgres) │
-                   └─────────────┘
-```
-
-| Service | Container | Exposed Ports | Network |
-|---------|-----------|---------------|---------|
-| db | uah-dev-db | None | uah-infra |
-| backend | uah-dev-backend | None | uah-infra |
-| frontend | uah-dev-frontend | 80/443 (via VPN only) | Shares VPN container |
-| vpn | uah-dev-vpn | 51820/udp | uah-infra |
-
-**Access:** `http://dev.uahapp.com` (or `https://dev.uahapp.com` when TLS enabled) — requires VPN connection.
-
-### VPN-only HTTPS for Dev
-
-To enable HTTPS in dev without exposing your app publicly, place cert/key files on the server and keep DNS pointing to your VPN/private address.
-
-1. Put cert files in `./volumes/certs/dev/` as:
-     - `tls.crt`
-     - `tls.key`
-2. Set env vars in `.env`:
-     - `DEV_TLS_ENABLED=true`
-     - `DEV_TLS_CERT_PATH=/etc/nginx/certs/tls.crt`
-     - `DEV_TLS_KEY_PATH=/etc/nginx/certs/tls.key`
-3. Rebuild frontend container:
-     - `docker compose up -d --build frontend`
-
-If TLS is enabled but cert files are missing, frontend falls back to HTTP automatically.
-
----
-
-## Local Development
-
-The local path is now frontend-first and mock-first so you can render all modules without starting backend services.
-
-### Fast path (frontend mock mode)
+### Frontend-only local UI work
 
 ```bash
 cd frontend
@@ -120,584 +43,110 @@ npm install
 npm run dev
 ```
 
-Open `http://localhost:5173`.
+This is the fastest path for UI work. It uses the in-browser mock API layer and does not require backend services.
 
-- `npm run dev` defaults to mock mode.
-- API calls are handled by an in-browser mock API layer.
-- This path is isolated from dev/beta/prod infrastructure.
-- Non-local frontend builds default to backend mode.
-- Mock mode still uses browser storage for its fake JWT; deployed stacks now use a backend-issued `HttpOnly` auth cookie instead.
-
-### Optional local backend passthrough mode
+### Local backend + frontend
 
 ```bash
-# from repo root
 docker compose -f docker-compose.local.yml --profile backend up -d db-local backend-local
-
-# in a second terminal
 cd frontend
+npm install
 npm run dev:backend
 ```
 
-Notes:
+Use this path when the UI needs live backend behavior on localhost. The frontend dev server proxies `/api`, `/docs`, and `/openapi.json` to the backend origin.
 
-- Local compose binds backend and db to localhost only (`127.0.0.1`).
-- Backend mode refuses non-local API targets by default.
-- To intentionally target a non-local API in backend mode, set `VITE_ALLOW_REMOTE_API=true`.
+### Browser extension local harness
 
-### Local HTTPS harness for the browser extension
-
-Use this path when you want to test the current extension flow against a real local backend without relaxing the extension's HTTPS-only build rules. The extension now supports:
-
-- popup auth and cached profile/resume/account views
-- a persistent pinned side panel on supported tabs
-- manual profile-driven `Scan page` and `Fill page` actions on the current tab
-
-For extension-specific behavior and architecture details, see [uah-browser-extension/README.md](./uah-browser-extension/README.md).
-
-Quick helper:
+Use the extension README for the full flow, but the usual local helper is:
 
 ```powershell
 pwsh -File .\scripts\local\lifecycle\local-extension-test.ps1
 ```
 
-Tiny wrappers:
+That helper expects a real repo-root `.env`, `frontend/.env.local`, and a localhost-focused extension env file.
 
-```powershell
-pwsh -File .\scripts\local\lifecycle\extension-local.ps1
-pwsh -File .\scripts\local\lifecycle\extension-beta.ps1
-```
+## Runtime Environments
 
-Use `extension-beta.ps1` when you want the unpacked extension built against beta with Google OAuth enabled.
+### Local
 
-To build the unpacked extension for beta endpoint testing instead of localhost, run:
+- `docker-compose.local.yml` provides localhost-only DB/backend support.
+- `frontend` runs through Vite outside Docker.
+- `uah-browser-extension` can target localhost HTTPS for real auth/cookie flows.
 
-```powershell
-pwsh -File .\scripts\local\lifecycle\local-extension-test.ps1 -ExtensionTarget beta
-```
+### Dev
 
-1. Generate trusted localhost certs with `mkcert`:
+- `docker-compose.yml` is the primary dev stack.
+- Nginx serves the frontend and proxies `/api` to the backend.
+- Dev is the most permissive environment for diagnostics and generated API docs.
 
-```bash
-mkdir -p volumes/certs/local
-mkcert -install
-mkcert -cert-file volumes/certs/local/tls.crt -key-file volumes/certs/local/tls.key localhost 127.0.0.1 ::1
-```
+### Beta
 
-2. Create the root local env file from `env-examples/local/.env.example` and set at least:
-   - `SESSION_COOKIE_HTTPS_ONLY=true`
-   - `PUBLIC_APP_URL=https://localhost:5173`
-   - optional seeded login:
-     - `DEV_AUTH_TEST_ACCOUNT_ENABLED=true`
-     - `DEV_AUTH_TEST_PASSWORD=<your local password>`
+- `docker-compose.beta.yml` is an override layered onto `docker-compose.yml`.
+- Beta is isolated by compose project name, cookie namespace, Redis namespace, and DB.
+- The current beta shape uses a `cloudflared` tunnel container rather than exposing the frontend directly on a public host port.
 
-3. Create `frontend/.env.local` from `frontend/.env.local.example`.
-   `npm run dev` in `frontend/` still uses mock mode/email-only login, while `npm run dev:backend` is the real-backend path used by the localhost extension harness.
+## Canonical Commands
 
-4. Configure the extension for localhost HTTPS:
-   - use `uah-browser-extension/.env.local` for the local harness
-   - keep both origins on `https://localhost:5173`
-   - set either `VITE_EXTENSION_AUTH_NAMESPACE=local` or an explicit `VITE_EXTENSION_AUTH_COOKIE_NAME`
-
-5. Start the local backend:
-
-```bash
-docker compose -f docker-compose.local.yml --profile backend up -d db-local backend-local
-```
-
-6. Start the frontend over HTTPS:
+### Frontend
 
 ```bash
 cd frontend
-npm install
+npm run dev
 npm run dev:backend
+npm run build
 ```
 
-7. Open `https://localhost:5173` and confirm the browser trusts the cert before loading the extension.
-
-8. Build and load the unpacked extension:
+### Browser extension
 
 ```bash
 cd uah-browser-extension
 npm install
 npm run build
+npm test
 ```
 
-Notes:
+### Backend host-run workflow
 
-- The Vite dev server remains the single browser-facing origin for both app pages and `/api` requests.
-- Google OAuth is intentionally out of scope for the localhost harness; use email/password for local extension testing.
-- Cert files under `volumes/certs/local/` stay ignored by git through the existing `volumes/` ignore rule.
-- The local helper flow expects repo-root `.env`, `frontend/.env.local`, and a localhost-targeted extension env file before the default `-ExtensionTarget local` run.
-- Use `-ExtensionTarget beta` to build the extension against the remote HTTPS env in `uah-browser-extension/.env` and skip local backend/frontend startup.
-- The helper script starts `backend-local`, launches the HTTPS frontend in a new PowerShell window, builds the extension, and prints a Chrome smoke-test checklist that covers login, cached session restore, profile/resume loading, full-app links, and logout cleanup.
-
-### Environment template
-
-- Use `env-examples/local/.env.example` as the starting point for local root `.env` values.
-- Use `frontend/.env.local.example` as the starting point for frontend HTTPS backend-mode values.
-
-For host-run backend workflows (`uvicorn` outside Docker), continue using the **[Backend Local Development Guide](./docs/backend/README.md)**.
-
----
-
-## File Structure
-
-```
-/srv/uah/environments/dev/
-├── .env                          # Environment variables (secrets, DB creds)
-├── docker-compose.yml            # Service definitions
-├── backend/
-│   ├── Dockerfile
-│   ├── requirements.txt
-│   └── app/
-│       ├── main.py               # FastAPI entry point
-│       ├── api/routes.py         # API route handlers
-│       ├── core/config.py        # Centralized settings from env vars
-│       ├── db/session.py         # SQLAlchemy engine + session factory
-│       ├── db/base.py            # Declarative Base for models
-│       └── models/__init__.py    # Import all models here
-├── frontend/
-│   ├── Dockerfile
-│   ├── nginx.conf                # Nginx config (proxy + SPA fallback)
-│   ├── package.json
-│   └── src/
-│       ├── App.vue               # Root component (backend status check)
-│       └── main.js               # Vue app mount
-├── volumes/postgres/             # Persistent DB data (DO NOT DELETE)
-└── logs/
-```
-
----
-
-## Quick Start
+Use [docs/backend/README.md](docs/backend/README.md) for the full setup, including venv activation and `.env` loading. The typical local run command from `backend/` is:
 
 ```bash
-# Start dev stack (default: no rebuild)
-bash scripts/uah.sh dev start
-
-# Rebuild only frontend and start stack
-bash scripts/uah.sh dev start --build-frontend
-
-# Restart beta stack with full rebuild
-bash scripts/uah.sh beta restart --build-all
+alembic upgrade head
+python -m uvicorn app.main:app --reload
 ```
 
----
+### Server lifecycle helper
 
-## Syncing Dev from GitHub
-
-Use `scripts/uah.sh` as the canonical lifecycle entrypoint. Legacy-style sync wrappers are supported as pass-through aliases.
-
-### Usage
+`scripts/uah.sh` is the canonical lifecycle entrypoint for repo-managed server environments.
 
 ```bash
-# Dev sync (fast-forward only)
-bash scripts/uah.sh dev sync
-
-# Dev hard sync (discard local changes)
-bash scripts/uah.sh dev sync hard
-
-# Dev sync + full rebuild after sync
-bash scripts/uah.sh dev sync --build-all
-
-# Beta sync (default mode is safe) + optional rebuild
-bash scripts/uah.sh beta sync --build-frontend
-bash scripts/uah.sh beta sync safe --build-frontend
-bash scripts/uah.sh beta sync hard --build-all
-```
-
-### What it does
-
-1. Fetches latest refs from `origin`
-2. Checks out `dev` and syncs branch state
-3. Supports `safe` (`pull --ff-only`) and `hard` (`reset --hard origin/dev`) sync modes
-4. If the environment backend is already running, automatically runs `alembic upgrade head` in the backend container and refreshes `backend`, `celery_worker`, and `celery_beat`
-5. Optionally runs post-sync compose startup with rebuild flags when provided, then applies the same Alembic + runtime refresh flow
-6. Runs environment feature validation after sync in warn-only mode so missing keys are surfaced early
-
-If safe sync detects blockers (local file changes, local commits, or non-fast-forward state):
-
-1. It prints the detected issues
-2. In interactive shells, it prompts to abort or force hard sync
-3. In non-interactive mode, safe sync exits with an error and does not modify the working tree
-
-> **Note:** Default sync behavior is still git-only for stopped stacks. If the backend container is already running, sync now also performs a live Alembic reconcile and refreshes the schema-sensitive runtime services.
-
----
-
-## Lifecycle Script Commands
-
-`scripts/uah.sh` is the canonical command entrypoint for dev/beta lifecycle operations.
-
-```bash
-# Show full CLI help and flag reference
 bash scripts/uah.sh --help
-```
-
-If you omit the environment argument, `scripts/uah.sh` auto-detects context from:
-
-1. Current path segments like `/environments/dev`, `/environments/beta`, `/environments/prod`
-2. Root `.env` values (`ENVIRONMENT`, `ENV`, `COMPOSE_PROJECT_NAME`)
-
-If detection fails, pass `dev`, `beta`, or `prod` explicitly.
-
-Wrapper scripts under `scripts/dev/lifecycle/` and `scripts/beta/lifecycle/` pass all arguments through to `scripts/uah.sh`, so rebuild flags work there too.
-Wrappers remain stable aliases; `scripts/uah.sh` is the canonical interface.
-
-### Command reference
-
-| Scope | Command |
-|-------|---------|
-| Dev start | `bash scripts/uah.sh dev start` |
-| Dev restart | `bash scripts/uah.sh dev restart` |
-| Dev stop | `bash scripts/uah.sh dev stop` |
-| Dev sync (safe/hard) | `bash scripts/uah.sh dev sync` / `bash scripts/uah.sh dev sync hard` |
-| Beta start | `bash scripts/uah.sh beta start` |
-| Beta restart | `bash scripts/uah.sh beta restart` |
-| Beta stop | `bash scripts/uah.sh beta stop` |
-| Beta sync (safe/hard) | `bash scripts/uah.sh beta sync safe` / `bash scripts/uah.sh beta sync hard` |
-| Dev wrapper examples | `bash scripts/dev/lifecycle/dev-start.sh` / `bash scripts/dev/lifecycle/dev-restart.sh` / `bash scripts/dev/lifecycle/sync-dev.sh` |
-| Beta wrapper examples | `bash scripts/beta/lifecycle/beta-start.sh` / `bash scripts/beta/lifecycle/beta-restart.sh` / `bash scripts/beta/lifecycle/sync-beta.sh` |
-
-### Debug option interface
-
-The interactive debug consoles still work as before:
-
-- `bash scripts/uah.sh dev debug`
-- `bash scripts/uah.sh beta debug`
-
-You can now run targeted debug operations directly through `uah.sh`:
-
-- `bash scripts/uah.sh <env> debug status`
-- `bash scripts/uah.sh <env> debug connectivity <check>`
-- `bash scripts/uah.sh <env> debug logs <service> [--tail N] [--follow] [--raw|--errors|--filtered]`
-- `bash scripts/uah.sh <env> debug queue <action>`
-- `bash scripts/uah.sh <env> debug database <action>`
-- `bash scripts/uah.sh dev debug users <action>`
-- `bash scripts/uah.sh <env> debug network <action>`
-
-Run `bash scripts/uah.sh <env> debug help` for the full matrix.
-
-### Rebuild flags
-
-Use these flags with `start`, `restart`, or `sync`:
-
-- `--no-build` (default behavior)
-- `--build` or `--build-all`
-- `--build-frontend`
-- `--build-backend`
-- `--build-db`
-- `--build-redis`
-- `--build-cloudflared`
-- `--build-service <name>` or `--build-service=<name>`
-
-When service-specific build flags are used, scripts rebuild selected services first and then bring the full stack up.
-
-### Sync blocker prompts
-
-When safe sync is blocked in an interactive shell, the script shows detected issues and prompts for:
-
-- `abort` to stop safely with no git reset
-- `force` to run hard sync (`reset --hard origin/dev`) after confirmation
-- `status` to inspect full git status
-- `diff` to inspect diff summary
-
-### Shell script permissions
-
-Shell scripts in this repository are tracked as executable by default.
-
-- `.sh` files are normalized with `.gitattributes` to keep LF line endings.
-- You should not need recurring `chmod +x` sweeps after pulling the normalization commit.
-- If sync still reports blockers, use the `status` and `diff` prompt options to confirm whether blockers are real content edits.
-
-### Examples
-
-```bash
-# Default start (no rebuild)
 bash scripts/uah.sh dev start
-
-# Rebuild backend only, then start full stack
-bash scripts/uah.sh dev start --build-backend
-
-# Rebuild frontend + backend on restart
-bash scripts/uah.sh dev restart --build-frontend --build-backend
-
-# Full rebuild on beta restart
+bash scripts/uah.sh dev sync
 bash scripts/uah.sh beta restart --build-all
-
-# Beta wrapper usage (same options)
-bash scripts/beta/lifecycle/beta-restart.sh --build-all
 ```
 
-### Startup preflight checks
+Wrapper scripts under `scripts/dev/lifecycle/` and `scripts/beta/lifecycle/` remain supported aliases, but they pass through to `scripts/uah.sh`.
 
-On `start`, `restart`, and `sync` with rebuild flags, scripts validate:
+## Repository Layout
 
-1. Docker CLI and Docker Compose plugin are available
-2. Required external networks exist (`uah-infra`, and `uah-beta-infra` for beta)
-3. Required infrastructure container `uah-dev-vpn` is running
-4. Redis host ports are available before startup (`REDIS_HOST_PORT` for dev, `BETA_REDIS_HOST_PORT` for beta)
-5. Environment feature requirements in root `.env` via `scripts/lib/env-feature-check.sh`
-
-After containers are brought up for `dev` or `beta`, lifecycle scripts now automatically run `alembic upgrade head` inside the backend container and restart `backend`, `celery_worker`, and `celery_beat` so schema-dependent services stay aligned.
-
-### Concurrent Dev + Beta OCR Routing
-
-When both environments run on the same host, route ownership is now managed explicitly:
-
-- `dev start` applies dev-owned WireGuard route and VPN forwarding rules for desktop Ollama.
-- `dev stop` removes only dev-owned rules.
-- `beta start` applies beta-owned route/rules.
-- `beta stop` removes only beta-owned rules and preserves the shared host route when a sibling backend is still running.
-
-Route scripts:
-
-- `scripts/dev/network/apply_desktop_ollama_temp_route.sh`
-- `scripts/dev/network/rollback_desktop_ollama_temp_route.sh`
-- `scripts/beta/network/apply_desktop_ollama_temp_route.sh`
-- `scripts/beta/network/rollback_desktop_ollama_temp_route.sh`
-
-### Debug Console Scope
-
-Dev debug console is now near-parity with beta for operational checks:
-
-- Ollama reachability status in the header.
-- Queue management menu in dev debug.
-- Networking diagnostics in dev debug.
-- Frontend/Nginx logs sourced from compose logs (not in-container log files).
-
-Entry points:
-
-- `bash scripts/uah.sh dev debug`
-- `bash scripts/uah.sh beta debug`
-
-### Queue Scope Interpretation
-
-Queue execution remains isolated by environment (separate Redis containers and queue namespaces).
-
-- Dev queue position is scoped to dev.
-- Beta queue position is scoped to beta.
-- UI now labels queue scope/environment to avoid cross-environment ambiguity when both show position `1`.
-
----
-
-## Direct Docker Compose Commands
-
-### Rebuild a single service (does NOT affect others)
-
-```bash
-# Backend only — use after changing Python code or requirements.txt
-docker compose up -d --build backend
-
-# Frontend only — use after changing Vue code, nginx.conf, or package.json
-docker compose up -d --build frontend
-
-# Database — rarely needed, only if changing Postgres version
-docker compose up -d --build db
+```text
+backend/                 FastAPI app, models, services, migrations, tests
+frontend/                Vue SPA, local mock API, shared UI primitives
+uah-browser-extension/   MV3 extension, adapters, autofill runtime, tests
+docs/                    Active docs plus historical archive
+scripts/                 Lifecycle, sync, audit, debug, and env helpers
+shared/                  Shared theme assets
+env-examples/            Sanitized example env files for each environment
 ```
 
-### Restart without rebuilding
+## Documentation Rules
 
-```bash
-# Restart one service (keeps existing image)
-docker compose restart backend
-docker compose restart frontend
-docker compose restart db
-```
-
-### Stop a single service
-
-```bash
-# Stop one service without removing it
-docker compose stop backend
-
-# Start it back
-docker compose start backend
-```
-
-### Stop everything (preserves data)
-
-```bash
-docker compose down
-```
-
-> **Warning:** `docker compose down -v` will **delete the Postgres volume**. Never use `-v` unless you intend to wipe the database.
-
----
-
-## Checking Status
-
-```bash
-# See all running containers and their health
-docker compose ps
-
-# View last 50 lines of logs for a service
-docker compose logs backend --tail 50
-docker compose logs frontend --tail 50
-docker compose logs db --tail 50
-
-# Follow logs in real-time (Ctrl+C to stop)
-docker compose logs -f backend
-```
-
----
-
-## Testing Endpoints
-
-The backend container uses `python:3.12-slim` (no curl). Use these methods:
-
-```bash
-# Test backend health
-docker exec uah-dev-backend python -c \
-  "import urllib.request; print(urllib.request.urlopen('http://localhost:8000/health').read().decode())"
-
-# Test API status
-docker exec uah-dev-backend python -c \
-  "import urllib.request; print(urllib.request.urlopen('http://localhost:8000/api/status').read().decode())"
-
-# Test frontend + proxy (curl is available in the nginx container)
-docker exec uah-dev-frontend curl -s http://localhost/
-docker exec uah-dev-frontend curl -s http://localhost/api/status
-docker exec uah-dev-frontend curl -s http://localhost/docs | head -20
-```
-
----
-
-## Accessing Dev Tools (VPN Required)
-
-| URL | Description |
-|-----|-------------|
-| `https://dev.uahapp.com` | Frontend app (preferred, when TLS enabled) |
-| `http://dev.uahapp.com` | Frontend app (fallback when TLS disabled) |
-| `http://dev.uahapp.com/status` | System status page (full diagnostics) |
-| `http://dev.uahapp.com/api/status` | API status check (JSON) |
-| `http://dev.uahapp.com/api/diagnostics` | Full diagnostics payload (JSON) |
-| `http://dev.uahapp.com/docs` | Swagger UI (auto-generated) |
-| `http://dev.uahapp.com/redoc` | ReDoc (alternative API docs) |
-| `http://dev.uahapp.com/openapi.json` | Raw OpenAPI spec |
-
----
-
-## Database Access
-
-```bash
-# Open a psql shell inside the DB container
-docker exec -it uah-dev-db psql -U uah -d uah_dev
-
-# Run a quick query
-docker exec uah-dev-db psql -U uah -d uah_dev -c "\dt"
-
-# Check if DB is accepting connections
-docker exec uah-dev-db pg_isready -U uah -d uah_dev
-```
-
----
-
-## Common Workflows
-
-### I changed backend Python code
-
-```bash
-# Uvicorn has --reload enabled and the backend/ directory is volume-mounted.
-# Changes to .py files are picked up automatically — no rebuild needed.
-# Just check the logs:
-docker compose logs -f backend
-```
-
-### I changed requirements.txt
-
-```bash
-# Must rebuild to install new packages
-docker compose up -d --build backend
-```
-
-### I changed frontend Vue/JS code
-
-```bash
-# Frontend must be rebuilt (Vite builds static assets into the Nginx image)
-docker compose up -d --build frontend
-```
-
-### I changed nginx.conf
-
-```bash
-# Must rebuild frontend since nginx.conf is baked into the image
-docker compose up -d --build frontend
-```
-
-### I need to wipe the database and start fresh
-
-```bash
-docker compose down
-sudo rm -rf ./volumes/postgres/*
-docker compose up -d --build
-```
-
----
-
-## What NOT to Touch
-
-| Item | Reason |
-|------|--------|
-| `/srv/uah/infrastructure/` | VPN and tunnel configs — managed separately |
-| `uah-dev-vpn` container | Frontend depends on its network namespace |
-| `uah-infra` Docker network | Shared across infrastructure and app services |
-| Cloudflare tunnel config | Managed outside this repo |
-| Port `51820/udp` | WireGuard VPN — do not change |
-
----
-
-## Environment Variables
-
-All secrets live in `.env` at the project root. Docker Compose reads it automatically.
-
-Canonical templates live in:
-- `env-examples/dev/.env.example`
-- `env-examples/beta/.env.example`
-- `env-examples/prod/.env.example`
-
-The application does **not** read files directly from `env-examples/` at runtime.
-Copy the appropriate template values into a real root `.env` before running services.
-
-| Variable | Used By | Description |
-|----------|---------|-------------|
-| `POSTGRES_USER` | db, backend | Database username |
-| `POSTGRES_PASSWORD` | db, backend | Database password |
-| `POSTGRES_DB` | db, backend | Database name |
-| `POSTGRES_PORT` | backend | Database port (default: 5432) |
-| `COMPOSE_PROJECT_NAME` | docker compose | Project namespace |
-| `ENV` | reference | Current environment |
-| `AUTH_NAMESPACE` | backend, frontend build | Environment auth namespace (`dev`, `beta`, `prod`) |
-| `AUTH_COOKIE_NAME` | backend | `HttpOnly` browser auth cookie name for API sessions |
-| `SESSION_COOKIE_NAME` | backend | Environment-scoped session cookie name (must not be `session`) |
-| `SESSION_COOKIE_SAMESITE` | backend | Session cookie SameSite policy (`lax`, `strict`, `none`) |
-| `SESSION_COOKIE_PATH` | backend | Session cookie path (usually `/`) |
-| `SESSION_COOKIE_HTTPS_ONLY` | backend | Use secure-only session cookie flag |
-| `GMAIL_TOKEN_ENCRYPTION_KEY` | backend | Dedicated encryption key for persisted Gmail refresh tokens |
-| `VITE_AUTH_NAMESPACE` | frontend build | Frontend auth storage namespace key suffix |
-| `VITE_LOCAL_MODE` | frontend build/runtime | Frontend API mode (`backend` for deployed stacks, `mock` for local-only UI runs) |
-| `DEV_DOMAIN` | reference | Domain for dev access |
-
-Compose now requires environment-scoped auth naming for backend startup.
-Use environment-scoped values such as:
-
-- Dev: `AUTH_NAMESPACE=dev`, `AUTH_COOKIE_NAME=uah_auth_dev`, `SESSION_COOKIE_NAME=uah_session_dev`
-- Beta: `AUTH_NAMESPACE=beta`, `AUTH_COOKIE_NAME=uah_auth_beta`, `SESSION_COOKIE_NAME=uah_session_beta`
-- Prod: `AUTH_NAMESPACE=prod`, `AUTH_COOKIE_NAME=uah_auth_prod`, `SESSION_COOKIE_NAME=uah_session_prod`
-
-For remote environments, keep `SESSION_COOKIE_HTTPS_ONLY=true` and set a dedicated `GMAIL_TOKEN_ENCRYPTION_KEY` if Gmail integration is enabled.
-
-> **Never commit `.env` to git.** It contains credentials.
+- Active docs should describe current behavior, not aspirational behavior.
+- If a behavior is temporary, say that explicitly.
+- Dated audits and migration notes belong in `docs/archive/`.
+- When changing a user-visible or operator-visible behavior, update the corresponding source-of-truth doc in the same change.
 
 ## License
 
 UAH is licensed under AGPL-3.0 with Commons Clause.
-
-- ✅ Free for personal, educational, and non-commercial use
-- ✅ Modifications must be open sourced under the same license  
-- ✅ Self-hosting for non-commercial purposes is permitted
-- ❌ Commercial use, resale, or monetization requires explicit written 
-     permission from the project maintainers
-
-Contact: admincontact@uahapp.com for commercial licensing inquiries.

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,45 +1,9 @@
 """
-API Routes
-==========
+Shared API routes that do not yet live in a narrower module.
 
-All /api/* endpoints live here.
-
-How routing works:
-  - This file defines an APIRouter that gets mounted in main.py.
-  - Each endpoint is a decorated async function.
-  - FastAPI automatically generates OpenAPI/Swagger docs from the
-    type hints and docstrings you provide.
-
-Where to add new routes:
-  - Simple CRUD routes can be added directly here.
-  - As the app grows, split into sub-routers:
-      app/api/v1/users.py
-      app/api/v1/jobs.py
-    and include them in main.py with version prefixes.
-
-Where business logic should go:
-  - Keep route handlers thin — they should validate input, call a
-    service function, and return the result.
-  - Business logic belongs in a services/ directory:
-      app/services/scraper.py    — web scraping with BeautifulSoup
-      app/services/jobs.py       — job application logic
-  - Import and call those services from route handlers.
-
-Where scraping services will live:
-  - app/services/scraper.py (create when needed)
-  - Use BeautifulSoup + httpx/requests for scraping.
-  - Keep scraping logic fully decoupled from route handlers.
-
-How DB session will be injected later:
-  - Import `get_db` from app.db.session
-  - Add it as a FastAPI dependency:
-      from fastapi import Depends
-      from app.db.session import get_db
-      from sqlalchemy.orm import Session
-
-      @router.get("/items")
-      async def list_items(db: Session = Depends(get_db)):
-          return db.query(Item).all()
+This file currently carries the jobs/geolocation/status/OAuth surfaces plus a
+few compatibility-heavy helpers. Purpose-specific routes such as auth, account,
+resume, applicant profile, Gmail, and apply sessions live in their own modules.
 """
 import asyncio
 from datetime import datetime, timezone

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,6 +46,8 @@ from app.models.apply_session import ApplySession, ApplySessionEvent
 
 logger = logging.getLogger(__name__)
 
+# These tables still rely on startup-time `create_all()` support for local/dev
+# compatibility. The newer jobs catalog schema is tracked through Alembic.
 LEGACY_STARTUP_TABLES = [
     User.__table__,
     SavedJob.__table__,
@@ -418,15 +420,18 @@ async def lifespan(app: FastAPI):
     init_engine()
     engine = get_engine()
 
-    # Create all tables on startup
+    # Local/dev startup still carries a small compatibility layer for older
+    # volumes so contributors can keep moving even when their schema lags.
     Base.metadata.create_all(bind=engine, tables=LEGACY_STARTUP_TABLES)
     _ensure_users_table_columns(engine)
     _ensure_resumes_table_columns(engine)
     _ensure_saved_jobs_table_columns(engine)
     _ensure_applicant_profiles_table_columns(engine)
+    # First normalize whatever already exists in the database.
     _enforce_email_first_identity_mirror()
     _bootstrap_admin_user_if_enabled()
     _ensure_dev_test_user_if_enabled()
+    # Then normalize any bootstrap-created rows using the same invariant.
     _enforce_email_first_identity_mirror()
 
     geo_dataset_status = ensure_city_dataset()
@@ -466,6 +471,8 @@ async def lifespan(app: FastAPI):
         logger.info("Redis parse queue worker stopped")
 
 _runtime_environment = (settings.ENVIRONMENT or os.getenv("ENVIRONMENT", "development")).strip().lower()
+# Generated API docs are a local/dev convenience. Beta-style environments
+# should expose the product surface, not a public OpenAPI explorer.
 _docs_enabled = _runtime_environment in {"development", "dev", "local"}
 
 app = FastAPI(

--- a/backend/app/scrapers/SCRAPERS.md
+++ b/backend/app/scrapers/SCRAPERS.md
@@ -1,101 +1,43 @@
-# UAH Scraper System
+# Scraper Scaffold
 
-This directory is a forward-looking scaffold for ethical scraper adapters. It does not replace the current live provider system in `backend/app/providers/`, and it is not wired into Celery yet. Its job is to make future provider additions consistent, reviewable, and safe before we plug anything into the live job-sync pipeline.
+This directory documents the ethical scraper scaffold under `backend/app/scrapers/`.
 
-## Architecture Overview
+Important boundary:
 
-```text
-PreScrapingChecklist.py
-        |
-        v
- provider approval
-        |
-        v
-BaseProviderAdapter
-        |
-        +--> provider adapters (scaffold)
-        |
-        +--> opt_out.py <--> opt_out_registry.json
-        |
-        v
-registry.py
-        |
-        v
-future pipeline integration
-  (live app.providers / Celery wiring later)
-```
+- this scaffold is not the same thing as the live provider pipeline in `backend/app/providers/`
+- it exists to make future provider evaluation and adapter work more structured
 
-- `checklist/PreScrapingChecklist.py` automates the first review pass for a new provider.
-- `base/BaseProviderAdapter.py` defines the adapter contract, UAHBot user agent, robots handling, and request pacing.
-- `providers/` contains scaffold-native adapters only. Current live examples remain in `backend/app/providers/`.
-- `registry.py` resolves scaffold adapters for future integration work.
-- `opt_out.py` and `opt_out_registry.json` provide a permanent, version-controlled removal path for providers.
+## Current Role
 
-## UAH Scraping Ethics
+The scaffold is for:
 
-- We only scrape sites with no explicit robots.txt prohibition and no ToS language against automated access
-- We identify ourselves as UAHBot/1.0 on every request
-- We honor Crawl-delay directives
-- We cache aggressively and never re-fetch unnecessarily
-- We provide a clear opt-out mechanism — any provider can email data@uahapp.com to be removed, and we honor it without question
-- We are not-for-profit — no individual profits from this data pipeline
+- provider review workflows
+- opt-out bookkeeping
+- a future adapter contract for scraper-based providers
 
-## How To Add A New Provider
+It is not currently the primary runtime path for the live jobs catalog.
 
-1. Run `python -m backend.app.scrapers.checklist.PreScrapingChecklist --url https://example.com`.
-2. Review the output. The provider must be `APPROVED` before adapter work proceeds.
-3. Create a new adapter in `backend/app/scrapers/providers/`.
-4. Extend `BaseProviderAdapter` and implement every required method.
-5. Register the adapter in `backend/app/scrapers/registry.py`.
-6. Summarize the checklist outcome in the PR or documentation notes. Raw JSON logs remain local tooling artifacts because `checklist_log/` is gitignored.
+## Main Pieces
 
-## Opt-Out System
-
-Providers can email `data@uahapp.com` from their organization domain to request removal. Requests are honored promptly, without debate, and permanently recorded in `opt_out_registry.json`.
-
-Use the helper functions in `opt_out.py`:
-
-- `register_opt_out(provider_name, base_url, contact_email, date, notes)`
-- `check_opt_out(base_url)`
-- `list_opted_out()`
-- `remove_opt_out(base_url, confirmation_notes)`
-
-The registry is committed to git on purpose. Opt-out requests should stay historically visible, auditable, and hard to accidentally erase.
-
-## Rate Limiting Rules
-
-- The base adapter default is `2.0` seconds between requests.
-- The effective floor is always `1.0` seconds, even if a provider-specific override returns less.
-- When `robots.txt` defines `Crawl-delay`, UAH uses the higher value between the adapter delay and the robots directive.
-- Future providers should route all outbound HTTP calls through the base adapter request helper so the same pacing logic is applied everywhere.
-
-## Normalization Schema
-
-All adapters normalize into `app.schemas.job.NormalizedJob`.
-
-| Field | Type |
+| File / area | Purpose |
 | --- | --- |
-| `provider` | `str` |
-| `provider_job_id` | `str` |
-| `provider_url` | `str \| None` |
-| `apply_url` | `str \| None` |
-| `apply_host` | `str \| None` |
-| `apply_portal` | `str \| None` |
-| `source_tags` | `list[str]` |
-| `title` | `str` |
-| `company` | `str \| None` |
-| `company_url` | `str \| None` |
-| `location` | `str \| None` |
-| `is_remote` | `bool` |
-| `job_type` | `str \| None` |
-| `experience_level` | `str \| None` |
-| `categories` | `list[str]` |
-| `description` | `str \| None` |
-| `published_at` | `datetime \| None` |
+| `checklist/PreScrapingChecklist.py` | First-pass provider review automation |
+| `base/BaseProviderAdapter.py` | Shared adapter contract and request etiquette |
+| `providers/` | Scaffold-native provider adapters |
+| `registry.py` | Future scaffold adapter lookup |
+| `opt_out.py` and `opt_out_registry.json` | Version-controlled provider removal path |
 
-## Example Implementations
+## Ethics And Guardrails
 
-This scaffold intentionally does not duplicate the six live provider adapters that already exist in `backend/app/providers/`. Use these files as real normalization and request-shape examples:
+- honor `robots.txt`
+- review provider terms before adapter work
+- use clear identification and respectful pacing
+- keep an explicit opt-out path
+- preserve historical opt-out records in version control
+
+## Live Pipeline Reminder
+
+If you need the currently active provider implementations, use:
 
 - `backend/app/providers/the_muse.py`
 - `backend/app/providers/arbeitnow.py`
@@ -104,7 +46,11 @@ This scaffold intentionally does not duplicate the six live provider adapters th
 - `backend/app/providers/adzuna.py`
 - `backend/app/providers/careerjet.py`
 
-## Provider Status
+## Provider Status Table
+
+The status table below is a planning aid, not a live-service guarantee.
+
+`Legacy / pending rerun` means the last documented checklist review is no longer assumed current and should be rerun before treating the provider as newly approved.
 
 | Provider | Base URL | Rate Limit | Status | Checklist Review Date |
 | --- | --- | --- | --- | --- |
@@ -116,13 +62,14 @@ This scaffold intentionally does not duplicate the six live provider adapters th
 | Careerjet | `https://www.careerjet.com` | Disabled stub | Dormant | Legacy / pending rerun |
 | WhatJobs | `https://www.whatjobs.com` | `2.0s/request` scaffold default | Inactive | Pending |
 
-## Opt-Out Contact
+## Adding A New Provider
 
-If you operate one of these sites and want UAH to stop indexing your content, email `data@uahapp.com` from your organization domain. Removal requests are honored promptly and permanently recorded.
+1. Run the checklist.
+2. Review robots/ToS/output manually.
+3. Decide whether the provider belongs in the live pipeline now, the scaffold only, or not at all.
+4. Capture the reasoning in the PR or current docs.
 
-## Contributing A New Adapter
+## Related Docs
 
-- A merged PR is required before an adapter can be treated as part of the community-supported listing.
-- Reaching out to an LTS team member before starting a new adapter is encouraged so contributors do not duplicate work.
-- The pre-scraping checklist must pass before adapter work proceeds.
-- Include a short checklist summary in the PR so reviewers can confirm why the provider was approved.
+- [../../../docs/provider-checklist-template.md](../../../docs/provider-checklist-template.md)
+- [../../../docs/ARCHITECTURE.md](../../../docs/ARCHITECTURE.md)

--- a/backend/app/services/job_search.py
+++ b/backend/app/services/job_search.py
@@ -79,6 +79,8 @@ def _build_search_tags(job: Job) -> list[str]:
 def _serialize_job(job: Job) -> dict:
     compat_id: int | str
     raw_provider_job_id = str(job.provider_job_id)
+    # Older clients treated some provider job ids as integers, so keep the
+    # numeric shape when we can while still exposing the canonical string id.
     compat_id = int(raw_provider_job_id) if raw_provider_job_id.isdigit() else raw_provider_job_id
     published_at_iso = job.published_at.astimezone(timezone.utc).isoformat() if job.published_at else None
     locations = [job.location] if job.location else []
@@ -236,6 +238,8 @@ def search_local_jobs(
     total_pages = max(ceil(total / page_size), 1) if total else 1
     filter_metadata = _build_jobs_filter_metadata_payload(db)
 
+    # Mirror the provider-backed search response shape so the frontend can swap
+    # between local-catalog and provider results without a second serializer.
     return {
         "jobs": jobs,
         "total": total,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,124 @@
+# UAH Architecture
+
+This document explains how the current codebase is split, how requests move through it, and where to look when a feature crosses multiple layers.
+
+For setup instructions, use the linked source-of-truth guides instead:
+
+- Repo entrypoint: [../README.md](../README.md)
+- Backend local development: [backend/README.md](backend/README.md)
+- Frontend development: [frontend/README.md](frontend/README.md)
+- Browser extension: [../uah-browser-extension/README.md](../uah-browser-extension/README.md)
+
+## Top-Level Shape
+
+| Area | Purpose |
+| --- | --- |
+| `backend/` | FastAPI app, SQLAlchemy models, Alembic migrations, Celery tasks, provider ingestion, resume parsing, and auth/account APIs. |
+| `frontend/` | Vue 3 SPA for the main UAH product surface. Supports mock-first local development and backend passthrough mode. |
+| `uah-browser-extension/` | MV3 browser extension that reuses backend auth and exposes profile/resume/autofill tools inside job board tabs. |
+| `shared/` | Cross-surface styling assets such as the shared theme CSS. |
+| `scripts/` | Lifecycle, audit, sync, debug, and environment-specific operational helpers. |
+| `docs/` | Current source-of-truth docs plus an archive for dated snapshots. |
+
+## Request Flow
+
+### Main web app
+
+1. The Vue frontend serves the SPA shell.
+2. Browser requests go through Nginx to `/api/*`.
+3. FastAPI handles auth, account, job search, resume, profile, integration, and diagnostics endpoints.
+4. SQLAlchemy persists application data in Postgres.
+5. Optional queue-backed parsing and job sync flows use Redis plus Celery worker/beat processes.
+
+### Browser extension
+
+1. The popup UI talks to the background service worker through runtime messages only.
+2. The background worker owns auth, API fetches, cache hydration, tab opening, and content-script injection.
+3. The extension reuses the backend's auth flows and environment-scoped auth cookie names.
+4. Manual autofill injects runtime code into the active tab only when the user explicitly scans or fills a page.
+
+## Backend Boundaries
+
+The backend is split by responsibility rather than by one giant route file.
+
+| Layer | Location | Responsibility |
+| --- | --- | --- |
+| Application entrypoint | `backend/app/main.py` | FastAPI setup, startup/shutdown work, docs gating, router registration, and session middleware. |
+| Route modules | `backend/app/api/` | Thin HTTP layer for auth, account, resume, jobs, applicant profiles, integrations, Gmail, and apply sessions. |
+| Services | `backend/app/services/` | Business logic such as resume parsing, job search shaping, provider requests, canonicalization, and queue orchestration. |
+| Data models | `backend/app/models/` | SQLAlchemy tables for users, resumes, jobs, applicant profiles, parse jobs, and related state. |
+| Schemas | `backend/app/schemas/` | Pydantic request/response shapes and compatibility fields. |
+| Background work | `backend/app/tasks/`, `backend/app/worker.py` | Celery tasks for job sync and maintenance. |
+| Migrations | `backend/alembic/` | Schema changes for durable database evolution. |
+
+### Current backend behavior that matters for docs
+
+- Swagger/OpenAPI routes are enabled only when `ENVIRONMENT` is `development`, `dev`, or `local`.
+- `/api/status` is the lightweight public connectivity probe.
+- `/api/diagnostics` is admin-gated.
+- The identity model is email-first, but `username` still exists as a compatibility mirror in parts of the schema and DB.
+- Saved jobs routes are authenticated and derive ownership from the current session, not from caller-supplied user IDs.
+
+## Frontend Boundaries
+
+The frontend is a Vue 3 SPA with two local-development modes.
+
+| Mode | Entry | Behavior |
+| --- | --- | --- |
+| Mock-first | `npm run dev` | Uses the in-browser mock API layer and local storage state so the UI can render without backend services. |
+| Backend passthrough | `npm run dev:backend` | Proxies `/api`, `/docs`, and `/openapi.json` to a local backend origin. |
+
+### Current frontend surface
+
+- Auth/account, resume/profile management, job board, settings, status, and contributor/commitment pages are active.
+- Some routes still exist as placeholders or partial shells, especially `Analytics`, `Timeline`, and `Application`.
+- The `Dev` page is gated by the debug-tools helper instead of being globally public.
+- Auth is cookie-first in deployed/backend mode, while mock mode still persists a local token for isolated UI development.
+
+## Browser Extension Boundaries
+
+The extension intentionally keeps responsibility split across three layers:
+
+| Layer | Location | Responsibility |
+| --- | --- | --- |
+| Popup app | `uah-browser-extension/src/App.vue` and related UI code | User-facing views, actions, and pinned-surface rendering. |
+| Background worker | `uah-browser-extension/src/background/index.js` | Auth, API fetches, storage, caching, tab management, and script injection. |
+| Injected runtimes | `uah-browser-extension/src/autofill/`, `src/pinned-panel/` | Page scanning/filling and the floating pinned panel injected into supported tabs. |
+
+### Adapter system
+
+- Base ATS adapters cover platform-wide conventions such as Workday, Greenhouse, Lever, and iCIMS.
+- Company overrides layer on top of base adapters when one employer diverges from the platform defaults.
+- Resolution always tries company overrides before generic ATS matches.
+
+## Deployment Shapes
+
+### Local
+
+- `docker-compose.local.yml` is for localhost-only DB/backend support.
+- Frontend local development stays outside Docker via Vite.
+- The extension localhost harness uses HTTPS on `https://localhost:5173`.
+
+### Dev
+
+- `docker-compose.yml` defines the core dev stack.
+- Nginx fronts the SPA and `/api` proxy.
+- Dev is team-oriented and can keep docs routes enabled.
+
+### Beta
+
+- `docker-compose.beta.yml` is an override layered on top of the main compose file.
+- Beta currently uses a `cloudflared` tunnel container rather than exposing the frontend directly on a public host port.
+- Beta should be documented as its own environment with isolated cookie names, Redis namespace, compose project name, and DB.
+
+## Where To Document Changes
+
+Use this table when a change crosses multiple parts of the repo:
+
+| Change type | Docs to update |
+| --- | --- |
+| New backend env var or behavior change | [backend/README.md](backend/README.md), [SERVER_ENV_CHECKLIST.md](SERVER_ENV_CHECKLIST.md), and the relevant `env-examples/*/.env.example` file |
+| Frontend route, auth, or local-dev behavior change | [frontend/README.md](frontend/README.md) and sometimes [../README.md](../README.md) |
+| Extension build/runtime/autofill change | [../uah-browser-extension/README.md](../uah-browser-extension/README.md) and adapter docs if relevant |
+| Deployment/lifecycle change | [../README.md](../README.md), [WORKFLOW.MD](WORKFLOW.MD) if team process changed, and beta docs if deployment-specific |
+| Migration plan or one-time incident analysis | [archive/README.md](archive/README.md), not the active docs set |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,57 @@
+# UAH Documentation Map
+
+This directory is the documentation landing page for the repository.
+
+Use it to answer two questions quickly:
+
+1. Which document is the current source of truth?
+2. Which documents are preserved only for historical context?
+
+## Start Here
+
+| Need | Current doc |
+| --- | --- |
+| Repo overview, local development, and stack entrypoints | [../README.md](../README.md) |
+| System architecture and subsystem boundaries | [ARCHITECTURE.md](ARCHITECTURE.md) |
+| Backend local development and runtime notes | [backend/README.md](backend/README.md) |
+| Frontend local development and active UI/runtime behavior | [frontend/README.md](frontend/README.md) |
+| Browser extension architecture, build, and testing | [../uah-browser-extension/README.md](../uah-browser-extension/README.md) |
+| Environment templates and runtime `.env` rules | [env-examples/README.md](env-examples/README.md) |
+| Server-side env requirements and operational checklist | [SERVER_ENV_CHECKLIST.md](SERVER_ENV_CHECKLIST.md) |
+| Contribution policy | [../CONTRIBUTING.md](../CONTRIBUTING.md) |
+| Branch / PR workflow | [WORKFLOW.MD](WORKFLOW.MD) |
+| Security policy | [../SECURITY.md](../SECURITY.md) |
+| Security audit script usage | [SECURITY_AUDIT_GUIDE.md](SECURITY_AUDIT_GUIDE.md) |
+| Beta deployment setup | [beta-prep/BETA_SETUP.md](beta-prep/BETA_SETUP.md) |
+| Beta release checklist | [beta-prep/SECURITY_CHECKLIST.md](beta-prep/SECURITY_CHECKLIST.md) |
+| Cloudflare tunnel and access posture for beta | [beta-prep/CLOUDFLARE_SECURITY.md](beta-prep/CLOUDFLARE_SECURITY.md) |
+| Temporary desktop Ollama route runbook | [beta-prep/TEMP_DESKTOP_OLLAMA_ROUTING_RUNBOOK.md](beta-prep/TEMP_DESKTOP_OLLAMA_ROUTING_RUNBOOK.md) |
+
+## Subsystem Docs
+
+These docs live next to the subsystem they describe because they are only useful when working in that area.
+
+| Area | Doc | Notes |
+| --- | --- | --- |
+| Extension ATS adapter system | [../uah-browser-extension/src/adapters/ADAPTERS.md](../uah-browser-extension/src/adapters/ADAPTERS.md) | Base ATS adapters, company overrides, and test expectations. |
+| Extension company override rules | [../uah-browser-extension/src/adapters/companies/README.md](../uah-browser-extension/src/adapters/companies/README.md) | Narrow guide for company-specific adapter deviations. |
+| Scraper scaffold | [../backend/app/scrapers/SCRAPERS.md](../backend/app/scrapers/SCRAPERS.md) | Forward-looking scaffold, not the live provider pipeline. |
+| Provider review template | [provider-checklist-template.md](provider-checklist-template.md) | Checklist for evaluating new providers before adapter work. |
+
+## Active Docs Rules
+
+When editing the codebase, treat these conventions as repository policy:
+
+- Root-level READMEs and docs in this directory should describe current behavior, not planned behavior.
+- If a behavior is temporary, say that explicitly and name the current workaround.
+- If a compatibility surface still exists, document it as compatibility-only instead of implying it is preferred.
+- Prefer cross-links over duplicating the same explanation in multiple places.
+- Put dated implementation notes, audits, and migration plans in [archive/](archive/README.md) instead of leaving them mixed with active guides.
+
+## Historical Material
+
+Historical docs are intentionally preserved, but they are no longer treated as the current source of truth.
+
+- Historical audits, implementation notes, and migration plans live under [archive/](archive/README.md).
+- Active guides should link to historical docs only when the old context still helps explain why something exists.
+- If you are unsure whether a document is current, use the tables above first and treat archive docs as background only.

--- a/docs/SECURITY_AUDIT_GUIDE.md
+++ b/docs/SECURITY_AUDIT_GUIDE.md
@@ -1,32 +1,31 @@
 # Security Audit Guide
 
-This guide covers the new comprehensive security audit workflow integrated into the scripts stack.
+This guide covers the repository's script-based security audit workflow.
 
-## Entrypoints
+## Canonical Entrypoints
 
-Unified router:
+Primary router:
 
 ```bash
 bash scripts/uah.sh <dev|beta|prod> audit [options]
 ```
 
-Environment-specific wrappers:
+Environment wrapper aliases:
 
 ```bash
 bash scripts/dev/lifecycle/dev-audit.sh [options]
 bash scripts/beta/lifecycle/beta-audit.sh [options]
 ```
 
-Wrappers are stable aliases; `scripts/uah.sh` remains the canonical audit interface.
-Audit options are also listed in `bash scripts/uah.sh --help`.
-
-Direct environment scripts:
+Direct diagnostic scripts:
 
 ```bash
 bash scripts/dev/diagnostic/dev-security-audit.sh [options]
 bash scripts/beta/diagnostic/beta-security-audit.sh [options]
 bash scripts/prod/prod-security-audit.sh [options]
 ```
+
+`scripts/uah.sh` remains the source-of-truth interface.
 
 ## Options
 
@@ -39,62 +38,42 @@ bash scripts/prod/prod-security-audit.sh [options]
 -h, --help            Show usage help
 ```
 
-## Modes
+## What The Audit Checks
 
-- `full`: run repository, dependency, runtime, and host firewall checks.
-- `repo`: run repository and dependency checks only.
-- `docker`: run repository/dependency checks plus runtime container checks.
-- `host`: run repository/dependency checks plus host firewall checks.
+### Repository / configuration checks
 
-## Check Coverage
+- env template coverage and drift
+- placeholder / weak-secret detection
+- compose rendering and compose hardening checks
+- frontend build-safety checks
+- backend dependency checks when `pip-audit` is available
+- frontend and extension dependency checks when `npm audit` is available
+- secret-scanning parity with `gitleaks` when available
 
-Repository/build checks:
+### Runtime checks
 
-- Beta-aware environment validation aligned with `config.py`, compose, and env templates.
-- Conditional OAuth, Gmail, SMTP, queue, and local pipeline validation.
-- Secret quality and placeholder detection.
-- Environment file permission checks.
-- Env example drift detection via `.github/scripts/check_env_sync.py`.
-- Compose render and compose hardening checks.
-- Frontend nginx header / HSTS / TLS-entrypoint static checks.
-- Frontend production-build safety checks (including Vue devtools gating).
-- Secret scanning parity with `gitleaks` when available.
-- Backend dependency vulnerability checks (`pip-audit` when available).
-- Frontend dependency vulnerability checks (`npm audit` when available).
-- Browser extension dependency vulnerability checks (`npm audit` when a lockfile is present).
+- expected container presence and health
+- exposed host ports
+- privileged container / capability checks
+- HTTP surface probes such as `/api/`, `/api/status`, `/api/diagnostics`, `/docs`, `/redoc`, and `/openapi.json`
+- beta tunnel/container expectations
 
-Runtime checks:
+### Host checks
 
-- Expected container presence by environment.
-- Container health state checks.
-- Privileged container and capability checks.
-- Host port exposure checks for backend/db/frontend/redis.
-- HTTP surface probes (`/api/`, `/api/diagnostics`, `/docs`, `/redoc`, `/openapi.json`).
-- Beta cloudflared runtime check.
-- Optional image vulnerability checks (`trivy` when available).
-- Beta manual-controls reminders for Cloudflare and other operator-managed hardening that the repo cannot prove automatically.
+- firewall readability
+- Docker user-chain hints
+- environment-specific exposure warnings
 
-Host firewall checks:
+## Interpreting Current Behavior
 
-- iptables rules readability and DOCKER-USER chain presence.
-- beta-focused DOCKER-USER rule presence hints.
-- UFW status checks and beta-origin exposure warnings.
+These expectations matter when reading audit results:
 
-## Exit Codes
+- `/api/status` is the lightweight public connectivity route.
+- `/api/diagnostics` is admin-gated.
+- generated docs routes are expected in local/dev-style environments but should be absent in beta-like environments where `ENVIRONMENT=beta`.
+- beta currently uses a `cloudflared` tunnel container in the repo-managed compose override.
 
-- `0`: pass, or warning-only when `--fail-on-warn` is not set.
-- `1`: warning-only with `--fail-on-warn`.
-- `2`: one or more failed checks.
-
-## JSON Reports
-
-If `--json` is supplied without a path, output is written to:
-
-```text
-logs/security-audit/<env>-audit-<timestamp>.json
-```
-
-## Recommended Workflows
+## Recommended Usage
 
 Dev full audit:
 
@@ -108,23 +87,20 @@ Beta full audit with explicit env file:
 bash scripts/uah.sh beta audit --env-file /srv/uah/environments/beta/.env --mode full --json
 ```
 
-Host firewall only (with sudo where required):
+Host-layer checks where privilege is needed:
 
 ```bash
 sudo bash scripts/uah.sh beta audit --mode host --json
 ```
 
-Read-only baseline plus optional remediation pass:
+## Exit Codes
 
-```bash
-bash scripts/uah.sh dev audit --mode full --json
-bash scripts/uah.sh dev audit --mode full --fix --json
-```
+- `0`: pass, or warning-only when `--fail-on-warn` is not set
+- `1`: warning-only with `--fail-on-warn`
+- `2`: one or more failed checks
 
 ## Notes
 
-- The default behavior is read-only.
-- Some checks are skipped or downgraded to warnings when tools are unavailable (`pip-audit`, `npm`, `trivy`, `gitleaks`, `iptables`, `ufw`) or when privilege is insufficient.
-- Beta manual-controls findings are warnings by default because they require operator verification outside the repo.
-- In this repository, beta is modeled explicitly as `ENVIRONMENT=beta` / `ENV=beta`; the audit no longer assumes beta should masquerade as `production`.
-- If you run the audit from a Windows workstation, prefer CI or a real bash-capable environment for final verification when local bash integration is unreliable.
+- The default audit mode is read-only.
+- Some checks degrade to warnings when required tools are not installed.
+- The audit can confirm a large amount of repo-managed posture, but operator-managed Cloudflare Access/WAF configuration still requires manual review.

--- a/docs/SERVER_ENV_CHECKLIST.md
+++ b/docs/SERVER_ENV_CHECKLIST.md
@@ -1,89 +1,172 @@
 # Server Environment Checklist
 
-This checklist captures environment variables that must exist on server-side `.env` files for reliable UAH operations.
+This checklist groups the server-side env keys that matter most for reliable UAH operation.
 
-## Required For Startup
+Treat it as an operator-facing summary. The detailed variable set still lives in:
+
+- `backend/app/core/config.py`
+- `env-examples/*/.env.example`
+- compose files and lifecycle scripts
+
+## Always Required
 
 - `POSTGRES_PASSWORD`
 - `SECRET_KEY`
 - `SESSION_SECRET`
+- `AUTH_NAMESPACE`
+- `SESSION_COOKIE_NAME`
 
-## Required For Core Auth and Search Features
+These are non-optional for backend startup in repo-managed environments.
+
+## Core Runtime Identity
+
+- `ENV`
+- `ENVIRONMENT`
+- `COMPOSE_PROJECT_NAME`
+- `PUBLIC_APP_URL`
+- `AUTH_COOKIE_NAME`
+- `SESSION_COOKIE_NAME`
+- `SESSION_COOKIE_SAMESITE`
+- `SESSION_COOKIE_PATH`
+- `SESSION_COOKIE_HTTPS_ONLY`
+
+These values control environment labeling, cookie naming, and whether generated API docs are enabled.
+
+## Dev / Local Test Account Controls
+
+Document these keys in templates even when disabled:
+
+- `DEV_AUTH_TEST_ACCOUNT_ENABLED`
+- `DEV_AUTH_TEST_EMAIL`
+- `DEV_AUTH_TEST_USERNAME` (legacy fallback only)
+- `DEV_AUTH_TEST_PASSWORD`
+- `DEV_AUTH_TEST_FIRST_NAME`
+- `DEV_AUTH_TEST_LAST_NAME`
+- `DEV_AUTH_TEST_IS_ADMIN`
+- `DEV_AUTH_TEST_IS_DEVELOPER`
+- `DEV_AUTH_TEST_ROTATE_PASSWORD`
+
+Policy:
+
+- local/dev may enable the seeded account intentionally
+- beta/prod should keep it disabled
+- if `DEV_AUTH_TEST_USERNAME` is used, it should contain an email value
+
+## OAuth And Account Integrations
+
+### Google sign-in
 
 - `GOOGLE_CLIENT_ID`
 - `GOOGLE_CLIENT_SECRET`
 - `GOOGLE_REDIRECT_URI`
-- `MUSE_API_KEY`
 
-## Dev Test Account Controls
-
-Document these keys in env templates even when disabled:
-
-- `DEV_AUTH_TEST_ACCOUNT_ENABLED`
-- `DEV_AUTH_TEST_PASSWORD`
-- `DEV_AUTH_TEST_EMAIL`
-- `DEV_AUTH_TEST_USERNAME` (legacy fallback only)
-- `DEV_AUTH_TEST_FIRST_NAME`
-- `DEV_AUTH_TEST_LAST_NAME`
-- `DEV_AUTH_TEST_IS_ADMIN`
-- `DEV_AUTH_TEST_ROTATE_PASSWORD`
-
-Environment policy:
-
-- Dev/local: may enable test account; when enabled, email and password must be set.
-- `DEV_AUTH_TEST_USERNAME` is legacy-only compatibility and should be an email value if used.
-- Beta/prod: must keep `DEV_AUTH_TEST_ACCOUNT_ENABLED=false`.
-
-## Required For Gmail Integration
+### Gmail integration
 
 - `GMAIL_CLIENT_ID`
 - `GMAIL_CLIENT_SECRET`
 - `GMAIL_REDIRECT_URI`
+- `GMAIL_TOKEN_ENCRYPTION_KEY`
 
-## Required For Beta Tunnel
+## Email Delivery
 
-- `CLOUDFLARE_BETA_TUNNEL_TOKEN` (beta only)
+- `EMAILS_ENABLED`
+- `SMTP_HOST`
+- `SMTP_PORT`
+- `SMTP_FROM`
+- `SMTP_USE_TLS`
+- `SMTP_USE_SSL`
+- `SMTP_TIMEOUT_SECONDS`
+- `SMTP_USERNAME` and `SMTP_PASSWORD` when the provider requires login
 
-## Required When Queue Is Enabled
+## Job Search Providers
 
-- `REDIS_ENABLED=true`
-- `REDIS_URL=redis://uah-redis:6379/0` (dev default)
+### Primary provider config
+
+- `MUSE_API_KEY`
+- `THE_MUSE_API_KEY`
+- `THE_MUSE_RATE_LIMIT_PER_HOUR`
+- `JOB_PROVIDER_CONTROLS_JSON`
+
+### Optional provider credentials / throttles
+
+- `FINDWORK_API_KEY`
+- `ADZUNA_APP_ID`
+- `ADZUNA_APP_KEY`
+- `JOOBLE_API_KEY`
+- `ARBEITNOW_INTER_REQUEST_DELAY`
+- `FINDWORK_INTER_REQUEST_DELAY`
+- `JOOBLE_INTER_REQUEST_DELAY`
+- `JOOBLE_PAGE_SIZE`
+- `ADZUNA_DAILY_REQUEST_BUDGET`
+
+## Search And Geolocation Controls
+
+- `MUSE_PAGE_CHASE_*`
+- `MUSE_ADAPTIVE_PAGE_CHASE_*`
+- `MUSE_LOCATION_PARAM_CAP`
+- `MUSE_LOCATION_INDEX_*`
+- `CONSTRAINT_COMPATIBILITY_ENABLED`
+- `CONSTRAINT_FILTER_MIN_CONFIDENCE`
+- `JOBS_DEFAULT_PAGE_SIZE`
+- `JOBS_CACHE_*`
+- `JOBS_URL_VALIDATION_*`
+- `JOB_LINK_RECHECK_HOURS`
+- `GEO_IP_PROVIDER`
+- `IPSTACK_API_KEY`
+- `GEOLOCATION_AUTO_BUILD_DATASET`
+- `GEOLOCATION_IGNORE_LOCAL_DATASET`
+- `GEOLOCATION_DATASET_TIMEOUT_SECONDS`
+- `NOMINATIM_USER_AGENT`
+
+## Queue And Background Work
+
+### Enablement and connection
+
+- `REDIS_ENABLED`
+- `REDIS_URL`
+- `REDIS_HOST_PORT`
+- `BETA_REDIS_URL`
+- `BETA_REDIS_HOST_PORT`
+
+### Queue naming and isolation
+
 - `PARSE_QUEUE_NAME`
 - `PARSE_QUEUE_NAME_CLOUD`
 - `PARSE_QUEUE_NAME_LOCAL`
 - `PARSE_QUEUE_NAME_RULES`
-- `BETA_REDIS_URL=redis://uah-beta-redis:6379/0` (beta compose override default)
 - `BETA_PARSE_QUEUE_NAME`
 - `BETA_PARSE_QUEUE_NAME_CLOUD`
 - `BETA_PARSE_QUEUE_NAME_LOCAL`
 - `BETA_PARSE_QUEUE_NAME_RULES`
-- `BETA_REDIS_HOST_PORT=6380` (when dev and beta run on the same host)
 
-## Recommended Parse Queue Controls
+### Retry / worker tuning
 
-- `PARSE_QUEUE_MAX_RETRIES`
-- `PARSE_QUEUE_MAX_RETRIES_CLOUD`
-- `PARSE_QUEUE_MAX_RETRIES_LOCAL`
-- `PARSE_QUEUE_MAX_RETRIES_RULES`
-- `PARSE_QUEUE_CONCURRENCY_CLOUD`
-- `PARSE_QUEUE_CONCURRENCY_LOCAL`
-- `PARSE_QUEUE_CONCURRENCY_RULES`
-- `PARSE_QUEUE_CLOUD_MIN_INTERVAL_SECONDS`
+- `PARSE_QUEUE_MAX_RETRIES*`
+- `PARSE_QUEUE_CONCURRENCY_*`
 - `PARSE_QUEUE_CLAIM_TTL_SECONDS`
 - `PARSE_QUEUE_SHUTDOWN_DRAIN_SECONDS`
 - `PARSE_QUEUE_STALE_JOB_MINUTES`
 
-## Optional Job Board URL Validation Controls
+### Job sync maintenance
 
-- `JOBS_URL_VALIDATION_ENABLED`
-- `JOBS_URL_VALIDATION_TIMEOUT_SECONDS`
-- `JOBS_URL_VALIDATION_MAX_CHECKS_PER_REQUEST`
-- `JOBS_URL_VALIDATION_CONCURRENCY`
-- `JOBS_URL_VALIDATION_BAD_TTL_SECONDS`
-- `JOBS_URL_VALIDATION_GOOD_TTL_SECONDS`
-- `JOBS_URL_VALIDATION_UNKNOWN_TTL_SECONDS`
+- `JOB_SYNC_ENABLED`
+- `JOB_SYNC_STALE_THRESHOLD_HOURS`
+- `JOB_SYNC_SOFT_DELETE_MISSES`
+- `JOB_SYNC_HARD_PURGE_DAYS`
+- `JOB_SYNC_DISPATCH_INTERVAL_SECONDS`
+- `JOB_SYNC_CLEANUP_INTERVAL_SECONDS`
+- `JOB_SYNC_LOCK_TTL_SECONDS`
+- `JOB_SYNC_CLEANUP_LOCK_TTL_SECONDS`
+- `JOB_SYNC_CATEGORY_SCHEDULE_JSON`
+- `JOB_SYNC_ENABLED_PROVIDERS_JSON`
+- `JOB_LINK_BACKFILL_*`
+- `JOB_DEDUP_BACKFILL_*`
+- `JOB_COUNTRY_BACKFILL_*`
+- `JOB_STALE_AUDIT_*`
 
-## Required For Cloud Parse
+## Resume Parsing
+
+### Cloud parsing
 
 - `ZAI_API_KEY`
 - `ZAI_OCR_URL`
@@ -91,23 +174,30 @@ Environment policy:
 - `ZAI_LLM_MODEL`
 - `ZAI_LLM_MAX_TOKENS`
 
-## Required When Local Pipeline Is Enabled
+### Local pipeline
 
-- `USE_LOCAL_PIPELINE=true`
+- `USE_LOCAL_PIPELINE`
 - `LOCAL_OCR_URL`
 - `LOCAL_OCR_MODEL`
 - `LOCAL_LLM_URL`
 - `LOCAL_LLM_MODEL`
+- `LOCAL_OCR_TIMEOUT`
+- `LOCAL_LLM_TIMEOUT`
+- `LOCAL_OCR_DPI`
 
-## Operational Notes
+## Beta-Specific Tunnel / Routing
 
-- Runtime script entrypoint is `scripts/uah.sh`.
-- `scripts/uah.sh` auto-detects environment context when env is omitted (path and root `.env` heuristics).
-- Lifecycle env requirement check entrypoint is `scripts/lib/env-feature-check.sh`.
-- Security audit entrypoint is `scripts/uah.sh <dev|beta|prod> audit`.
-- Dev cert sync hook is `scripts/dev/certbot-sync-dev-cert.sh`.
-- Password reset script reads `.env` from repo root by default and supports override via `UAH_ENV_FILE`.
-- Concurrent dev and beta on one host require distinct Redis host ports (`REDIS_HOST_PORT=6379`, `BETA_REDIS_HOST_PORT=6380`).
-- Beta queue defaults should use the `uah:beta:*` namespace to avoid cross-environment key overlap.
-- `scripts/uah.sh` runs env checks during startup preflight and warns after sync operations.
-- Debug operations are first-class under `scripts/uah.sh <env> debug ...` for connectivity, logs, queue, network, database, and dev user admin tasks.
+- `DEV_DOMAIN`
+- `CLOUDFLARE_BETA_TUNNEL_TOKEN`
+- `DEV_TLS_ENABLED`
+- `DEV_TLS_CERT_PATH`
+- `DEV_TLS_KEY_PATH`
+
+Current beta deployments use the `cloudflared` tunnel override, so the tunnel token is part of the repo-managed beta shape.
+
+## Operational Reminders
+
+- `scripts/uah.sh` is the canonical lifecycle entrypoint.
+- `scripts/lib/env-feature-check.sh` is the lifecycle-side env validation helper.
+- `bash scripts/uah.sh <env> audit ...` is the canonical security audit entrypoint.
+- Env templates should stay aligned with `backend/app/core/config.py` and the compose files.

--- a/docs/WORKFLOW.MD
+++ b/docs/WORKFLOW.MD
@@ -3,6 +3,8 @@
 This guide covers the full loop from picking up an issue to getting your code into `dev`.
 Follow this every time. It keeps everything logged, traceable, and clean.
 
+If your change affects setup, runtime behavior, or operator workflow, update the relevant source-of-truth docs in the same PR. Use [README.md](README.md) and [../CONTRIBUTING.md](../CONTRIBUTING.md) as the starting points.
+
 ---
 
 ## The Core Rule

--- a/docs/archive/LOCAL_OLLAMA_REDIS_MIGRATION_PLAN.md
+++ b/docs/archive/LOCAL_OLLAMA_REDIS_MIGRATION_PLAN.md
@@ -1,3 +1,13 @@
+# Historical Snapshot: UAH Resume Pipeline Migration Plan
+
+This document is preserved as a dated migration record.
+
+It is not the current source of truth for resume parsing or queue setup. Use these active docs first:
+
+- [../README.md](../README.md)
+- [../backend/README.md](../backend/README.md)
+- [../SERVER_ENV_CHECKLIST.md](../SERVER_ENV_CHECKLIST.md)
+
 # UAH Resume Pipeline Migration Plan
 
 ## Goal

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,28 @@
+# Documentation Archive
+
+This directory contains historical snapshots that are intentionally preserved but are not the current source of truth.
+
+## What belongs here
+
+- Dated implementation notes
+- One-time audits
+- Migration plans
+- Supporting inventory files that only make sense together with a dated audit
+
+## How to use archive docs
+
+- Use them for background, rationale, and change history.
+- Do not treat them as authoritative setup or behavior docs without checking the active guides first.
+- If an archive document is still useful, active documentation should link to it explicitly and explain why it still matters.
+
+## Current source-of-truth entrypoints
+
+Use these first before opening anything in the archive:
+
+- [../README.md](../README.md)
+- [../ARCHITECTURE.md](../ARCHITECTURE.md)
+- [../backend/README.md](../backend/README.md)
+- [../frontend/README.md](../frontend/README.md)
+- [../../uah-browser-extension/README.md](../../uah-browser-extension/README.md)
+- [../beta-prep/BETA_SETUP.md](../beta-prep/BETA_SETUP.md)
+- [../beta-prep/SECURITY_CHECKLIST.md](../beta-prep/SECURITY_CHECKLIST.md)

--- a/docs/archive/backend/EMAIL_FIRST_IDENTITY_AUTOFILL_RESET_IMPLEMENTATION_2026-04-11.md
+++ b/docs/archive/backend/EMAIL_FIRST_IDENTITY_AUTOFILL_RESET_IMPLEMENTATION_2026-04-11.md
@@ -1,3 +1,13 @@
+# Historical Snapshot: Email-First Identity + Autofill Scope Reset (2026-04-11)
+
+This document is an archival implementation note. It explains a specific migration window and should not be treated as the current setup guide.
+
+For current behavior, use:
+
+- [../../backend/README.md](../../backend/README.md)
+- [../../ARCHITECTURE.md](../../ARCHITECTURE.md)
+- [../../../uah-browser-extension/README.md](../../../uah-browser-extension/README.md)
+
 # Email-First Identity + Autofill Scope Reset (2026-04-11)
 
 ## What Changed

--- a/docs/archive/backend/ENDPOINT_UTILIZATION_AUDIT_2026-04-11.md
+++ b/docs/archive/backend/ENDPOINT_UTILIZATION_AUDIT_2026-04-11.md
@@ -1,3 +1,13 @@
+# Historical Snapshot: Endpoint Utilization Audit (Active Runtime Scope)
+
+This audit captured route usage on 2026-04-11. It is preserved for historical context and should not be treated as the current product roadmap or API usage matrix.
+
+Use these active docs first:
+
+- [../../backend/README.md](../../backend/README.md)
+- [../../frontend/README.md](../../frontend/README.md)
+- [../../ARCHITECTURE.md](../../ARCHITECTURE.md)
+
 # Endpoint Utilization Audit (Active Runtime Scope)
 
 Date: 2026-04-11
@@ -249,6 +259,6 @@ Scope rules applied:
 
 ## Evidence Notes
 
-- Backend inventory source: `docs/backend/endpoint_inventory_backend.tsv`.
-- Frontend active-call inventory source: `docs/backend/endpoint_inventory_frontend_calls.tsv`.
+- Backend inventory source: `docs/archive/backend/endpoint_inventory_backend.tsv`.
+- Frontend active-call inventory source: `docs/archive/backend/endpoint_inventory_frontend_calls.tsv`.
 - Active runtime route scope source: `frontend/src/router/index.js`.

--- a/docs/archive/backend/GOOGLE_OAUTH_CONNECTED_ACCOUNTS_IMPLEMENTATION_2026-04-11.md
+++ b/docs/archive/backend/GOOGLE_OAUTH_CONNECTED_ACCOUNTS_IMPLEMENTATION_2026-04-11.md
@@ -1,3 +1,13 @@
+# Historical Snapshot: Google OAuth + Connected Accounts Implementation (2026-04-11)
+
+This document is an archival implementation note tied to a specific change window.
+
+Use these active docs for current behavior:
+
+- [../../backend/README.md](../../backend/README.md)
+- [../../frontend/README.md](../../frontend/README.md)
+- [../../../uah-browser-extension/README.md](../../../uah-browser-extension/README.md)
+
 # Google OAuth + Connected Accounts Implementation (2026-04-11)
 
 ## Scope Implemented

--- a/docs/archive/beta-prep/AUDIT.md
+++ b/docs/archive/beta-prep/AUDIT.md
@@ -1,3 +1,13 @@
+# Historical Snapshot: UAH Codebase Security & Production-Readiness Audit
+
+This document is an archival audit snapshot. It captures findings at the time it was written, not guaranteed current behavior.
+
+Use these active docs for the current beta posture:
+
+- [../../beta-prep/BETA_SETUP.md](../../beta-prep/BETA_SETUP.md)
+- [../../beta-prep/SECURITY_CHECKLIST.md](../../beta-prep/SECURITY_CHECKLIST.md)
+- [../../SECURITY_AUDIT_GUIDE.md](../../SECURITY_AUDIT_GUIDE.md)
+
 # UAH Codebase Security & Production-Readiness Audit
 
 **Branch audited:** `dev`  

--- a/docs/archive/beta-prep/CODE_CHANGES.md
+++ b/docs/archive/beta-prep/CODE_CHANGES.md
@@ -1,3 +1,12 @@
+# Historical Snapshot: Beta Environment — Required Code Changes
+
+This document is preserved as a point-in-time implementation delta list from an earlier beta planning pass.
+
+It should not be treated as the current beta setup guide. Use these active docs instead:
+
+- [../../beta-prep/BETA_SETUP.md](../../beta-prep/BETA_SETUP.md)
+- [../../beta-prep/SECURITY_CHECKLIST.md](../../beta-prep/SECURITY_CHECKLIST.md)
+
 # Beta Environment — Required Code Changes
 
 This document lists every specific file and change needed to support the beta deployment at `beta.uahapp.com`. Items are grouped by category. Changes that apply to a new `docker-compose.beta.yml` file are described as additions, not modifications to the existing dev file.

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -1,357 +1,259 @@
-# UAH Backend - Local Development Guide
+# Backend Development Guide
 
-This guide explains how to run the FastAPI backend locally for testing purposes on your own machine. We use `docker-compose.local.yml` for a localhost-only database and optional localhost-only backend profile, then run either host `uvicorn` or backend passthrough mode for frontend integration.
+This is the current source of truth for running the FastAPI backend locally.
 
-**Note:** This setup will run the database on your local machine and will not touch or break the dev server infrastructure.
+Use it when you need:
 
-## Choose Your Local Mode
+- a host-run backend with a local Postgres container
+- a localhost-only Docker backend for frontend integration
+- queue-enabled local parsing and job-sync testing
 
-Use one of these paths depending on what you are testing:
+For repo-wide context, start with [../README.md](../README.md) and [../ARCHITECTURE.md](../ARCHITECTURE.md).
 
-- Host Development (recommended): database in `docker-compose.local.yml`, backend via `uvicorn`, frontend via `npm run dev:backend`.
-- Backend Compose Profile (optional): database + backend via `docker-compose.local.yml --profile backend`, frontend via `npm run dev:backend`.
-- Full Docker Dev Stack: all services via `docker-compose.yml` for VPN-networked dev environment behavior.
+## Choose A Local Mode
 
-This document is the source of truth for Host Development and is intentionally isolated from the remote dev and beta deployment workflows.
+| Mode | When to use it | Command surface |
+| --- | --- | --- |
+| Host-run backend | Best for backend iteration, debugging, and normal local API work | Python venv + `uvicorn` |
+| Compose backend profile | Best when you want a full localhost-only backend container | `docker-compose.local.yml --profile backend` |
+| Full dev stack | Best when you need the deployed dev shape | `docker-compose.yml` and `scripts/uah.sh` |
 
 ## Prerequisites
-- [Docker](https://www.docker.com/) installed and running.
-- [Python 3.10-3.13](https://www.python.org/downloads/) installed.
-- Optional for full local UI flow: [Node.js 20+](https://nodejs.org/).
 
-## Required Environment Variables for Local Backend
+- Docker running locally
+- Python 3.10-3.13
+- Node.js 20+ if you also want the frontend
+- A real repo-root `.env`
 
-The backend validates required secrets on startup. Set these before launching `uvicorn`:
+Runtime env files always live at the repository root as `.env`. Do not point the application directly at files in `env-examples/`.
+
+## Required Env For Startup
+
+At minimum, the backend must have:
 
 - `POSTGRES_PASSWORD`
 - `SECRET_KEY`
 - `SESSION_SECRET`
-- `POSTGRES_HOST=localhost` (required for host-run backend with local DB container)
+- `POSTGRES_HOST=localhost` for host-run backend with the local DB container
 
-Recommended: load these from the repository root `.env` file instead of typing placeholder values manually.
+Helpful related docs:
 
-### Optional: Dev Test Account Bootstrap
+- [../SERVER_ENV_CHECKLIST.md](../SERVER_ENV_CHECKLIST.md)
+- [../env-examples/README.md](../env-examples/README.md)
+- [../../env-examples/local/.env.example](../../env-examples/local/.env.example)
 
-The backend supports a dev/local-only seeded test account via env flags:
+### Identity compatibility notes
 
-- `DEV_AUTH_TEST_ACCOUNT_ENABLED`
-- `DEV_AUTH_TEST_PASSWORD`
-- `DEV_AUTH_TEST_EMAIL`
-- `DEV_AUTH_TEST_USERNAME` (legacy fallback only)
-- `DEV_AUTH_TEST_FIRST_NAME`
-- `DEV_AUTH_TEST_LAST_NAME`
-- `DEV_AUTH_TEST_IS_ADMIN`
-- `DEV_AUTH_TEST_ROTATE_PASSWORD`
+The backend is email-first today, but a few compatibility surfaces still exist:
 
-Behavior:
+- `username` remains in the schema and database as a compatibility mirror of email.
+- `DEV_AUTH_TEST_USERNAME` is legacy fallback only and should contain an email value if used.
+- `/api/account/change-username` is retained as a compatibility endpoint and returns `410 Gone`.
 
-- If `DEV_AUTH_TEST_ACCOUNT_ENABLED=true`, email and password must be set.
-- `DEV_AUTH_TEST_USERNAME` remains accepted as a temporary compatibility fallback identifier but should be treated as an email value.
-- This feature is blocked in beta/prod and should remain disabled there.
+## Option 1: Host-Run Backend
 
-You can generate secrets with:
+### 1. Start the local database
 
-```bash
-python -c "import secrets; print(secrets.token_hex(32))"
-```
-
-## Step 1: Start the Local Database
-
-From the **root of the repository** (where the `docker-compose.local.yml` file is located), start the PostgreSQL container:
+From the repo root:
 
 ```bash
 docker compose -f docker-compose.local.yml up -d db-local
 ```
 
-This will automatically create a database container running on `localhost:5432` with the correct default user, password, and database variables.
+### 2. Create and activate a virtual environment
 
-Optional: run local backend in Docker as well (still localhost-only):
+Windows PowerShell:
 
-```bash
-docker compose -f docker-compose.local.yml --profile backend up -d db-local backend-local
-```
-
-## Step 2: Set Up Python Virtual Environment
-
-Navigate into the `backend/` directory from a terminal and create a virtual environment:
-
-### On Windows (PowerShell/CMD):
 ```powershell
 cd backend
 py -3.12 -m venv venv
 .\venv\Scripts\activate
 python -V
-python -c "import sys; print(sys.executable)"
 pip -V
 ```
 
-If Python 3.12 is not installed, use Python 3.13 instead:
+macOS / Linux:
 
-```powershell
-py -3.13 -m venv venv
-```
-
-Important checks on Windows:
-
-- `pip -V` must point inside `...\\UAH\\backend\\venv\\...`
-- If `pip -V` points to a global Python path (for example Python 3.14 under AppData), venv activation did not apply correctly
-
-### On Mac/Linux:
 ```bash
 cd backend
 python3 -m venv venv
 source venv/bin/activate
 ```
 
-## Step 3: Install Dependencies
+### 3. Install dependencies
 
-With the virtual environment activated, install the backend libraries:
 ```bash
 python -m pip install -r requirements.txt
 ```
 
-## Step 3.5: Apply Migrations
+### 4. Load repo-root `.env` values
 
-The jobs aggregation backend now uses Alembic for the local jobs catalog tables instead of relying on startup `create_all()` behavior.
+Windows PowerShell example:
 
-Run migrations from `backend/` after installing dependencies:
+```powershell
+Get-Content ..\.env | ForEach-Object {
+  if ($_ -match '^\s*#' -or $_ -match '^\s*$') { return }
+  $parts = $_.Split('=', 2)
+  if ($parts.Count -eq 2) {
+    [Environment]::SetEnvironmentVariable($parts[0], $parts[1], 'Process')
+  }
+}
+$env:POSTGRES_HOST = "localhost"
+```
+
+macOS / Linux example:
+
+```bash
+export POSTGRES_HOST=localhost
+```
+
+Use your real `.env` values. Do not swap in placeholder strings from the example files.
+
+### 5. Apply migrations
 
 ```bash
 alembic upgrade head
 ```
 
-If you are using host-run backend development, make sure `POSTGRES_HOST=localhost` is set in the current shell before running Alembic so it targets your local Postgres container.
-
-## Step 4: Run the Backend
-
-Before running the FastAPI server, you need to map PostgreSQL's host to `localhost` so Python knows where to find the database container you started in Step 1.
-
-Important: `POSTGRES_HOST=db` is for backend running inside Docker compose. For this host-run guide, use `POSTGRES_HOST=localhost`.
-
-Recommended on Windows (loads real values from repository root `.env`):
-
-```powershell
-# Run from backend/
-Get-Content ..\.env | ForEach-Object {
-	if ($_ -match '^\s*#' -or $_ -match '^\s*$') { return }
-	$parts = $_.Split('=',2)
-	if ($parts.Count -eq 2) {
-		[Environment]::SetEnvironmentVariable($parts[0], $parts[1], 'Process')
-	}
-}
-$env:POSTGRES_HOST="localhost"
-python -m uvicorn app.main:app --reload
-```
-
-Do not use placeholder values like `"your-db-password"` or `"your-generated-secret"` for local startup. Use your actual `.env` values.
-
-### On Windows (PowerShell):
-```powershell
-$env:POSTGRES_HOST="localhost"
-python -m uvicorn app.main:app --reload
-```
-
-### On Mac/Linux:
-```bash
-POSTGRES_PASSWORD="<actual-password>" \
-SECRET_KEY="<actual-secret-key>" \
-SESSION_SECRET="<actual-session-secret>" \
-POSTGRES_HOST=localhost \
-python -m uvicorn app.main:app --reload
-```
-
-## Step 5: Test the API
-
-Open your browser and navigate to the Swagger UI:
-- **API Sandbox:** [http://localhost:8000/docs](http://localhost:8000/docs)
-- **Health:** [http://localhost:8000/api/health](http://localhost:8000/api/health)
-- **API Root:** [http://localhost:8000/api/](http://localhost:8000/api/)
-
-Optional frontend dev flow (separate terminal from repository `frontend/` directory):
+### 6. Run the backend
 
 ```bash
+python -m uvicorn app.main:app --reload
+```
+
+### 7. Smoke test the local API
+
+```text
+http://localhost:8000/api/
+http://localhost:8000/api/health
+http://localhost:8000/api/status
+http://localhost:8000/docs
+```
+
+Notes:
+
+- `/docs`, `/redoc`, and `/openapi.json` are enabled only in `development`, `dev`, or `local` environments.
+- `/api/diagnostics` is admin-gated even in local/dev-style environments.
+
+## Option 2: Compose Backend Profile
+
+This keeps the backend inside Docker but still binds only to localhost.
+
+From the repo root:
+
+```bash
+docker compose -f docker-compose.local.yml --profile backend up -d db-local backend-local
+```
+
+Default local bindings:
+
+- DB: `127.0.0.1:5432`
+- Backend: `127.0.0.1:8000`
+
+This mode is a good match for `frontend` backend passthrough mode:
+
+```bash
+cd frontend
 npm install
 npm run dev:backend
 ```
 
-Then open [http://localhost:5173](http://localhost:5173). The Vite dev server proxies `/api`, `/docs`, and `/openapi.json` to `http://localhost:8000`.
+## Optional: Queue And Job Sync
 
-If you want frontend-only renderability without backend dependency, use `npm run dev` instead (mock mode).
+Resume parsing and local job-sync maintenance can run with Redis and Celery.
 
-## Optional: Run Job Sync Worker And Scheduler
+### Host-run worker path
 
-The local jobs catalog is refreshed by Celery worker/beat processes backed by Redis.
-
-Host-run example:
+Terminal 1, from repo root:
 
 ```bash
-# terminal 1, from repo root
 docker compose -f docker-compose.local.yml --profile jobs up -d redis-local
+```
 
-# terminal 2, from backend/
+Terminal 2, from `backend/`:
+
+```bash
 set REDIS_URL=redis://localhost:6379/0
 celery -A app.worker worker --loglevel=info --concurrency=2
+```
 
-# terminal 3, from backend/
+Terminal 3, from `backend/`:
+
+```bash
 set REDIS_URL=redis://localhost:6379/0
 celery -A app.worker beat --loglevel=info --scheduler celery.beat.PersistentScheduler
 ```
 
-Compose-only local path:
+### Compose-only jobs path
 
 ```bash
 docker compose -f docker-compose.local.yml --profile jobs up -d db-local redis-local celery-worker-local celery-beat-local
 ```
 
-Key env vars for jobs sync:
+### Common queue-related env knobs
 
-- `THE_MUSE_API_KEY`
-- `THE_MUSE_RATE_LIMIT_PER_HOUR`
-- `JOBS_URL_VALIDATION_ENABLED`
-- `JOBS_URL_VALIDATION_TIMEOUT_SECONDS`
-- `JOB_LINK_RECHECK_HOURS`
-- `JOB_SYNC_STALE_THRESHOLD_HOURS`
-- `JOB_SYNC_SOFT_DELETE_MISSES`
-- `JOB_SYNC_HARD_PURGE_DAYS`
-- `JOB_LINK_BACKFILL_BATCH_SIZE`
-- `JOB_LINK_BACKFILL_INTERVAL_SECONDS`
-- `JOB_COUNTRY_BACKFILL_BATCH_SIZE`
-- `JOB_COUNTRY_BACKFILL_INTERVAL_SECONDS`
-- `JOB_STALE_AUDIT_AGE_DAYS`
-- `JOB_STALE_AUDIT_ESCALATION_DAYS`
-- `JOB_STALE_AUDIT_BATCH_SIZE`
-- `JOB_STALE_AUDIT_INTERVAL_SECONDS`
-- `JOB_SYNC_CATEGORY_SCHEDULE_JSON`
+- `REDIS_ENABLED`
+- `REDIS_URL`
+- `PARSE_QUEUE_NAME*`
+- `PARSE_QUEUE_MAX_RETRIES*`
+- `PARSE_QUEUE_CONCURRENCY_*`
+- `JOB_SYNC_*`
+- `JOB_LINK_*`
+- `JOB_COUNTRY_BACKFILL_*`
 
-## Teardown
+See [../SERVER_ENV_CHECKLIST.md](../SERVER_ENV_CHECKLIST.md) for the categorized checklist.
 
-To shut down the backend, press `Ctrl + C` in the terminal where `uvicorn` is running.
+## Local Frontend Integration
 
-To shut down the local database:
-```bash
-# From the root of the repository
-docker compose -f docker-compose.local.yml down
-```
-
-## Full Docker Dev Stack (non-host mode)
-
-If you need to mirror the shared dev infrastructure behavior instead of host-run debugging, use `docker-compose.yml` from the repository root:
+When the backend is up locally:
 
 ```bash
-docker compose up -d --build
+cd frontend
+npm run dev:backend
 ```
 
-This mode expects the existing shared dev networking assumptions (including external infrastructure such as the VPN container). It is separate from the host-run local flow above.
+That Vite mode proxies:
 
-## Email Verification / Password Reset (Google Workspace)
+- `/api`
+- `/docs`
+- `/openapi.json`
 
-Right now, the API endpoints for email verification and password reset generate JWT tokens.
-
-- If `EMAILS_ENABLED=false`, the backend returns the token in the API response ("dev only") so you can test locally.
-- If `EMAILS_ENABLED=true`, the backend will email the token using SMTP.
-
-Dev token endpoints:
-
-- Password reset token: `POST /api/account/forgot-password`
-- Email verification token (authenticated): `POST /api/account/send-verification`
-
-### Option A (simplest): Gmail SMTP with an App Password
-
-1. Pick a real mailbox like `noreply@uahapp.com` (or `security@uahapp.com`).
-2. Enable 2‑Step Verification on that mailbox.
-3. Create an App Password (Google Account → Security → App passwords).
-4. Set these env vars for the backend:
-
-```powershell
-$env:EMAILS_ENABLED="true"
-$env:PUBLIC_APP_URL="https://uahapp.com"
-
-$env:SMTP_HOST="smtp.gmail.com"
-$env:SMTP_PORT="587"
-$env:SMTP_USE_TLS="true"
-$env:SMTP_USERNAME="noreply@uahapp.com"
-$env:SMTP_PASSWORD="<APP_PASSWORD>"
-$env:SMTP_FROM="UAH <noreply@uahapp.com>"
-```
-
-### Option B (production-friendly): Google Workspace SMTP relay
-
-If you don’t want to store a mailbox password on the server, set up an SMTP relay in Google Admin:
-
-- Admin console → Apps → Google Workspace → Gmail → Routing → SMTP relay service
-- Allow your backend server IP(s) to relay
-- Require TLS
-- Restrict sender domain to `uahapp.com`
-
-Then configure the backend with `SMTP_HOST="smtp-relay.gmail.com"` (port 587) and either:
-- no auth (IP allowlist), or
-- SMTP auth (depending on your relay configuration)
-
-### Deliverability (recommended)
-
-For best results, ensure your DNS has:
-- SPF including Google (`include:_spf.google.com`)
-- DKIM enabled in Google Admin and published to DNS
-- A basic DMARC record
+to the configured local backend origin. In plain mock mode (`npm run dev`), the frontend does not require the backend.
 
 ## Troubleshooting
 
-### Error: `[Errno 13] Permission denied: ...\\venv\\Scripts\\python.exe` or `[WinError 5] Access is denied`
+### Virtualenv activation did not apply on Windows
 
-This means files in `backend/venv` are locked by a running Python/Uvicorn process (or another tool scanning loaded `.pyd` files).
+Symptoms:
 
-Fix (fastest on Windows):
-
-1. Stop running backend processes (`Ctrl+C` in backend terminals).
-2. Create a fresh virtual environment in a new folder and use that instead of the locked one:
-
-```powershell
-cd backend
-py -3.12 -m venv .venv312
-.\.venv312\Scripts\Activate.ps1
-python -m pip install -r requirements.txt
-```
-
-Then run backend with the same environment-loading flow shown above.
-
-Optional cleanup later (when no process holds locks): remove old `venv`.
-
-### Error: `sqlalchemy.exc.OperationalError` / `password authentication failed for user "uah"`
-
-This means your running local Postgres volume has a different password than the one your backend is using.
-
-Fix (keeps current local volume data):
-
-1. Confirm your intended password in repository root `.env` (`POSTGRES_PASSWORD`).
-2. Update the DB role password inside the local container:
-
-```powershell
-docker exec uah-local-db psql -U uah -d uah_dev -c "ALTER USER uah WITH PASSWORD '<POSTGRES_PASSWORD from .env>';"
-```
-
-Alternative (fresh local DB):
-
-```powershell
-docker compose -f docker-compose.local.yml down
-docker compose -f docker-compose.local.yml up -d
-```
-
-### Error: `ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'`
-
-This usually means the local venv is using an unsupported Python interpreter version for pinned dependency wheels (commonly Python 3.14).
+- `pip -V` points outside `backend/venv`
+- `python` resolves to a global interpreter
 
 Fix:
 
-1. Stop `uvicorn`.
-2. Remove the local venv.
-3. Recreate it with Python 3.13 (or 3.12) and reinstall dependencies.
+- reactivate the venv
+- verify `python -V`, `python -c "import sys; print(sys.executable)"`, and `pip -V`
 
-Windows example:
+### Database auth failures
 
-```powershell
-deactivate
-Remove-Item -Recurse -Force .\venv
-py -3.12 -m venv venv
-.\venv\Scripts\activate
-python -m pip install -r requirements.txt
-```
+Check:
+
+- repo-root `.env` contains the expected DB password
+- `POSTGRES_HOST=localhost` is set for the host-run path
+- the `db-local` container is healthy
+
+### Docs routes missing
+
+Check `ENVIRONMENT`. API docs are intentionally disabled outside `development`, `dev`, or `local`.
+
+### Diagnostics returns 401/403
+
+That is expected for non-admin sessions. `/api/status` is the public health-style route; `/api/diagnostics` is an admin-only troubleshooting surface.
+
+## Related Docs
+
+- Repo entrypoint: [../../README.md](../../README.md)
+- Architecture: [../ARCHITECTURE.md](../ARCHITECTURE.md)
+- Frontend guide: [../frontend/README.md](../frontend/README.md)
+- Extension guide: [../../uah-browser-extension/README.md](../../uah-browser-extension/README.md)
+- Historical backend implementation snapshots: [../archive/README.md](../archive/README.md)

--- a/docs/beta-prep/BETA_SETUP.md
+++ b/docs/beta-prep/BETA_SETUP.md
@@ -1,244 +1,122 @@
-# Beta Environment Setup Guide
+# Beta Setup Guide
 
-**Target domain:** `beta.uahapp.com`  
-**Based on:** `dev` branch  
-**For:** Team members with legitimate deploy access
+This guide describes the current repo-managed beta environment shape.
 
----
+Use it together with:
 
-## Overview
+- [SECURITY_CHECKLIST.md](SECURITY_CHECKLIST.md)
+- [CLOUDFLARE_SECURITY.md](CLOUDFLARE_SECURITY.md)
+- [../env-examples/README.md](../env-examples/README.md)
 
-This guide covers everything needed to configure and deploy the UAH application on `beta.uahapp.com`. The beta deployment is Cloudflare-proxied (no VPN required) and targets semi-public access for approved testers and graders.
+Historical beta audit notes live in [../archive/README.md](../archive/README.md).
 
-Before following this guide, ensure you have:
+## Current Beta Shape
 
-- SSH access to the beta server host
-- Access to the team's secret management tool (for `.env` values)
-- Google Cloud Console access (for OAuth callback URI updates)
-- Cloudflare access for the `uahapp.com` zone
+- base compose file: `docker-compose.yml`
+- beta override: `docker-compose.beta.yml`
+- environment template: `env-examples/beta/.env.example`
+- ingress pattern: `cloudflared` tunnel container
+- backend environment label: `ENVIRONMENT=beta`
+- cookie / storage namespace: beta-specific
 
----
+## 1. Prepare The Beta `.env`
 
-## Part 1 — Domain and Routing
+On the beta deployment host, create a real repo-root `.env` from:
 
-### 1.1 Current dev.uahapp.com References That Need Updating
-
-Every occurrence of `dev.uahapp.com` in the codebase is driven by environment variables. **No source code changes are needed** to switch from dev to beta — only `.env` values must change.
-
-The following table maps each occurrence to the env var that controls it:
-
-| File | Variable | Current dev value | Beta value |
-|------|----------|------------------|------------|
-| `.env` | `DEV_DOMAIN` | `dev.uahapp.com` | `beta.uahapp.com` |
-| `.env` | `GOOGLE_REDIRECT_URI` | `https://dev.uahapp.com/api/auth/google/callback` | `https://beta.uahapp.com/api/auth/google/callback` |
-| `.env` | `PUBLIC_APP_URL` | `https://dev.uahapp.com` | `https://beta.uahapp.com` |
-| `.env` | `COMPOSE_PROJECT_NAME` | `uah-dev` | `uah-beta` |
-
-### 1.2 Where Nginx Uses the Domain
-
-The `docker-compose.yml` passes `DEV_DOMAIN` into the frontend container. The Nginx container startup script (`docker-entrypoint.d/10-select-nginx-config.sh`) uses this variable to substitute the `__DOMAIN__` placeholder in the Nginx config template.
-
-When `DEV_DOMAIN=beta.uahapp.com`, Nginx will serve the `server_name beta.uahapp.com;` block correctly.
-
-### 1.3 OAuth Callback URIs — External Service Updates
-
-When the beta environment is ready, update the following external services before going live:
-
-**Google Cloud Console:**
-
-1. Go to the project in [console.cloud.google.com](https://console.cloud.google.com)
-2. Navigate to **APIs & Services → Credentials → OAuth 2.0 Client IDs**
-3. Edit the client used by UAH
-4. Under **Authorized redirect URIs**, add: `https://beta.uahapp.com/api/auth/google/callback`
-5. You may leave `https://dev.uahapp.com/api/auth/google/callback` in place so dev continues to work
-
-**Note:** The `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` values can be the same for dev and beta if they are part of the same Google Cloud project. The redirect URI is what differentiates the environments.
-
----
-
-## Part 2 — Environment Variables
-
-### 2.1 Creating the Beta .env File
-
-On the beta server, create `/srv/uah/environments/beta/.env` using `env-examples/beta/.env.example` as the template.
-
-Important: runtime expects `.env` in the deployment root (`/srv/uah/environments/beta/.env`), not inside `env-examples/`.
-
-**Variables that differ between dev and beta:**
-
-| Variable | dev value | beta value | Notes |
-|----------|----------|-----------|-------|
-| `COMPOSE_PROJECT_NAME` | `uah-dev` | `uah-beta` | Prevents container name conflicts |
-| `ENV` | `dev` | `beta` | Environment label used in logs |
-| `ENVIRONMENT` | `development` | `production` | Controls debug mode in backend |
-| `DEV_DOMAIN` | `dev.uahapp.com` | `beta.uahapp.com` | Used by Nginx server_name |
-| `POSTGRES_DB` | `uah_dev` | `uah_beta` | Separate database from dev |
-| `POSTGRES_PASSWORD` | (dev password) | (beta-specific strong secret) | Must be different from dev |
-| `SECRET_KEY` | (dev secret) | (beta-specific strong secret) | Must be different from dev |
-| `SESSION_SECRET` | (dev secret) | (beta-specific strong secret) | Must be different from dev |
-| `GOOGLE_REDIRECT_URI` | `https://dev.uahapp.com/api/auth/google/callback` | `https://beta.uahapp.com/api/auth/google/callback` | Must be registered in GCP |
-| `PUBLIC_APP_URL` | `https://dev.uahapp.com` | `https://beta.uahapp.com` | Used in email links |
-| `EMAILS_ENABLED` | `false` | `true` | Enable real email sending |
-| `BETA_REDIS_HOST_PORT` | n/a | `6380` | Prevents localhost Redis port collisions when dev and beta run together |
-| `BETA_REDIS_URL` | n/a | `redis://uah-beta-redis:6379/0` | Pins beta backend to the beta Redis container |
-| `BETA_PARSE_QUEUE_NAME*` | n/a | `uah:beta:parse_jobs*` | Keeps beta queue keys isolated from dev |
-| `ADMIN_BOOTSTRAP_ENABLED` | `false` | `false` | Keep disabled unless you need to create an admin |
-| `DEV_TLS_ENABLED` | `false` | `false` | TLS is handled by Cloudflare, not the container |
-
-**Variables that should be the same or equivalent:**
-
-- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` — same GCP project, unless you create a separate beta OAuth client
-- `ZAI_API_KEY` — reuse dev key or provision a separate key depending on usage/quota
-- `SMTP_*` — same SMTP provider, sender address should be `noreply@uahapp.com`
-
-If you are running dev and beta from the same checkout on one host, keep `REDIS_HOST_PORT=6379` for dev and set `BETA_REDIS_HOST_PORT=6380` for beta.
-
-### 2.2 Variables That Must Never Be Committed
-
-The following variables must **never** appear in any committed file (including example files):
-
-- `POSTGRES_PASSWORD`
-- `SECRET_KEY`
-- `SESSION_SECRET`
-- `GOOGLE_CLIENT_SECRET`
-- `ZAI_API_KEY`
-- `SMTP_PASSWORD`
-- `IPSTACK_API_KEY`
-- `ADMIN_BOOTSTRAP_PASSWORD`
-
-The `env-examples/beta/.env.example` file uses placeholder values for all of these.
-
----
-
-## Part 3 — Beta Docker Compose Changes
-
-### 3.1 Overview of Changes Needed
-
-The existing `docker-compose.yml` is designed for the dev VPN deployment. For beta, the following changes are required:
-
-| Change | Reason |
-|--------|--------|
-| Remove `./backend:/app` volume mount | Hot-reload source mount is a dev-only feature |
-| Remove `--reload` from backend Dockerfile CMD (or override in compose) | Hot-reload should not run in production |
-| Change `network_mode: "container:uah-dev-vpn"` | Beta uses Cloudflare, not a VPN container |
-| Add `ports:` mapping for Nginx | With no VPN container, frontend needs a host port |
-| Update container names to `uah-beta-*` | Avoids conflicts with dev containers on same host |
-| Add `mem_limit` and `cpus` resource limits | Prevent resource exhaustion |
-| Update `COMPOSE_PROJECT_NAME` to `uah-beta` | Consistent naming |
-
-### 3.2 Beta-Specific Compose Behavior
-
-For beta, the frontend container should **not** use `network_mode: "container:uah-dev-vpn"`. Instead, it should expose a port on the host (e.g., `80:80`) so that Cloudflare's reverse proxy can reach it. Cloudflare handles TLS termination, so the Nginx container only needs to serve HTTP on port 80. The origin firewall (iptables/ufw) ensures only Cloudflare IP ranges can reach that port.
-
-See `CODE_CHANGES.md` for the exact compose diff.
-
-### 3.3 Backend Dockerfile for Beta
-
-The backend Dockerfile currently uses `CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]`.
-
-For beta, override this in `docker-compose.yml` using the `command:` key to remove `--reload`:
-
-```yaml
-backend:
-  command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+```text
+env-examples/beta/.env.example
 ```
 
-Do not modify the `dev` Dockerfile directly — use the compose override so the dev environment is not affected.
+Key beta identity settings:
 
-### 3.4 Ports That Must Not Be Exposed
+- `ENV=beta`
+- `ENVIRONMENT=beta`
+- `COMPOSE_PROJECT_NAME=uah-beta`
+- `AUTH_NAMESPACE=beta`
+- `AUTH_COOKIE_NAME=uah_auth_beta`
+- `SESSION_COOKIE_NAME=uah_session_beta`
+- `PUBLIC_APP_URL=https://beta.uahapp.com`
+- `GOOGLE_REDIRECT_URI=https://beta.uahapp.com/api/auth/google/callback`
+- `GMAIL_REDIRECT_URI=https://beta.uahapp.com/api/integrations/gmail/callback`
+- `CLOUDFLARE_BETA_TUNNEL_TOKEN=...`
 
-| Service | Port | Must expose? |
-|---------|------|-------------|
-| `db` (Postgres) | 5432 | ❌ Never — internal only |
-| `backend` (FastAPI) | 8000 | ❌ Never — proxied by Nginx |
-| `frontend` (Nginx) | 80 | ✅ Yes — to host, for Cloudflare proxy |
-| `frontend` (Nginx) | 443 | ❌ No — TLS handled by Cloudflare |
+Beta should also use isolated Redis and queue namespaces:
 
-The host machine's firewall (see `CLOUDFLARE_SECURITY.md`) must ensure that port 80 is only reachable from Cloudflare IP ranges.
+- `BETA_REDIS_URL`
+- `BETA_PARSE_QUEUE_NAME*`
+- `BETA_REDIS_HOST_PORT`
 
----
+## 2. Confirm Required External Networks
 
-## Part 4 — Branch Strategy
+The current beta override expects these Docker networks to exist:
 
-### 4.1 Beta Branch Rules
+- `uah-infra`
+- `uah-beta-infra`
 
-The `beta` branch does not exist yet. When the team is ready to create it, follow these steps:
+If they do not exist on the target host yet, create them before startup.
 
-1. Create `beta` from the current `dev` branch:
-   ```
-   git checkout dev
-   git checkout -b beta
-   git push origin beta
-   ```
+## 3. Start The Stack
 
-2. In GitHub repository settings → **Branches** → **Add branch protection rule**:
-   - Branch name pattern: `beta`
-   - ✅ **Require a pull request before merging**
-   - ✅ **Require approvals** (at least 1)
-   - ✅ **Restrict pushes that create matching branches** — allow only UAHTEAM
-   - ✅ **Do not allow bypassing the above settings**
+From the repo root on the beta host:
 
-3. Only UAHTEAM members may push to `beta`. All changes must come via pull request from `dev`.
-
-4. No direct commits to `beta` are permitted, even from team leads.
-
-### 4.2 Merge Workflow
-
-```
-feature/* → dev (via PR)
-dev → beta (via PR, reviewed by team lead)
-beta → prod (via PR, full review + sign-off)
+```bash
+docker compose -f docker-compose.yml -f docker-compose.beta.yml up -d --build
 ```
 
-### 4.3 Keeping Beta in Sync with Dev
+This launches the normal app stack plus beta overrides, including the `cloudflared` service.
 
-After each sprint, open a pull request from `dev` into `beta`. Code review should focus on:
+## 4. Verify The Expected Containers
 
-- Any new endpoints being added to the unauthenticated list
-- Any new environment-specific values being hardcoded
-- Any dependency version changes
+The beta stack should include environment-scoped names such as:
 
----
+- `uah-beta-db`
+- `uah-beta-backend`
+- `uah-beta-frontend`
+- `uah-beta-redis`
+- `uah-beta-celery-worker`
+- `uah-beta-celery-beat`
+- `uah-beta-cloudflared`
 
-## Part 5 — Beta Deployment Steps (Checklist)
+## 5. Current Runtime Expectations
 
-Follow these steps in order when deploying to beta for the first time.
+These are current behavior notes, not future aspirations:
 
-### Pre-deployment
+- generated API docs should be disabled because `ENVIRONMENT=beta`
+- `/api/diagnostics` remains admin-gated
+- saved jobs routes are authenticated
+- the beta override currently still bind-mounts `./backend:/app`
+- the frontend joins the `cloudflared` service network namespace instead of publishing a public host port directly
 
-- [ ] Create the `beta` branch in GitHub and set branch protection rules (see §4.1)
-- [ ] Provision the beta server host (separate VM or separate directory on the same host as dev)
-- [ ] Create DNS record: `beta.uahapp.com → [origin server IP]`, proxied through Cloudflare (orange cloud)
-- [ ] Configure Cloudflare Access policy for `beta.uahapp.com` (see `CLOUDFLARE_SECURITY.md`)
-- [ ] Configure origin firewall to only accept traffic from Cloudflare IP ranges (see `CLOUDFLARE_SECURITY.md`)
+That backend bind mount is important to understand before any broader external rollout. It is current behavior and should be reviewed explicitly during beta hardening.
 
-### Environment Configuration
+## 6. OAuth And Email Checks
 
-- [ ] Create `/srv/uah/environments/beta/` directory on the server
-- [ ] Copy `env-examples/beta/.env.example` to `/srv/uah/environments/beta/.env` and fill in all secrets
-- [ ] Verify `.env` file is not world-readable (`chmod 600 .env`)
-- [ ] Confirm all required variables are set (none are empty)
+Before inviting testers:
 
-### Docker Deployment
+- register the beta Google OAuth callback URI
+- register the beta Gmail callback URI if Gmail integration is enabled
+- confirm `EMAILS_ENABLED=true` and working SMTP or relay settings
+- verify that reset and verification links point at `https://beta.uahapp.com`
 
-- [ ] Clone or copy the repository to the beta deployment directory
-- [ ] Ensure the external `uah-infra` Docker network exists on the host (`docker network create uah-infra`)
-- [ ] Run `docker compose up -d --build` from the beta deployment directory
-- [ ] Verify all containers start without errors (`docker compose logs`)
-- [ ] Verify the health check passes (`docker compose ps`)
+## 7. Recommended Validation
 
-### Verification
+```bash
+bash scripts/uah.sh beta audit --mode full --json
+```
 
-- [ ] Access `https://beta.uahapp.com` via Cloudflare Access (confirm gating works)
-- [ ] Log in with a test account and confirm OAuth flow completes
-- [ ] Confirm email sending works (trigger a verification or password reset)
-- [ ] Confirm `/api/health` returns `{"status": "healthy"}`
-- [ ] Confirm `/api/diagnostics` is **not** accessible (returns 404 or 401 depending on the fix applied)
-- [ ] Confirm `/docs` and `/redoc` are **not** accessible
-- [ ] Complete the full demo flow end-to-end
+Then manually confirm:
 
----
+- tunnel connectivity
+- login
+- register / verify-email flows
+- password reset
+- job search
+- resume upload / parse
+- any enabled extension flow against the beta origin
 
-## Appendix: Beta Env Example Template
+## Related Docs
 
-See the file at `env-examples/beta/.env.example` for the complete annotated environment variable template for the beta deployment.
+- [SECURITY_CHECKLIST.md](SECURITY_CHECKLIST.md)
+- [CLOUDFLARE_SECURITY.md](CLOUDFLARE_SECURITY.md)
+- [../../docker-compose.beta.yml](../../docker-compose.beta.yml)
+- [../../env-examples/beta/.env.example](../../env-examples/beta/.env.example)

--- a/docs/beta-prep/CLOUDFLARE_SECURITY.md
+++ b/docs/beta-prep/CLOUDFLARE_SECURITY.md
@@ -1,220 +1,47 @@
-# Cloudflare Security Configuration Guide
+# Cloudflare And Tunnel Notes For Beta
 
-**Domain:** `beta.uahapp.com`  
-**For:** Team members with Cloudflare access to the `uahapp.com` zone  
-**Intent:** This guide describes *what to configure and why* — not the specific conditions, IP ranges, or rule logic that would expose the security posture.
+This guide documents the current beta ingress posture at a high level.
 
----
+## Current Repo-Managed Shape
 
-## Overview
+The repository currently models beta ingress through a `cloudflared` tunnel container defined in `docker-compose.beta.yml`.
 
-All traffic to `beta.uahapp.com` must route through Cloudflare. The origin server is never exposed directly to the internet. Cloudflare provides:
+That means:
 
-- Reverse proxy and DDoS protection (orange-cloud proxy)
-- Zero Trust access control (authentication before the app is reached)
-- WAF (web application firewall) with managed rules
-- Rate limiting on sensitive endpoints
-- TLS termination and HTTPS enforcement
+- the beta frontend joins the `cloudflared` network namespace
+- the repo-managed beta path does not rely on publishing the frontend directly on a public host port
+- Cloudflare-side policy still matters, but part of the public-exposure story now lives in tunnel configuration instead of only origin firewall rules
 
----
+## What The Repo Can Prove
 
-## Section 1 — Cloudflare Proxy (Orange Cloud)
+The repository can help prove:
 
-### 1.1 Confirm the DNS Record Is Proxied
+- the beta override includes `cloudflared`
+- the tunnel token is expected in env
+- beta-specific hostnames and namespaces are configured
+- the app itself disables generated docs in `ENVIRONMENT=beta`
+- diagnostics stay admin-gated
 
-In the Cloudflare dashboard for `uahapp.com`:
+## What Still Needs Manual Operator Review
 
-1. Go to **DNS → Records**
-2. Find or create the A record for `beta.uahapp.com` pointing to the origin server IP
-3. The **Proxy status** column must show the orange cloud icon (Proxied), not the grey cloud (DNS only)
-4. If it is grey, click the record, toggle proxy to **Proxied**, and save
+The repo cannot fully prove these Cloudflare-side controls:
 
-All traffic to `beta.uahapp.com` will now route through Cloudflare's network. The origin server's IP address will not appear in DNS lookups for this subdomain.
+- Access / Zero Trust policy for who may enter beta
+- WAF rules and rate limits
+- DNS / hostname wiring in Cloudflare
+- tunnel ownership, routing, and service mapping
 
-### 1.2 Block Direct-to-Origin IP Access
+Those should be reviewed alongside the repo-managed audit before inviting external testers.
 
-Even with Cloudflare proxying active, an attacker who discovers the origin server IP can bypass Cloudflare by sending requests directly to that IP. To prevent this, configure the origin server's host firewall to only accept inbound HTTP/HTTPS traffic from Cloudflare's IP ranges.
+## Practical Review Items
 
-**How to do this:**
+- Confirm the hostname used by `PUBLIC_APP_URL` matches the Cloudflare-routed beta hostname.
+- Confirm the tunnel publishes the expected service only.
+- Confirm beta access control is intentional for the audience you are inviting.
+- Confirm Cloudflare-side rate limiting covers auth-sensitive routes.
 
-1. Retrieve the current list of Cloudflare's IP ranges from the official source:  
-   [https://www.cloudflare.com/ips/](https://www.cloudflare.com/ips/)  
-   Do not embed this list in this document or any configuration file — the list is maintained by Cloudflare and must be fetched fresh when applied.
+## Related Docs
 
-2. Update the host's firewall rules (iptables, ufw, or cloud security group) to:
-   - Allow inbound TCP on port 80 from Cloudflare IP ranges only
-   - Drop all other inbound TCP on port 80
-   - Keep port 22 (SSH) restricted to the team's management IP(s) — not from Cloudflare
-
-3. Confirm no other ports are accessible from the public internet. Specifically:
-   - Port 5432 (Postgres) — must be blocked
-   - Port 8000 (FastAPI backend) — must be blocked
-   - WireGuard port (if present from dev deployment) — must be blocked or restricted
-
-4. After applying firewall rules, test by attempting to access the origin IP directly on port 80 from an IP that is not in Cloudflare's range — the connection should be refused.
-
-### 1.3 Origin-Only Ports
-
-The only port that the public Cloudflare proxy touches on the origin is port 80. All other service ports (database, backend API) are internal to Docker and must never be exposed on the host.
-
----
-
-## Section 2 — Cloudflare Zero Trust Access Policy
-
-The Cloudflare Access policy sits in **front of the entire `beta.uahapp.com` subdomain**. Any visitor who navigates to any path on `beta.uahapp.com` will be intercepted by Cloudflare Access and must authenticate before they can reach the application at all.
-
-This is the same pattern used for the team's VPN portal.
-
-### 2.1 Create a Cloudflare Access Application
-
-1. In the Cloudflare dashboard, navigate to **Zero Trust → Access → Applications**
-2. Click **Add an application** → select **Self-hosted**
-3. Configure:
-   - **Application name:** UAH Beta
-   - **Application domain:** `beta.uahapp.com` (covers all paths)
-   - **Session duration:** Set to a value appropriate for a testing session (e.g., 24 hours)
-4. Click **Next**
-
-### 2.2 Create an Access Policy
-
-1. Name the policy (e.g., "Approved Testers")
-2. Set **Action** to **Allow**
-3. Under **Include**, select **Emails** as the rule type
-4. Enter the approved email addresses for testers, graders, and team members
-5. Do not document the approved email list in this guide or in any repository file
-6. Click **Save**
-
-The allowed authentication methods are configured under **Login methods** on the Access application. Enable **One-time PIN** (email-based) so approved users receive a PIN to their email address — no additional account creation required.
-
-### 2.3 Adding and Removing Approved Emails
-
-To **add** a tester:
-
-1. Go to **Zero Trust → Access → Applications → UAH Beta → Edit policy**
-2. Under **Include → Emails**, add the new email address
-3. Save the policy
-
-To **remove** a tester:
-
-1. Go to **Zero Trust → Access → Applications → UAH Beta → Edit policy**
-2. Under **Include → Emails**, remove the email address
-3. Save the policy
-4. If the person has an active session, go to **Zero Trust → Access → Active Sessions** and revoke their session
-
-### 2.4 Temporary Time-Limited Access
-
-For a testing session that should have a defined end time:
-
-1. Create a separate Access policy scoped to the testing period:
-   - Set the policy's **Session duration** to match the testing window
-   - Add the tester's email to this policy
-2. After the testing session ends, edit the policy to remove the email, or delete the temporary policy entirely
-3. Optionally, manually revoke any active sessions from **Zero Trust → Access → Active Sessions**
-
-Alternatively, use a **service token** for programmatic or automated testing:
-
-1. Go to **Zero Trust → Access → Service Tokens**
-2. Create a token with an explicit expiration
-3. Provide the token to the tester
-4. After the session, delete the service token — it will immediately invalidate access
-
-### 2.5 Confirming the Access Policy Is Active
-
-After configuring:
-
-1. Open a private/incognito browser window
-2. Navigate to `https://beta.uahapp.com`
-3. You should be redirected to the Cloudflare Access authentication page before seeing the app
-4. Complete authentication with an approved email — confirm access is granted
-5. Try with an unapproved email — confirm access is denied
-
----
-
-## Section 3 — WAF and Rate Limiting
-
-### 3.1 Enable the WAF Managed Ruleset
-
-1. In the Cloudflare dashboard, go to **Security → WAF**
-2. Under **Managed rules**, enable the **Cloudflare Managed Ruleset**
-3. Set the ruleset action to **Block** (not just Log) once you have confirmed it does not block legitimate traffic
-4. Enable the **Cloudflare OWASP Core Ruleset** as well, starting in **Log** mode before switching to **Block**
-
-**Recommendation:** Run the WAF in Log mode for the first 24–48 hours of beta and review the security events before switching to Block mode. This prevents false positives from blocking legitimate testers.
-
-### 3.2 Rate Limiting Rules
-
-Create rate limiting rules under **Security → WAF → Rate limiting rules** for the following endpoint groups:
-
-**Authentication endpoints** (`/api/auth/*`):
-- Intent: Prevent brute-force login and registration attempts
-- Set a threshold appropriate for normal human login behavior
-- Action: Block, with a duration that deters automated attempts without affecting real users
-
-**Password reset** (`/api/account/forgot-password`):
-- Intent: Prevent automated email flooding via the password reset flow
-- Set a low threshold — legitimate users rarely trigger this endpoint more than once per session
-- Action: Block
-
-**Email verification** (`/api/account/send-verification`):
-- Intent: Prevent email spam via the verification resend endpoint
-- Set a per-IP threshold similar to password reset
-- Action: Block
-
-Do not document specific threshold values (requests per second/minute) or the exact matching conditions in this guide.
-
-### 3.3 Bot Fight Mode
-
-1. Go to **Security → Bots**
-2. Enable **Bot Fight Mode**
-
-This blocks known bad bots from reaching the origin. Note that Cloudflare Access authentication already prevents most automated access, but Bot Fight Mode adds an additional layer before the Access gate.
-
----
-
-## Section 4 — SSL/TLS Configuration
-
-### 4.1 Set TLS Mode to Full (Strict)
-
-1. Go to **SSL/TLS → Overview**
-2. Set the encryption mode to **Full (strict)**
-
-Full (strict) requires that the origin server presents a valid certificate. Either:
-- Use a **Cloudflare Origin Certificate** (recommended — generated in the Cloudflare dashboard and trusted by Cloudflare's proxy) and configure the Nginx container to use it, or
-- Use a Let's Encrypt certificate on the origin
-
-With Full (strict), Cloudflare will not proxy traffic to an origin that presents an untrusted or self-signed certificate.
-
-**Note:** If using the current `DEV_TLS_ENABLED=false` config (Nginx serving plain HTTP), you must enable `DEV_TLS_ENABLED=true` and provision an origin certificate before switching to Full (strict). Alternatively, Cloudflare's **Full** mode (not strict) allows plain HTTP to the origin — but Full (strict) is the required setting for beta.
-
-### 4.2 Enable HSTS
-
-1. Go to **SSL/TLS → Edge Certificates**
-2. Under **HTTP Strict Transport Security (HSTS)**, click **Enable HSTS**
-3. Configure:
-   - **Max Age:** 6 months (15552000 seconds) or longer
-   - **Include subdomains:** Optional — only enable if all subdomains of `uahapp.com` serve HTTPS
-   - **Preload:** Only enable after the deployment has been stable for some time
-
-HSTS instructs browsers to always use HTTPS for this domain and refuse plaintext connections.
-
-### 4.3 Minimum TLS Version
-
-1. Go to **SSL/TLS → Edge Certificates**
-2. Under **Minimum TLS Version**, select **TLS 1.2**
-
-This ensures that older, insecure TLS versions (1.0, 1.1) are not negotiated with browsers.
-
----
-
-## What This Guide Intentionally Does Not Include
-
-This guide is written for developers with legitimate access. It intentionally omits the following to avoid creating an attack profile:
-
-- The origin server's IP address
-- The specific Cloudflare IP ranges to use in firewall rules (link provided instead)
-- The list of approved email addresses for the Access policy
-- Specific rate limit thresholds or request counts
-- Any conditions under which the Access policy can be bypassed
-- Any service token values or bypass headers
-
-If you need any of the above, they are stored in the team's secret manager, not in this repository.
+- [BETA_SETUP.md](BETA_SETUP.md)
+- [SECURITY_CHECKLIST.md](SECURITY_CHECKLIST.md)
+- [../SECURITY_AUDIT_GUIDE.md](../SECURITY_AUDIT_GUIDE.md)

--- a/docs/beta-prep/SECURITY_CHECKLIST.md
+++ b/docs/beta-prep/SECURITY_CHECKLIST.md
@@ -1,115 +1,64 @@
-# Beta Pre-Launch Security Checklist
+# Beta Security Checklist
 
-Track this checklist as a GitHub issue before sharing `beta.uahapp.com` with any external testers or graders.
-All items must be checked before the beta URL is shared outside the core team.
+Use this checklist before sharing `beta.uahapp.com` outside the core team.
 
----
+This file describes the current beta shape. Historical findings and one-time gap analyses belong in the archive, not here.
 
-## Environment Configuration
+## Environment
 
-- [ ] All `.env` values confirmed set correctly for the beta environment (no dev URLs, no empty secrets)
-- [ ] No `.env` file committed to the `beta` branch — confirmed via `git status` and `.gitignore` check
-- [ ] `ENVIRONMENT=beta` and `ENV=beta` set in beta `.env`
-- [ ] `AUTH_NAMESPACE=beta` and `VITE_AUTH_NAMESPACE=beta` set for cookie/storage isolation
-- [ ] `VITE_LOCAL_MODE=backend` set for beta builds (not `mock`)
-- [ ] `SESSION_COOKIE_HTTPS_ONLY=true` set in beta `.env`
-- [ ] `COMPOSE_PROJECT_NAME=uah-beta` set to avoid container name conflicts with dev
-- [ ] `PUBLIC_APP_URL=https://beta.uahapp.com` set correctly (used in email links)
-- [ ] `GOOGLE_REDIRECT_URI=https://beta.uahapp.com/api/auth/google/callback` set correctly
-- [ ] `EMAILS_ENABLED=true` and all SMTP values configured and tested
-- [ ] `ADMIN_BOOTSTRAP_ENABLED=false` unless a one-time admin account creation is needed
+- [ ] Beta host uses a real repo-root `.env` derived from `env-examples/beta/.env.example`
+- [ ] `ENV=beta` and `ENVIRONMENT=beta` are set
+- [ ] `COMPOSE_PROJECT_NAME=uah-beta` is set
+- [ ] `AUTH_NAMESPACE=beta`, `AUTH_COOKIE_NAME=uah_auth_beta`, and `SESSION_COOKIE_NAME=uah_session_beta` are set
+- [ ] `PUBLIC_APP_URL=https://beta.uahapp.com` is set
+- [ ] `SESSION_COOKIE_HTTPS_ONLY=true` is set
+- [ ] Beta secrets differ from dev secrets
 
-## Secrets Quality
+## Tunnel / Cloudflare
 
-- [ ] `SECRET_KEY` is a strong random value (minimum 32 hex characters, not a default or placeholder)
-- [ ] `SESSION_SECRET` is a strong random value (minimum 32 hex characters, not a default or placeholder)
-- [ ] `POSTGRES_PASSWORD` is a strong random value, different from the dev environment password
-- [ ] `SECRET_KEY`, `SESSION_SECRET`, and `POSTGRES_PASSWORD` are different from their dev counterparts
+- [ ] `CLOUDFLARE_BETA_TUNNEL_TOKEN` is set
+- [ ] `uah-beta-cloudflared` is running
+- [ ] `beta.uahapp.com` resolves through the intended Cloudflare/tunnel setup
+- [ ] Access policy, WAF, and rate limiting have been reviewed outside the repo-managed audit
 
-## Backend Security
+## Backend
 
-- [ ] Beta runtime confirmed in backend logs/startup output (`ENVIRONMENT=beta`)
-- [ ] Hot-reload (`--reload`) flag removed from the backend process (use `command:` override in compose)
-- [ ] Source code volume mount (`./backend:/app`) removed from compose for beta
-- [ ] `/api/jobs/save` endpoint requires authentication (fix from `AUDIT.md` §1.5 applied)
-- [ ] `/api/jobs/saved` endpoint requires authentication (fix from `AUDIT.md` §1.5 applied)
-- [ ] `/api/diagnostics` is either removed, auth-gated (admin only), or not proxied by Nginx
-- [ ] `/docs`, `/redoc`, `/openapi.json` are either disabled in FastAPI or not proxied by Nginx
-- [ ] Beta celery worker and beat services are running and isolated from dev
+- [ ] `/api/status` responds as expected
+- [ ] `/api/diagnostics` requires an admin session
+- [ ] `/docs`, `/redoc`, and `/openapi.json` are not exposed in beta
+- [ ] Saved jobs routes require authentication
+- [ ] Queue-backed services use beta-specific Redis and queue namespaces
+- [ ] The current beta backend bind mount (`./backend:/app`) has been reviewed and explicitly accepted or changed before broader exposure
 
 ## Frontend
 
-- [ ] Frontend built in production mode (Vite `npm run build`, not `npm run dev`)
-- [ ] `vite-plugin-vue-devtools` confirmed excluded from production build output
-- [ ] No hardcoded dev URLs present in the built frontend (verify `dist/` assets)
+- [ ] Frontend was built through the compose workflow, not `npm run dev`
+- [ ] Public status behavior is acceptable when diagnostics access is limited
+- [ ] No dev-only URLs are present in the beta runtime configuration
 
-## CORS
+## Identity / Integrations
 
-- [ ] CORS policy confirmed — no `CORSMiddleware` with wildcard origins is present in `backend/app/main.py`
-- [ ] All API calls route through the Nginx same-origin proxy — no cross-origin requests needed
+- [ ] Google OAuth beta callback URI is registered
+- [ ] Gmail callback URI is registered if Gmail integration is enabled
+- [ ] Email verification and password reset links point to beta
+- [ ] SMTP / relay configuration has been tested
 
-## OAuth
+## Data / Services
 
-- [ ] `https://beta.uahapp.com/api/auth/google/callback` added to Google Cloud Console authorized redirect URIs
-- [ ] Google OAuth login flow tested end-to-end on `beta.uahapp.com`
+- [ ] Beta DB is separate from dev
+- [ ] Beta Redis is separate from dev
+- [ ] Celery worker and beat are healthy when queue-backed features are enabled
+- [ ] Required provider API keys are configured for the intended beta feature set
 
-## Cloudflare — Proxy
+## Validation
 
-- [ ] `beta.uahapp.com` DNS record confirmed as **Proxied** (orange cloud) in Cloudflare dashboard
-- [ ] Origin server firewall configured — only Cloudflare IP ranges can reach port 80 on the host
-- [ ] Direct-to-origin IP access confirmed blocked (test from a non-Cloudflare IP)
-- [ ] No other ports (5432, 8000, WireGuard) accessible from the public internet on the beta host
+- [ ] `bash scripts/uah.sh beta audit --mode full --json` has been run
+- [ ] Registration/login/password-reset/manual smoke tests passed
+- [ ] Resume upload and parsing smoke tests passed
+- [ ] Job search smoke tests passed
 
-## Cloudflare — Zero Trust Access
+## Related Docs
 
-- [ ] Cloudflare Access application created for `beta.uahapp.com`
-- [ ] Access policy configured with approved tester/grader email list
-- [ ] One-time PIN email authentication enabled
-- [ ] Access policy tested with at least one approved tester email — confirmed gating works
-- [ ] Access policy tested with an unapproved email — confirmed access is denied
-
-## Cloudflare — WAF and Rate Limiting
-
-- [ ] Cloudflare WAF managed ruleset enabled on `beta.uahapp.com`
-- [ ] Rate limiting rule active on `/api/auth/*` (brute-force prevention)
-- [ ] Rate limiting rule active on `/api/account/forgot-password` (email flood prevention)
-- [ ] Rate limiting rule active on `/api/account/send-verification` (email flood prevention)
-- [ ] Bot Fight Mode enabled
-
-## Cloudflare — SSL/TLS
-
-- [ ] SSL/TLS mode set to **Full (strict)**
-- [ ] HSTS enabled with minimum 6-month max-age
-- [ ] Minimum TLS version set to **TLS 1.2**
-- [ ] HTTPS redirect confirmed (HTTP → HTTPS for all traffic)
-
-## Database
-
-- [ ] Database (port 5432) confirmed not exposed on any public port
-- [ ] Beta database is separate from the dev database (`POSTGRES_DB=uah_beta`)
-- [ ] Database volume stored on the beta host — not shared with dev
-
-## Dependencies
-
-- [ ] `pip-audit` or `safety` run against `backend/requirements.txt` — no critical CVEs unaddressed
-- [ ] `npm audit` run against `frontend/package.json` — no critical CVEs unaddressed
-- [ ] `npm audit` run against `uah-browser-extension/package.json` when the extension lockfile is present
-- [ ] `gitleaks` scan run against tracked repo files — no unapproved secret findings
-- [ ] Dependabot alerts reviewed in GitHub — no critical vulnerabilities outstanding
-
-## Final Verification
-
-- [ ] Full demo flow completed on `beta.uahapp.com` before sharing access with testers:
-  - [ ] Registration with email/password
-  - [ ] Email verification flow
-  - [ ] Google OAuth login
-  - [ ] Job search and save
-  - [ ] Resume upload and parse
-  - [ ] Password reset flow
-  - [ ] Profile update
-- [ ] At least one team member has tested the complete flow in a fresh private browser window via Cloudflare Access authentication
-- [ ] Beta URL and tester instructions shared only with the approved list — not posted publicly
-
----
-
-*This checklist was generated as part of the beta prep audit. See `docs/beta-prep/AUDIT.md` for full findings and `docs/beta-prep/BETA_SETUP.md` for setup instructions.*
+- [BETA_SETUP.md](BETA_SETUP.md)
+- [CLOUDFLARE_SECURITY.md](CLOUDFLARE_SECURITY.md)
+- [../SECURITY_AUDIT_GUIDE.md](../SECURITY_AUDIT_GUIDE.md)

--- a/docs/beta-prep/TEMP_DESKTOP_OLLAMA_ROUTING_RUNBOOK.md
+++ b/docs/beta-prep/TEMP_DESKTOP_OLLAMA_ROUTING_RUNBOOK.md
@@ -1,5 +1,7 @@
 # Temporary Desktop Ollama Routing Runbook
 
+This is an operational workaround runbook, not a permanent architecture doc. Keep it only as long as the desktop-routed local pipeline path is intentionally in use.
+
 ## Purpose
 Provide a scoped, reversible temporary route so the backend container can reach desktop Ollama at `10.8.0.8:11434` through the existing `uah-dev-vpn` WireGuard container.
 

--- a/docs/env-examples/README.md
+++ b/docs/env-examples/README.md
@@ -1,48 +1,40 @@
-# Environment Example Templates
+# Environment Example Files
 
-This folder contains sanitized, committed templates for each deployment stage.
+This folder contains sanitized example env files for each environment shape used by the repository.
 
-## Runtime Rule (Important)
+## Runtime Rule
 
-The application expects a real `.env` file in the repository root at runtime.
+The application does not run directly from files inside this directory.
 
-- Runtime location: `./.env`
-- Template location only: `env-examples/*/.env.example`
+- Runtime file location: repo-root `.env`
+- Template location: `env-examples/*/.env.example`
 
-Do not run the app directly from files inside this folder.
-Copy the relevant template values into root `.env` before starting services.
+Copy the relevant example into a real root `.env`, then replace placeholder values with environment-specific secrets and URLs.
 
-## Folder Intent
+## Available Templates
 
-- `env-examples/dev/.env.example`
-  - Canonical development template.
-  - Mirrors current dev variables and defaults.
-  - Uses fake placeholders for secret values.
+| Template | Purpose |
+| --- | --- |
+| `env-examples/dev/.env.example` | Team-oriented dev stack values |
+| `env-examples/beta/.env.example` | Beta deployment values, namespacing, and tunnel-related settings |
+| `env-examples/local/.env.example` | Frontend-first local development with optional localhost backend |
+| `env-examples/prod/.env.example` | Production placeholder/stub for future production hardening |
 
-- `env-examples/beta/.env.example`
-  - Canonical beta/staging template.
-  - Mirrors beta values (domain, compose name, cloudflare token var).
-  - Uses fake placeholders for secret values.
+## Repository Policy
 
-- `env-examples/prod/.env.example`
-  - Placeholder production stub.
-  - Tracks required production fields without storing real credentials.
+- Never commit a real `.env`.
+- Never replace placeholders in `*.env.example` with live credentials.
+- Keep templates aligned with `backend/app/core/config.py`, compose files, and lifecycle/audit expectations.
+- When a new environment variable is added, update the relevant example files in the same change.
 
-- `env-examples/local/.env.example`
-  - Frontend-first local template with secure defaults.
-  - Supports mock-only frontend mode and optional local backend profile.
-  - Keeps localhost-only host bindings and admin bootstrap disabled by default.
+## Template Design Notes
 
-## Security Notes
+- Placeholders are intentionally fake values so secret scanners do not treat them as leaked credentials.
+- Beta and local templates keep some disabled-by-default keys present on purpose so audits and setup flows can verify them explicitly.
+- A documented key may be required only when a feature is enabled. That still belongs in the example file.
 
-- Never commit real `.env` files.
-- Never paste real credentials into any `*.env.example` file.
-- Placeholders are intentionally non-secret strings so scanners do not treat them as leaked keys.
+## Related Docs
 
-## Sync Notes
-
-- CI validates that `backend/app/core/config.py` env usage is represented in:
-  - `env-examples/dev/.env.example`
-  - `env-examples/beta/.env.example`
-- Keep variables present even when a feature is disabled in that environment.
-  - Example: beta keeps `DEV_AUTH_TEST_*` keys documented with empty values while `DEV_AUTH_TEST_ACCOUNT_ENABLED=false`.
+- Repo entrypoint: [../../README.md](../../README.md)
+- Server checklist: [../SERVER_ENV_CHECKLIST.md](../SERVER_ENV_CHECKLIST.md)
+- Backend guide: [../backend/README.md](../backend/README.md)

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -1,107 +1,148 @@
-# frontend
+# Frontend Development Guide
 
-This template should help get you started developing with Vue 3 in Vite.
+This is the current source of truth for the Vue frontend.
 
-For end-to-end local setup (database + backend + frontend), follow the authoritative flow in [../backend/README.md](../backend/README.md). This file only covers frontend commands.
+For repo-wide context, use:
 
-## Recommended IDE Setup
+- [../../README.md](../../README.md)
+- [../ARCHITECTURE.md](../ARCHITECTURE.md)
 
-[VS Code](https://code.visualstudio.com/) + [Vue (Official)](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur).
+## What This App Is
 
-## Recommended Browser Setup
+The frontend is a Vue 3 SPA that talks to the FastAPI backend through same-origin `/api` routes in deployed environments. In local development it can run in one of two modes:
 
-- Chromium-based browsers (Chrome, Edge, Brave, etc.):
-  - [Vue.js devtools](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)
-  - [Turn on Custom Object Formatter in Chrome DevTools](http://bit.ly/object-formatters)
-- Firefox:
-  - [Vue.js devtools](https://addons.mozilla.org/en-US/firefox/addon/vue-js-devtools/)
-  - [Turn on Custom Object Formatter in Firefox DevTools](https://fxdx.dev/firefox-devtools-custom-object-formatters/)
+- mock-first mode for UI work with no backend dependency
+- backend passthrough mode for real API behavior on localhost
 
-## Customize configuration
+## Scripts
 
-See [Vite Configuration Reference](https://vite.dev/config/).
+Run these from `frontend/`:
 
-## Project Setup
-
-Run commands from the `frontend/` directory:
-
-```sh
+```bash
 npm install
+npm run dev
+npm run dev:backend
+npm run build
+npm run check:cards
 ```
 
-### Compile and Hot-Reload for Development
+### What each script does
 
-Mock-first mode (default) renders the app without requiring backend services:
+| Script | Purpose |
+| --- | --- |
+| `npm run dev` | Mock-first local development. Uses the in-browser mock API layer. |
+| `npm run dev:backend` | Proxies `/api`, `/docs`, and `/openapi.json` to the configured backend origin. |
+| `npm run build` | Production build of the SPA bundle. |
+| `npm run check:cards` | Contract check for the shared card component and its consumers. |
 
-```sh
+## Auth And Runtime Behavior
+
+### Backend mode
+
+- The app expects backend-issued auth cookies and session-backed API behavior.
+- `syncCurrentUser()` is the main frontend-side identity refresh path.
+- `/api/status` is the lightweight public connectivity check.
+- `/api/diagnostics` is admin-gated, so the status page must handle limited-access states gracefully.
+
+### Mock mode
+
+- The mock API layer emulates auth and common data flows entirely in-browser.
+- Mock mode keeps local storage namespaced by `VITE_AUTH_NAMESPACE`.
+- Mock mode is for renderability and workflow development, not for proving backend correctness.
+
+## Current Route Surface
+
+### Active, non-placeholder views
+
+- `Home`
+- `Job-Board`
+- `Resumes`
+- `Applicant-Information`
+- `Settings`
+- `Login`
+- `Register`
+- `Forgot-Password`
+- `Reset-Password`
+- `Status`
+- `Our-Commitment`
+- `Contributors`
+- `Dev` (debug-tools gated)
+
+### Placeholder or thin-shell views
+
+These routes exist, but they are not full product surfaces yet:
+
+- `Analytics`
+- `Timeline`
+- `Application`
+
+`Notifications` has a routed surface, but it is currently a simple static shell rather than a fully wired reminders system.
+
+Document those views as partial, not complete.
+
+## Local Development Modes
+
+### Mock-first mode
+
+```bash
 npm run dev
 ```
 
-Backend passthrough mode proxies `/api`, `/docs`, and `/openapi.json` to local backend:
+Use this for:
 
-```sh
+- layout work
+- component iteration
+- route flow scaffolding
+- work that should not depend on backend availability
+
+### Backend passthrough mode
+
+```bash
 npm run dev:backend
 ```
 
-Security notes:
+Important behavior:
 
-- Local dev server binds to `127.0.0.1` by default.
-- Backend mode only allows loopback targets unless you explicitly set `VITE_ALLOW_REMOTE_API=true`.
-- Keep `VITE_AUTH_NAMESPACE=dev` for local workflows to avoid auth storage collisions with other environments.
-
-### Compile and Minify for Production
-
-```sh
-npm run build
-```
+- defaults to `http://localhost:8000` unless overridden
+- refuses non-loopback backend targets unless `VITE_ALLOW_REMOTE_API=true`
+- can optionally serve over HTTPS when the local HTTPS env vars are configured
 
 ## Shared Card Contract
 
-- `frontend/src/components/Card.vue` is the shared structural card primitive.
-- Its internal class contract is namespaced as `ui-card*`; do not target bare `.card` or `.big-card`.
-- Public variants are limited to:
-  - `default` for dashboard and form cards
-  - `job` for job listing cards
-  - `minimal` for inset or nested cards
-- Page-level tuning must happen through caller-owned classes and these documented CSS variables:
-  - `--ui-card-bg`
-  - `--ui-card-border`
-  - `--ui-card-shadow`
-  - `--ui-card-padding`
-  - `--ui-card-header-bg`
-  - `--ui-card-header-padding`
-- Do not restyle shared internals globally.
-- Run `npm run check:cards` before opening a PR that changes shared card consumers or the card primitive.
+`frontend/src/components/Card.vue` is a shared UI primitive, not a page-specific card.
+
+Public variants:
+
+- `default`
+- `job`
+- `minimal`
+
+Caller-owned tuning should happen through documented CSS variables rather than global overrides:
+
+- `--ui-card-bg`
+- `--ui-card-border`
+- `--ui-card-shadow`
+- `--ui-card-padding`
+- `--ui-card-header-bg`
+- `--ui-card-header-padding`
+
+Run `npm run check:cards` if a change touches the card primitive or many card consumers.
 
 ## Job Board Notes
 
-- Filter metadata is backend-owned via `GET /api/jobs/filter-metadata` and includes:
-  - Canonical category groups/aliases
-  - Supported level labels
-  - `location_param_cap`
-- Default discovery is intentionally broad:
-  - `Remote` and `Hybrid` start enabled.
-  - Backend may run a one-time relaxed-location fallback when strict location matching returns no jobs.
-- Job search sends keyword/date server-side (`q`, `posted_after`) so totals and pagination match backend filtering.
-- Before search, the UI preflights location trimming and shows `Using X of Y resolved locations`.
-- Compatibility transparency:
-  - With Remote off, constraint-overlap roles can still appear (policy: `allow-if-overlap`).
-  - The Job Board shows a diagnostics hint when this happens.
-- Local mock mode emulates:
-  - Category expansion behavior
-  - Location cap/truncation diagnostics
-  - Search diagnostics fields used by Job Board transparency UI
+- Filter metadata is backend-owned through `GET /api/jobs/filter-metadata`.
+- Keyword search and `posted_after` filtering are sent server-side so totals and pagination stay consistent.
+- Location canonicalization and cap/truncation diagnostics are surfaced in the UI before search.
+- Result totals from provider-backed search are conservative estimates; local DB-backed search can return exact totals.
 
-## Identity And Autofill Notes (April 11, 2026)
+## Docs And Debug Expectations
 
-- Identity is now email-first in UI flows.
-  - Login uses email as the sign-in identifier.
-  - Register no longer asks for username.
-  - Settings no longer shows username management.
-- Autofill policy is intentionally narrow:
-  - Keep browser/password-manager metadata only on auth + account-security forms:
-    - `Login`, `Register`, `Forgot-Password`, `Reset-Password`
-    - Settings `Change Email` + `Change Password`
-  - All profile/resume/settings-preference data-entry fields are `autocomplete="off"` to avoid noisy autofill interference.
-- Password manager compatibility is preserved for credential updates:
-  - Account-security forms provide username/email context and keep `current-password` / `new-password` semantics for password updates.
+- In local/dev-style environments, `/docs` and `/openapi.json` may be available through backend passthrough mode.
+- In beta-like environments, generated docs are intentionally disabled by the backend.
+- The `Dev` route should be treated as a gated troubleshooting surface, not a public product page.
+
+## Related Docs
+
+- Backend guide: [../backend/README.md](../backend/README.md)
+- Extension guide: [../../uah-browser-extension/README.md](../../uah-browser-extension/README.md)
+- Architecture: [../ARCHITECTURE.md](../ARCHITECTURE.md)

--- a/docs/provider-checklist-template.md
+++ b/docs/provider-checklist-template.md
@@ -1,10 +1,25 @@
-## Provider: [NAME]
-URL:
-Date reviewed:
-Reviewed by:
+# Provider Review Template
 
-robots.txt — checked ✓/✗
-ToS reviewed — checked ✓/✗
-Anti-bot signals — none detected ✓ / detected ✗
-Decision: APPROVED / NEEDS REVIEW / REJECTED
-Notes:
+Use this template when evaluating a new external job provider or scraper target.
+
+## Provider Summary
+
+- Provider name:
+- Base URL:
+- Date reviewed:
+- Reviewed by:
+
+## Access And Policy Review
+
+- `robots.txt` reviewed: yes / no
+- Terms of service reviewed: yes / no
+- Anti-bot signals observed: none / present
+- Authentication required for normal listing access: yes / no
+- Decision: approved / needs review / rejected
+
+## Notes
+
+- Why is this provider acceptable or unacceptable?
+- Are there rate-limit or crawl-delay constraints?
+- Are there provider-specific data quality concerns?
+- Does this belong in the live provider pipeline now, or only in the scaffold?

--- a/frontend/src/lib/auth.js
+++ b/frontend/src/lib/auth.js
@@ -42,12 +42,16 @@ function resolveFrontendAuthMode() {
 const DEFAULT_NAMESPACE = inferDefaultNamespace()
 const AUTH_NAMESPACE = normalizeNamespace(import.meta?.env?.VITE_AUTH_NAMESPACE) || DEFAULT_NAMESPACE
 const FRONTEND_AUTH_MODE = resolveFrontendAuthMode()
+// In backend mode the browser should trust the backend's HttpOnly cookie flow.
+// Only mock mode keeps an access token in local storage for isolated UI work.
 const SHOULD_PERSIST_ACCESS_TOKEN = FRONTEND_AUTH_MODE === 'mock'
 
 const LEGACY_ACCESS_TOKEN_KEY = 'uah_access_token'
 const LEGACY_CURRENT_USER_KEY = 'uah_current_user'
 const ACCESS_TOKEN_KEY = `uah_access_token:${AUTH_NAMESPACE}`
 const CURRENT_USER_KEY = `uah_current_user:${AUTH_NAMESPACE}`
+// Limit legacy-key migration to loopback development so deployed environments
+// do not unexpectedly inherit stale local-storage auth from older builds.
 const SHOULD_MIGRATE_LEGACY_KEYS = isLoopbackHost(window?.location?.hostname)
 const USER_SYNC_TTL_MS = 15_000
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -16,7 +16,8 @@ async function resolveAuthenticatedUser(force = false) {
   }
 }
 
-/* This grabs everything from and generates routes for everything in the views folder */
+// File-based route generation keeps the view directory honest: if a routed page
+// exists in `views/`, it is mounted here unless we explicitly special-case it.
 const viewRoutes = Object.keys(modules).map((path) => {
   const name = path
     .split('/')
@@ -61,6 +62,8 @@ const router = createRouter({
 })
 
 router.beforeEach(async (to) => {
+  // These routes stay reachable without an existing session, but they may still
+  // redirect signed-in users away from auth pages once identity is resolved.
   const publicPaths = new Set([
     '/login',
     '/register',
@@ -93,6 +96,8 @@ router.beforeEach(async (to) => {
     }
   }
 
+  // Keep the dev surface routed for contributors without making it a public UI
+  // entrypoint in normal browser sessions.
   if (to.meta?.debugOnly && !shouldShowDebugTools()) {
     return '/home'
   }

--- a/frontend/src/views/Contributors.vue
+++ b/frontend/src/views/Contributors.vue
@@ -116,7 +116,7 @@ const founders = [
   {
     name: 'Trent Brown',
     role: 'Lead architect & infrastructure',
-    blurb: 'Core systems design, infrastructure, project leadership, and most of what makes UAH unique.',
+    blurb: 'Core systems design, infrastructure, project leadership, envisioned many of the things that make UAH unique.',
     initials: 'TB',
     tint: 'rgba(99, 102, 241, 0.18)',
   },

--- a/test.txt
+++ b/test.txt
@@ -67,3 +67,9 @@ add more advanced routing for early college, highschool, and other things that m
 our commitment page added as our temp privacy policy thing, go through later and rewrite a lot wording wise
 
 some issues with the extension resizing lol
+
+widen search doesnt fully work yet
+
+make sure zip code input cant be broken
+
+de gear the whole app process from being so tech oriented

--- a/uah-browser-extension/README.md
+++ b/uah-browser-extension/README.md
@@ -1,125 +1,140 @@
 # UAH Browser Extension
 
-Vue 3 + Vite browser extension that gives UAH users quick access to their saved applicant profiles and parsed resume data without leaving the current job board tab.
+The browser extension gives users quick access to UAH profile and resume data without leaving the current job board tab.
 
-## What It Does
+It is Chrome-first, MV3-based, and intentionally built around explicit user actions rather than a continuously running page agent.
 
-- Signs in against the existing UAH backend. There is no separate extension auth system.
-- Supports email/password login and Google sign-in through the existing UAH OAuth endpoints.
-- Shows compact read-only views for:
-  - applicant profiles
-  - parsed resumes
-  - account and connected sign-in status
-- Lets users copy individual fields like email, phone, summary, skills, and quick resume snapshots.
-- Lets users pin the extension into the current tab as a floating side panel. The pinned panel reuses the same popup app in an iframe, remembers its position, and can be dismissed per-tab or fully unpinned.
-- Lets users run a manual, profile-driven page scan/fill flow on the current tab. The popup sends a prepared token map to the background worker, which injects the in-page autofill runtime only when you click `Scan page` or `Fill page`.
-- Lets users step through multi-page application flows with `Previous page` and `Next page` actions that try visible navigation controls first, then fall back to browser history for back navigation.
-- Opens the full UAH app for anything that belongs in the full product experience.
+## What It Does Today
 
-## Legacy Reference Folders
+- signs in against the existing UAH backend
+- supports email/password login and Google sign-in
+- shows cached read-only profile, resume, and account snapshots
+- injects a pinned side panel into supported tabs
+- runs a manual `Scan page` / `Fill page` flow on the active tab
+- provides simple application-step navigation helpers such as previous/next-page actions
 
-The repo still contains `uah-test-extension/` and `uah-apply-overlay-prototype/` as rough historical references. They are legacy prototypes and are not part of the supported build path for this extension.
+## Source Of Truth
+
+Use these docs together:
+
+- repo entrypoint: [../README.md](../README.md)
+- docs map: [../docs/README.md](../docs/README.md)
+- extension adapter system: [src/adapters/ADAPTERS.md](src/adapters/ADAPTERS.md)
+
+## Architecture
+
+### Popup app
+
+- `popup.html` mounts the Vue app
+- the same UI can render as the standard popup or the pinned panel surface
+- the popup does not talk to the backend directly
+
+### Background worker
+
+- owns auth, API fetches, storage, and cache invalidation
+- opens OAuth tabs
+- reads the environment-scoped backend auth cookie for the extension Google login bridge
+- injects the autofill and pinned-panel runtimes when needed
+
+### Injected runtimes
+
+- `src/autofill/` discovers visible fields, builds a fill plan, and writes values only when the user requests it
+- `src/pinned-panel/` renders the floating iframe surface inside the active page
 
 ## Storage Model
 
 - `chrome.storage.local`
-  - Stores only extension auth metadata and pinned UI preferences: the JWT, its expiry, and panel state so the extension can survive browser restarts.
+  - long-lived auth metadata
+  - pinned UI preferences
 - `chrome.storage.session`
-  - Stores non-sensitive view caches such as the current user snapshot, profile and resume summaries, and detail responses for the current browser session. These session caches are cleared on logout and whenever auth expires.
-- The extension does not use `localStorage` or `sessionStorage`.
+  - non-sensitive cached API payloads for the current browser session
 
-## Auth Flow
+The extension does not use `localStorage` or `sessionStorage`.
 
-### Email / Password
+## Auth Model
 
-1. The popup sends the credentials to the background service worker.
+### Email / password
+
+1. The popup sends credentials to the background worker.
 2. The background posts to `/api/auth/login` with `X-UAH-Client: extension`.
-3. The backend returns the normal token payload and also sets the same HttpOnly auth cookie it uses for the web app.
-4. The extension stores the JWT and expiry metadata in `chrome.storage.local`.
-5. Each popup open validates the stored expiry first, then calls `/api/auth/me`; any `401` clears auth and returns to the sign-in screen.
+3. The backend returns the normal token payload and sets the same environment-scoped auth cookie used by the web app.
+4. The extension persists JWT expiry metadata locally and validates it on future popup opens.
 
-### Google OAuth
+### Google sign-in
 
-1. The popup asks the background worker to start Google sign-in.
-2. The background opens `/api/auth/google?intent=login&client=extension` in a new tab.
-3. The backend completes the normal OAuth flow and redirects back to the configured UAH app origin.
-4. The background watches that auth tab, then reads the env-scoped UAH auth cookie from the configured API origin with `chrome.cookies`.
-5. The cookie JWT becomes the extension bearer token stored in `chrome.storage.local`.
+1. The background opens `/api/auth/google?intent=login&client=extension`.
+2. After the backend completes OAuth, the background reads the configured backend auth cookie from the API origin.
+3. That cookie value becomes the extension bearer token for subsequent API calls.
 
-## Runtime Flow
+This is why the build requires either `VITE_EXTENSION_AUTH_COOKIE_NAME` or `VITE_EXTENSION_AUTH_NAMESPACE`.
 
-### Popup and Background
-
-1. `popup.html` mounts the Vue app and chooses either the normal popup surface or the pinned-panel surface.
-2. The Vue UI talks only to the background service worker through runtime messages.
-3. The background worker owns auth, API fetches, cache hydration, logout cleanup, tab opening, and content-script injection.
-4. Profile, resume, and account API responses are cached in `chrome.storage.session` until logout, expiry, or a forced refresh.
-
-### Manual Autofill
+## Manual Autofill Flow
 
 1. The popup loads the selected applicant profile.
-2. The extension builds a sanitized token map from `profile.token_map` when present, otherwise from flattened canonical resume data plus a few profile-specific fields such as work authorization and links.
-3. Clicking `Scan page` or `Fill page` asks the background worker to inject `autofill-content.js` into the active tab.
-4. The injected runtime scans visible standard form controls on the top-level page and either reports matches or fills fields from the prepared token map.
-5. The extension does not run continuously in the page; the runtime is injected only when needed.
+2. The extension builds a sanitized token map from `profile.token_map` when present.
+3. If there is no explicit token map, the extension falls back to flattened canonical resume/profile data.
+4. Clicking `Scan page` or `Fill page` injects the content runtime into the active tab.
+5. The runtime inspects visible standard controls on the top-level page only.
 
-### Pinned Panel
+Current limitations:
 
-1. Clicking `Pin` stores the preference in extension storage.
-2. The background worker watches supported tabs and injects `pinned-panel.js` when pinning is enabled.
-3. The pinned runtime renders a floating iframe that points back to `popup.html?surface=pinned`.
-4. Position and size changes are persisted, while a temporary dismiss only hides the panel for the current tab until that tab navigates again.
+- no always-on monitoring
+- no iframe traversal
+- no shadow DOM support
+- no automatic final submission
 
-## Configuration
+## Pinned Panel
 
-Copy `.env.example` to `.env` inside `uah-browser-extension/` for shared remote targets, or set up the local harness config as described in the repo-root README. The build requires:
+- pinning is a user preference stored in extension storage
+- the background injects the pinned runtime on supported tabs when pinning is enabled
+- the pinned panel is an iframe that points back to `popup.html?surface=pinned`
+- panel position and size persist, but temporary dismissals stay tab-scoped
+
+## Build Configuration
+
+Required env values:
 
 - `VITE_EXTENSION_APP_ORIGIN`
 - `VITE_EXTENSION_API_ORIGIN`
 - `VITE_EXTENSION_AUTH_COOKIE_NAME` or `VITE_EXTENSION_AUTH_NAMESPACE`
 
-Both origins must be HTTPS-only. The build intentionally fails for non-HTTPS values.
+Both origins must be HTTPS origins. The build intentionally fails for non-HTTPS origins.
 
-The extension build emits three bundled surfaces into `dist/`:
+The build emits:
 
-- `manifest.json`, `popup.html`, and `background.js` from the main Vite build
-- `autofill-content.js` from `vite.autofill.config.mjs`
-- `pinned-panel.js` from `vite.pinned.config.mjs`
+- main extension bundle and `manifest.json`
+- `autofill-content.js`
+- `pinned-panel.js`
 
-## Local Build
+## Commands
+
+Run from `uah-browser-extension/`:
 
 ```bash
-cd uah-browser-extension
 npm install
 npm run build
+npm test
 ```
 
-This repo also supports a fallback where the extension reuses `frontend/node_modules` for Vite if that toolchain is already installed.
+### Tests
 
-## Load Unpacked In Chrome
+- `npm run test:autofill`
+- `npm run test:adapters`
 
-1. Build the extension with `npm run build`.
-2. Open `chrome://extensions`.
-3. Enable `Developer mode`.
-4. Click `Load unpacked`.
-5. Select `uah-browser-extension/dist`.
+## Local Harness
 
-## Load Temporarily In Firefox
+For the localhost HTTPS flow that pairs the extension with a real local backend/frontend, use the repo-root guidance in [../README.md](../README.md). The PowerShell helper remains:
 
-1. Build the extension with `npm run build`.
-2. Open `about:debugging`.
-3. Choose `This Firefox`.
-4. Click `Load Temporary Add-on...`.
-5. Select the generated `uah-browser-extension/dist/manifest.json`.
+```powershell
+pwsh -File .\scripts\local\lifecycle\local-extension-test.ps1
+```
 
-## Firefox Note
+## Known Boundaries
 
-The code isolates browser APIs behind a small wrapper to keep Firefox compatibility feasible later, but this version is Chrome-first and has only been planned and wired for MV3 behavior.
+- profile and resume editing stay in the main web app
+- the extension is a productivity surface, not a second full product shell
+- adapter coverage varies by ATS and company override depth
 
-## Known Limitations
+## Historical Note
 
-- The popup is intentionally read-only for profile and resume editing.
-- Resume upload/parse flows stay in the full app.
-- The manual autofill runtime is generic and intentionally limited to visible standard controls on the top-level page. It does not currently scan iframes or shadow DOM.
-- The navigation helpers only look for common visible button/link labels such as `Back`, `Previous`, `Next`, `Continue`, `Review`, and `Submit`.
-- Google sign-in depends on the configured UAH auth cookie name and the browser permitting the extension to read it through the `cookies` permission on the configured API origin.
+Legacy prototype folders may still exist in the repo as references, but they are not part of the supported build path for this extension.

--- a/uah-browser-extension/src/adapters/ADAPTERS.md
+++ b/uah-browser-extension/src/adapters/ADAPTERS.md
@@ -1,83 +1,93 @@
 # ATS Adapter System
 
-This scaffold introduces an extensible adapter layer for ATS-specific and company-specific job application assistance in `uah-browser-extension`.
+This document describes the current adapter contract used by the browser extension.
 
-## Architecture Overview
+Use it together with:
 
-The registry resolves adapters in two stages:
+- [../../README.md](../../README.md)
+- [companies/README.md](companies/README.md)
 
-1. Company-specific overrides
-2. Base ATS adapters
+## Resolution Order
 
-If no company override matches the current page URL, the registry falls back to the generic adapter for that ATS platform.
+Adapter lookup is intentionally two-stage:
 
-```text
-resolveAdapter(url)
-  |
-  +-- companyOverrides[]
-  |     |
-  |     +-- ExampleCorpWorkdayAdapter
-  |     +-- ExampleCorpGreenhouseAdapter
-  |
-  +-- baseAdapters[]
-        |
-        +-- WorkdayAdapter
-        +-- GreenhouseAdapter
-        +-- LeverAdapter
-        +-- iCIMSAdapter
-```
+1. company-specific overrides
+2. base ATS adapters
 
-## How To Add A New ATS Platform
+That precedence matters. A company override should always win before the extension falls back to the generic platform adapter.
 
-1. Create a new file in `src/adapters/ats/`.
-2. Extend `BaseATSAdapter`.
-3. Implement every required public method:
-   `matches(url)`, `getATSName()`, `getCompanyName()`, `detectJobDetails()`, `detectFormFields()`, `isApplicationPage()`, and `getSupportLevel()`.
-4. Reuse the generic helpers where possible, especially `super.detectFormFields()`.
-5. Register the adapter in `src/adapters/index.js`.
-6. Add unit tests for `matches()` with real platform URL examples and nearby negative cases.
+## Base Contract
 
-## How To Add A Company-Specific Override
+Every registered adapter must implement:
 
-1. Identify the underlying ATS platform first.
-2. Create a file in `src/adapters/companies/[ats-name]/[CompanyName][ATS]Adapter.js`.
-3. Extend the base ATS adapter for that platform, not `BaseATSAdapter` directly.
-4. Add a top-level JSDoc comment describing what is different about this employer's instance.
-5. Override only the methods that actually differ from the base adapter.
-6. Register the override in `src/adapters/index.js`.
-7. Add tests that prove the override wins over the base ATS adapter for that company's URL.
+- `matches(url)`
+- `getATSName()`
+- `getCompanyName()`
+- `detectJobDetails()`
+- `detectFormFields()`
+- `isApplicationPage()`
+- `getSupportLevel()`
 
-## URL Pattern Reference
+`getCompanyName()` returning a non-empty value is what makes an adapter a company override instead of a base ATS adapter.
 
-| ATS | Supported pattern | Example |
-| --- | --- | --- |
-| Workday | `[company].wd1.myworkdayjobs.com` | `https://examplecorp.wd1.myworkdayjobs.com/en-US/careers/job/123` |
-| Workday | `[company].wd3.myworkdayjobs.com` | `https://contoso.wd3.myworkdayjobs.com/en-US/jobs` |
-| Workday | `[company].wd5.myworkdayjobs.com` | `https://fabrikam.wd5.myworkdayjobs.com/en-US/apply` |
-| Workday | `[company].myworkdayjobs.com` | `https://northwind.myworkdayjobs.com/en-US/careers` |
-| Greenhouse | `boards.greenhouse.io/[company]` | `https://boards.greenhouse.io/examplecorp/jobs/12345` |
-| Greenhouse | `[company].greenhouse.io` | `https://examplecorp.greenhouse.io/jobs/12345` |
-| Lever | `jobs.lever.co/[company]` | `https://jobs.lever.co/examplecorp/abc123` |
-| iCIMS | `careers.[company].icims.com` | `https://careers.examplecorp.icims.com/jobs/1234/software-engineer/job` |
-| iCIMS | `[company].icims.com` | `https://examplecorp.icims.com/jobs/1234/job` |
+## Base ATS Adapters
+
+Current base platforms:
+
+- Workday
+- Greenhouse
+- Lever
+- iCIMS
+
+Base adapters should handle platform-wide selectors and fallbacks that are likely to help more than one employer instance.
+
+## Company Overrides
+
+Company overrides are appropriate when one employer's implementation diverges from the platform defaults in a way that is not broadly reusable.
+
+Good override candidates:
+
+- renamed or badly labeled custom fields
+- extra required sections unique to one employer
+- job details moved into employer-specific wrappers
+
+Bad override candidates:
+
+- selector improvements that would help most or all sites on the same ATS
 
 ## Support Levels
 
-- `base`: The adapter recognizes the ATS and provides the shared fallback behavior for that platform.
-- `partial`: The adapter understands important customizations for one company, but contributors should still assume manual review is needed.
-- `full`: The adapter is intentionally tuned for the target site end to end and should only be used when the implementation really covers the full application flow.
+- `base`: platform recognition plus shared fallback behavior
+- `partial`: meaningful employer-specific tailoring, but manual review still expected
+- `full`: intentionally tuned end-to-end support with strong evidence and repeatable coverage
 
-Contributors should start at `base`, upgrade to `partial` when handling known deviations, and reserve `full` for adapters with strong evidence and repeatable test coverage.
+Reserve `full` for genuinely mature coverage.
+
+## How To Add A New ATS Platform
+
+1. Create a new adapter in `src/adapters/ats/`.
+2. Extend `BaseATSAdapter`.
+3. Reuse shared helpers where possible.
+4. Register the adapter in `src/adapters/index.js`.
+5. Add tests for positive and negative URL matches.
+
+## How To Add A Company Override
+
+1. Identify the underlying ATS first.
+2. Create the file in `src/adapters/companies/<ats-name>/`.
+3. Extend the platform adapter, not `BaseATSAdapter` directly.
+4. Override only the behavior that actually differs.
+5. Register the override in `src/adapters/index.js`.
+6. Add tests proving the override wins before the base ATS adapter.
 
 ## Testing Guidance
 
-- Start with unit tests for `matches()`, `resolveAdapter()`, and any custom selector behavior.
-- When manually checking a real ATS URL, use a non-production or low-risk listing when possible.
-- Stop before the final submission step. The goal is to confirm detection, field discovery, and step recognition, not to submit an application.
-- Prefer read-only inspection in DevTools or the extension test harness over live form submission.
+- test `matches()` with real-world positive and negative URLs
+- test registry precedence for override-vs-base behavior
+- test custom field discovery when the override exists only for one employer deviation
+- stop before final application submission when manually checking live pages
 
-## Contributing
+## Related Docs
 
-- A merged PR is required before an adapter can be treated as part of the community-supported listing.
-- Reaching out to an LTS team member before starting a new adapter is encouraged so contributors do not duplicate work.
-- If the change is really a shared selector improvement, prefer updating the base ATS adapter instead of creating a company override.
+- [companies/README.md](companies/README.md)
+- [../../README.md](../../README.md)

--- a/uah-browser-extension/src/adapters/companies/README.md
+++ b/uah-browser-extension/src/adapters/companies/README.md
@@ -1,20 +1,27 @@
 # Company Overrides
 
-Company overrides exist because ATS platforms are only partly standardized. Two employers can both use Workday, Greenhouse, Lever, or iCIMS and still ship meaningfully different application steps, labels, validation rules, and custom sections.
+Company overrides are the narrowest layer in the extension adapter system.
+
+They exist because two employers using the same ATS can still ship different field labels, extra custom sections, or non-standard page structure.
 
 ## Rules
 
-- Name override files as `[CompanyName][ATS]Adapter.js`.
-- Always extend the relevant base ATS adapter, never `BaseATSAdapter` directly.
-- Keep overrides minimal. Only replace the methods that differ from the shared ATS behavior.
+- Name files as `[CompanyName][ATS]Adapter.js`.
+- Extend the relevant ATS adapter, never `BaseATSAdapter` directly.
+- Keep the override minimal.
+- Add a top-level doc comment explaining what the employer does differently.
 
-## How To Spot A Real Deviation
+## When To Create An Override
 
-- Compare the target company's page structure against the base ATS adapter selectors.
-- Look for extra required sections, renamed labels, non-standard apply-step banners, or job detail elements moved into custom wrappers.
-- Confirm that the difference is company-specific and not a reusable improvement that belongs in the base ATS adapter.
+Create one when the difference is clearly employer-specific, such as:
 
-## Minimal Override Pattern
+- a custom work authorization section
+- a differently labeled required field
+- an employer-specific detail wrapper for job metadata
+
+Do not create one when the improvement belongs in the shared ATS adapter.
+
+## Minimal Pattern
 
 ```js
 import WorkdayAdapter from '../../ats/WorkdayAdapter.js'
@@ -30,15 +37,13 @@ export default class AcmeCorpWorkdayAdapter extends WorkdayAdapter {
   getCompanyName() {
     return 'Acme Corp'
   }
-
-  detectFormFields() {
-    const baseFields = super.detectFormFields()
-    const customField = this.findFieldByLabel(['work authorization'])
-    return customField
-      ? { ...baseFields, workAuthorization: customField }
-      : baseFields
-  }
 }
 ```
 
-When an override grows large, pause and check whether the base ATS adapter should learn a new shared selector instead.
+## Review Heuristic
+
+If an override starts growing large, stop and ask whether the shared platform adapter should learn a better generic selector or helper instead.
+
+## Related Docs
+
+- [../ADAPTERS.md](../ADAPTERS.md)

--- a/uah-browser-extension/src/adapters/index.js
+++ b/uah-browser-extension/src/adapters/index.js
@@ -57,6 +57,8 @@ export function resolveAdapter(url) {
   const normalizedUrl = normalizeUrl(url)
   if (!normalizedUrl) return null
 
+  // Company overrides are more specific than the generic ATS matchers and must
+  // win first when one employer deviates from the platform defaults.
   for (const adapter of companyOverrides) {
     if (adapter.matches(normalizedUrl)) {
       return adapter
@@ -76,6 +78,7 @@ export function getSupportedATS() {
   const names = []
   const seen = new Set()
 
+  // Report supported platform families, not every company-specific override.
   for (const adapter of baseAdapters) {
     const atsName = adapter.getATSName()
     if (seen.has(atsName)) continue

--- a/uah-browser-extension/src/autofill/dom.js
+++ b/uah-browser-extension/src/autofill/dom.js
@@ -31,6 +31,8 @@ export function getLabelFor(element, root = document) {
     if (text) return text
   }
 
+  // Real application forms are inconsistent, so the fallback chain broadens
+  // from explicit labels to nearby text only after stronger signals fail.
   const ariaLabel = element.getAttribute?.('aria-label')
   if (ariaLabel) return ariaLabel
 
@@ -147,6 +149,8 @@ export function fillPlan(plan, tokenMap) {
     const value = tokenMap?.[item.matchPath]
     if (value === null || value === undefined || value === '') continue
 
+    // Avoid filling stale end dates into entries that are explicitly marked as
+    // current in the source token map.
     if (item.matchPath.match(/\.(end_month|end_year|end_date)$/)) {
       const prefix = item.matchPath.replace(/\.(end_month|end_year|end_date)$/, '')
       if (tokenMap?.[`${prefix}.is_current`] === true) continue

--- a/uah-browser-extension/src/autofill/source.js
+++ b/uah-browser-extension/src/autofill/source.js
@@ -41,6 +41,8 @@ export function sanitizeTokenMap(tokenMap = {}) {
 }
 
 export function buildProfileAutofillSource(profile = {}) {
+  // Prefer an explicitly curated token map when one exists. Falling back to
+  // flattened canonical data keeps older or lightly managed profiles usable.
   const baseTokenMap = sanitizeTokenMap(
     isObject(profile.token_map) && Object.keys(profile.token_map).length
       ? profile.token_map

--- a/uah-browser-extension/src/pinned-panel/runtime.js
+++ b/uah-browser-extension/src/pinned-panel/runtime.js
@@ -130,6 +130,8 @@ function removePanel(doc = document) {
 }
 
 function buildPopupUrl() {
+  // The pinned surface reuses the same popup app in an iframe so background
+  // messaging, auth state, and UI logic stay shared across both surfaces.
   const popupUrl = globalThis.chrome?.runtime?.getURL?.('popup.html') || ''
   return `${popupUrl}?surface=pinned`
 }


### PR DESCRIPTION
Restructure and trim repository docs and make small backend compatibility tweaks.

- Rewrite README.md into a concise repo entrypoint with a docs map, quick-starts, and canonical commands; remove large host-specific runbook content in favor of focused docs links.
- Update CONTRIBUTING.md for clearer branch/PR guidance, migration/backfill guidance, and doc-updating rules.
- Add docs/ARCHITECTURE.md and revise backend/app/scrapers/SCRAPERS.md (scaffold vs live pipeline, ethics, and checklist flow). Move several dated docs into docs/archive.
- Backend changes:
  - backend/app/api/routes.py: replace long how-to docstring with a concise purpose note for shared routes.
  - backend/app/main.py: document legacy startup tables, adjust startup ordering to normalize DB rows before/after bootstrapping, and gate generated OpenAPI docs to local/dev environments only.
  - backend/app/services/job_search.py: preserve numeric compatibility IDs for older clients and mirror provider-backed response shape so frontend can swap sources without a second serializer.

Also touched various frontend/extension docs and small code comments. These changes are primarily documentation and safety/compatibility refinements to make contributor flows and local/dev behavior clearer.
